### PR TITLE
Fiducial volume coordaintes

### DIFF
--- a/projects/detector/private/pybindings/Axis1D.h
+++ b/projects/detector/private/pybindings/Axis1D.h
@@ -34,9 +34,9 @@ public:
             clone
         );
     }
-    std::shared_ptr<const Axis1D> create() const override {
+    std::shared_ptr<Axis1D> create() const override {
         PYBIND11_OVERRIDE_PURE_NAME(
-            std::shared_ptr<const Axis1D>,
+            std::shared_ptr<Axis1D>,
             Axis1D,
             "_create",
             create

--- a/projects/detector/private/pybindings/DensityDistribution.h
+++ b/projects/detector/private/pybindings/DensityDistribution.h
@@ -26,7 +26,7 @@ public:
         );
     }
 
-    DensityDistribution * clone() const override {
+    virtual DensityDistribution * clone() const override {
         PYBIND11_OVERRIDE_PURE_NAME(
             DensityDistribution *,
             DensityDistribution,
@@ -34,9 +34,9 @@ public:
             clone
         );
     }
-    std::shared_ptr<const DensityDistribution> create() const override {
+    virtual std::shared_ptr<DensityDistribution> create() const override {
         PYBIND11_OVERRIDE_PURE_NAME(
-            std::shared_ptr<const DensityDistribution>,
+            std::shared_ptr<DensityDistribution>,
             DensityDistribution,
             "_create",
             create

--- a/projects/detector/private/pybindings/DetectorModel.h
+++ b/projects/detector/private/pybindings/DetectorModel.h
@@ -229,5 +229,7 @@ void register_DetectorModel(pybind11::module_ & m) {
         .def("DetDirectionToGeoDirection", (
                     GeometryDirection (DetectorModel::*)(DetectorDirection const &) const
                     )(&DetectorModel::ToGeo))
+        .def("ParseFiducialVolume", (std::shared_ptr<LI::geometry::Geometry> (*)(std::string, std::string))(&DetectorModel::ParseFiducialVolume))
+        .def("ParseFiducialVolume", (std::shared_ptr<LI::geometry::Geometry> (*)(std::string, LI::math::Vector3D, LI::math::Quaternion))(&DetectorModel::ParseFiducialVolume))
         ;
 }

--- a/projects/detector/private/pybindings/Distribution1D.h
+++ b/projects/detector/private/pybindings/Distribution1D.h
@@ -34,9 +34,9 @@ public:
             clone
         );
     }
-    std::shared_ptr<const Distribution1D> create() const override {
+    virtual std::shared_ptr<Distribution1D> create() const override {
         PYBIND11_OVERRIDE_PURE_NAME(
-            std::shared_ptr<const Distribution1D>,
+            std::shared_ptr<Distribution1D>,
             Distribution1D,
             "_create",
             create

--- a/projects/detector/public/LeptonInjector/detector/Axis1D.h
+++ b/projects/detector/public/LeptonInjector/detector/Axis1D.h
@@ -31,7 +31,7 @@ public:
     virtual bool compare(const Axis1D& dens_distr) const = 0;
 
     virtual Axis1D* clone() const = 0;
-    virtual std::shared_ptr<const Axis1D> create() const = 0;
+    virtual std::shared_ptr<Axis1D> create() const = 0;
 
     virtual double GetX(const math::Vector3D& xi) const = 0;
     virtual double GetdX(const math::Vector3D& xi, const math::Vector3D& direction) const = 0;

--- a/projects/detector/public/LeptonInjector/detector/CartesianAxis1D.h
+++ b/projects/detector/public/LeptonInjector/detector/CartesianAxis1D.h
@@ -29,8 +29,8 @@ public:
     bool compare(const Axis1D& dens_distr) const override;
 
     Axis1D* clone() const override { return new CartesianAxis1D(*this); };
-    std::shared_ptr<const Axis1D> create() const override {
-        return std::shared_ptr<const Axis1D>(new CartesianAxis1D(*this));
+    std::shared_ptr<Axis1D> create() const override {
+        return std::shared_ptr<Axis1D>(new CartesianAxis1D(*this));
     };
 
     double GetX(const math::Vector3D& xi) const override;

--- a/projects/detector/public/LeptonInjector/detector/CartesianAxisDensityDistribution.h
+++ b/projects/detector/public/LeptonInjector/detector/CartesianAxisDensityDistribution.h
@@ -46,7 +46,7 @@ class DensityDistribution1D<CartesianAxis1D, DistributionT, typename std::enable
     };
 
     DensityDistribution* clone() const override { return new T(*this); };
-    std::shared_ptr<const DensityDistribution> create() const override {
+    std::shared_ptr<DensityDistribution> create() override {
         return std::shared_ptr<const DensityDistribution>(new T(*this));
     };
 

--- a/projects/detector/public/LeptonInjector/detector/ConstantDensityDistribution.h
+++ b/projects/detector/public/LeptonInjector/detector/ConstantDensityDistribution.h
@@ -51,8 +51,8 @@ class DensityDistribution1D<AxisT, ConstantDistribution1D, typename std::enable_
     };
 
     DensityDistribution* clone() const override { return new T(*this); };
-    std::shared_ptr<const DensityDistribution> create() const override {
-        return std::shared_ptr<const DensityDistribution>(new T(*this));
+    std::shared_ptr<DensityDistribution> create() const override {
+        return std::shared_ptr<DensityDistribution>(new T(*this));
     };
 
     double Derivative(const math::Vector3D& xi,

--- a/projects/detector/public/LeptonInjector/detector/ConstantDistribution1D.h
+++ b/projects/detector/public/LeptonInjector/detector/ConstantDistribution1D.h
@@ -24,8 +24,8 @@ public:
     ConstantDistribution1D(double val);
     bool compare(const Distribution1D& dist) const override;
     Distribution1D* clone() const override { return new ConstantDistribution1D(*this); };
-    std::shared_ptr<const Distribution1D> create() const override {
-        return std::shared_ptr<const Distribution1D>(new ConstantDistribution1D(*this));
+    std::shared_ptr<Distribution1D> create() const override {
+        return std::shared_ptr<Distribution1D>(new ConstantDistribution1D(*this));
     };
     double Derivative(double x) const override;
     double AntiDerivative(double x) const override;

--- a/projects/detector/public/LeptonInjector/detector/DensityDistribution.h
+++ b/projects/detector/public/LeptonInjector/detector/DensityDistribution.h
@@ -67,7 +67,7 @@ public:
 
 
     virtual DensityDistribution* clone() const = 0;
-    virtual std::shared_ptr<const DensityDistribution> create() const = 0;
+    virtual std::shared_ptr<DensityDistribution> create() const = 0;
 
     virtual double Derivative(const math::Vector3D& xi,
                               const math::Vector3D& direction) const = 0;

--- a/projects/detector/public/LeptonInjector/detector/DensityDistribution1D.h
+++ b/projects/detector/public/LeptonInjector/detector/DensityDistribution1D.h
@@ -48,8 +48,8 @@ public:
     };
 
     DensityDistribution* clone() const override { return new T(*this); };
-    std::shared_ptr<const DensityDistribution> create() const override {
-        return std::shared_ptr<const DensityDistribution>(new T(*this));
+    std::shared_ptr<DensityDistribution> create() const override {
+        return std::shared_ptr<DensityDistribution>(new T(*this));
     };
 
     double Derivative(const math::Vector3D& xi,

--- a/projects/detector/public/LeptonInjector/detector/DetectorModel.h
+++ b/projects/detector/public/LeptonInjector/detector/DetectorModel.h
@@ -267,6 +267,13 @@ public:
 
     static geometry::Geometry::IntersectionList GetOuterBounds(geometry::Geometry::IntersectionList const & intersections);
 
+    static std::tuple<LI::math::Vector3D, LI::math::Quaternion> ParseDetector(std::stringstream & ss);
+    static std::shared_ptr<geometry::Geometry> ParseGeometryObject(std::stringstream & line);
+    static int ParseMaterialID(std::stringstream & line, MaterialModel const & materials);
+    static std::shared_ptr<detector::DensityDistribution> ParseDensityDistribution(std::stringstream & line);
+    static std::shared_ptr<geometry::Geometry> ParseFiducialVolume(std::string fiducial_line, std::string origin_line);
+    static std::shared_ptr<geometry::Geometry> ParseFiducialVolume(std::string line, LI::math::Vector3D detector_origin, LI::math::Quaternion detector_quaternion);
+
 private:
     void LoadDefaultMaterials();
     void LoadDefaultSectors();

--- a/projects/detector/public/LeptonInjector/detector/Distribution1D.h
+++ b/projects/detector/public/LeptonInjector/detector/Distribution1D.h
@@ -19,7 +19,7 @@ public:
     bool operator!=(const Distribution1D& dist) const;
     virtual bool compare(const Distribution1D& dist) const = 0;
     virtual Distribution1D* clone() const = 0;
-    virtual std::shared_ptr<const Distribution1D> create() const = 0;
+    virtual std::shared_ptr<Distribution1D> create() const = 0;
     virtual double Derivative(double x) const = 0;
     virtual double AntiDerivative(double x) const = 0;
     virtual double Evaluate(double x) const = 0;

--- a/projects/detector/public/LeptonInjector/detector/ExponentialDistribution1D.h
+++ b/projects/detector/public/LeptonInjector/detector/ExponentialDistribution1D.h
@@ -25,8 +25,8 @@ public:
     ExponentialDistribution1D(double sigma);
     bool compare(const Distribution1D& dist) const override;
     Distribution1D* clone() const override { return new ExponentialDistribution1D(*this); };
-    std::shared_ptr<const Distribution1D> create() const override {
-        return std::shared_ptr<const Distribution1D>(new ExponentialDistribution1D(*this));
+    std::shared_ptr<Distribution1D> create() const override {
+        return std::shared_ptr<Distribution1D>(new ExponentialDistribution1D(*this));
     };
     double Derivative(double x) const override;
     double AntiDerivative(double x) const override;

--- a/projects/detector/public/LeptonInjector/detector/PolynomialDistribution1D.h
+++ b/projects/detector/public/LeptonInjector/detector/PolynomialDistribution1D.h
@@ -30,8 +30,8 @@ public:
     PolynomialDistribution1D(const std::vector<double>&);
     bool compare(const Distribution1D& dist) const override;
     Distribution1D* clone() const override { return new PolynomialDistribution1D(*this); };
-    std::shared_ptr<const Distribution1D> create() const override {
-        return std::shared_ptr<const Distribution1D>(new PolynomialDistribution1D(*this));
+    std::shared_ptr<Distribution1D> create() const override {
+        return std::shared_ptr<Distribution1D>(new PolynomialDistribution1D(*this));
     };
     double Derivative(double x) const override;
     double AntiDerivative(double x) const override;

--- a/projects/detector/public/LeptonInjector/detector/RadialAxis1D.h
+++ b/projects/detector/public/LeptonInjector/detector/RadialAxis1D.h
@@ -30,8 +30,8 @@ public:
     bool compare(const Axis1D& dens_distr) const override;
 
     Axis1D* clone() const override { return new RadialAxis1D(*this); };
-    std::shared_ptr<const Axis1D> create() const override {
-        return std::shared_ptr<const Axis1D>(new RadialAxis1D(*this));
+    std::shared_ptr<Axis1D> create() const override {
+        return std::shared_ptr<Axis1D>(new RadialAxis1D(*this));
     };
 
     double GetX(const math::Vector3D& xi) const override;

--- a/projects/detector/public/LeptonInjector/detector/RadialAxisPolynomialDensityDistribution.h
+++ b/projects/detector/public/LeptonInjector/detector/RadialAxisPolynomialDensityDistribution.h
@@ -54,7 +54,7 @@ class DensityDistribution1D<RadialAxis1D,PolynomialDistribution1D>
     };
 
     DensityDistribution* clone() const override { return new DensityDistribution1D(*this); };
-    std::shared_ptr<const DensityDistribution> create() const override {
+    std::shared_ptr<DensityDistribution> create() override {
         return std::shared_ptr<const DensityDistribution>(new DensityDistribution1D(*this));
     };
 

--- a/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
@@ -72,8 +72,8 @@ void SecondaryBoundedVertexDistribution::SampleVertex(std::shared_ptr<LI::utilit
             bool update_path = (fid_intersections.front().distance < max_length
                     && fid_intersections.back().distance > 0);
             if(update_path) {
-                LI::math::Vector3D first_point = (fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0;
-                LI::math::Vector3D last_point = (fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1;
+                LI::math::Vector3D first_point((fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0);
+                LI::math::Vector3D last_point((fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1);
                 path.SetPoints(DetectorPosition(first_point), DetectorPosition(last_point));
             }
         }
@@ -128,7 +128,7 @@ double SecondaryBoundedVertexDistribution::GenerationProbability(std::shared_ptr
 
     // Check if fiducial volume is provided
     if(fiducial_volume) {
-        std::vector<LI::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(detector_model->ToGeo(DetectorPosition(endcap_0)),detector_model->ToGeo(DetectorDirection(dir)));
+        std::vector<LI::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(endcap_0, dir);
         // If the path intersects the fiducial volume, restrict position to that volume
         if(!fid_intersections.empty()) {
             // make sure the first intersection happens before the maximum generation length
@@ -136,8 +136,8 @@ double SecondaryBoundedVertexDistribution::GenerationProbability(std::shared_ptr
             bool update_path = (fid_intersections.front().distance < max_length
                     && fid_intersections.back().distance > 0);
             if(update_path) {
-                DetectorPosition first_point = (fid_intersections.front().distance > 0) ? detector_model->ToDet(GeometryPosition(fid_intersections.front().position)) : DetectorPosition(endcap_0);
-                DetectorPosition last_point = (fid_intersections.back().distance < max_length) ? detector_model->ToDet(GeometryPosition(fid_intersections.back().position)) : DetectorPosition(endcap_1);
+                DetectorPosition first_point((fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0);
+                DetectorPosition last_point((fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1);
                 path.SetPoints(first_point, last_point);
             }
         }
@@ -207,7 +207,7 @@ std::tuple<LI::math::Vector3D, LI::math::Vector3D> SecondaryBoundedVertexDistrib
 
     // Check if fiducial volume is provided
     if(fiducial_volume) {
-        std::vector<LI::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(detector_model->ToGeo(DetectorPosition(endcap_0)),detector_model->ToGeo(DetectorDirection(dir)));
+        std::vector<LI::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(endcap_0, dir);
         // If the path intersects the fiducial volume, restrict position to that volume
         if(!fid_intersections.empty()) {
             // make sure the first intersection happens before the maximum generation length
@@ -215,8 +215,8 @@ std::tuple<LI::math::Vector3D, LI::math::Vector3D> SecondaryBoundedVertexDistrib
             bool update_path = (fid_intersections.front().distance < max_length
                     && fid_intersections.back().distance > 0);
             if(update_path) {
-                DetectorPosition first_point = (fid_intersections.front().distance > 0) ? detector_model->ToDet(GeometryPosition(fid_intersections.front().position)) : DetectorPosition(endcap_0);
-                DetectorPosition last_point = (fid_intersections.back().distance < max_length) ? detector_model->ToDet(GeometryPosition(fid_intersections.back().position)) : DetectorPosition(endcap_1);
+                DetectorPosition first_point((fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0);
+                DetectorPosition last_point((fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1);
                 path.SetPoints(first_point, last_point);
             }
         }

--- a/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
@@ -64,7 +64,7 @@ void SecondaryBoundedVertexDistribution::SampleVertex(std::shared_ptr<LI::utilit
 
     // Check if fiducial volume is provided
     if(fiducial_volume) {
-        std::vector<LI::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(detector_model->ToGeo(DetectorPosition(endcap_0)),detector_model->ToGeo(DetectorDirection(dir)));
+        std::vector<LI::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(endcap_0, dir);
         // If the path intersects the fiducial volume, restrict position to that volume
         if(!fid_intersections.empty()) {
             // make sure the first intersection happens before the maximum generation length
@@ -72,9 +72,9 @@ void SecondaryBoundedVertexDistribution::SampleVertex(std::shared_ptr<LI::utilit
             bool update_path = (fid_intersections.front().distance < max_length
                     && fid_intersections.back().distance > 0);
             if(update_path) {
-                DetectorPosition first_point = (fid_intersections.front().distance > 0) ? detector_model->ToDet(GeometryPosition(fid_intersections.front().position)) : DetectorPosition(endcap_0);
-                DetectorPosition last_point = (fid_intersections.back().distance < max_length) ? detector_model->ToDet(GeometryPosition(fid_intersections.back().position)) : DetectorPosition(endcap_1);
-                path.SetPoints(first_point, last_point);
+                LI::math::Vector3D first_point = (fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0;
+                LI::math::Vector3D last_point = (fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1;
+                path.SetPoints(DetectorPosition(first_point), DetectorPosition(last_point));
             }
         }
     }

--- a/projects/geometry/private/Placement.cxx
+++ b/projects/geometry/private/Placement.cxx
@@ -121,7 +121,7 @@ namespace geometry {
 } // namespace geometry
 } // namespace LI
 
-std::shared_ptr<const Placement> Placement::create() const { return std::shared_ptr<const Placement>( new Placement(*this) ); }
+std::shared_ptr<Placement> Placement::create() const { return std::shared_ptr<Placement>( new Placement(*this) ); }
 
 //-------------------------------------//
 // getter and setter functions

--- a/projects/geometry/public/LeptonInjector/geometry/Box.h
+++ b/projects/geometry/public/LeptonInjector/geometry/Box.h
@@ -43,7 +43,7 @@ public:
         }
     }
 
-    std::shared_ptr<const Geometry> create() const override { return std::shared_ptr<const Geometry>( new Box(*this) ); };
+    std::shared_ptr<Geometry> create() const override { return std::shared_ptr<Geometry>( new Box(*this) ); };
     void swap(Geometry&) override;
 
     virtual ~Box() {}

--- a/projects/geometry/public/LeptonInjector/geometry/Cylinder.h
+++ b/projects/geometry/public/LeptonInjector/geometry/Cylinder.h
@@ -43,7 +43,7 @@ public:
         }
     }
 
-    std::shared_ptr<const Geometry> create() const override { return std::shared_ptr<const Geometry>( new Cylinder(*this) ); };
+    std::shared_ptr<Geometry> create() const override { return std::shared_ptr<Geometry>( new Cylinder(*this) ); };
     void swap(Geometry&) override;
 
     virtual ~Cylinder() {}

--- a/projects/geometry/public/LeptonInjector/geometry/ExtrPoly.h
+++ b/projects/geometry/public/LeptonInjector/geometry/ExtrPoly.h
@@ -102,7 +102,7 @@ public:
     }
 
     /* Geometry* clone() const override{ return new ExtrPoly(*this); }; */
-    std::shared_ptr<const Geometry> create() const override{ return std::shared_ptr<const Geometry>( new ExtrPoly(*this) ); }
+    std::shared_ptr<Geometry> create() const override{ return std::shared_ptr<Geometry>( new ExtrPoly(*this) ); }
     void swap(Geometry&) override;
 
     virtual ~ExtrPoly() {}

--- a/projects/geometry/public/LeptonInjector/geometry/Geometry.h
+++ b/projects/geometry/public/LeptonInjector/geometry/Geometry.h
@@ -115,7 +115,7 @@ public:
     //Geometry(const nlohmann::json&);
 
     /* virtual Geometry* clone() const = 0; // virtual constructor idiom (used for deep copies) */
-    virtual std::shared_ptr<const Geometry> create() const = 0;
+    virtual std::shared_ptr<Geometry> create() const = 0;
     virtual void swap(Geometry&);
 
     virtual ~Geometry(){};

--- a/projects/geometry/public/LeptonInjector/geometry/GeometryMesh.h
+++ b/projects/geometry/public/LeptonInjector/geometry/GeometryMesh.h
@@ -56,7 +56,7 @@ public:
         }
     }
 
-    std::shared_ptr<const Geometry> create() const override { return std::shared_ptr<const Geometry>( new TriangularMesh(*this) ); };
+    std::shared_ptr<Geometry> create() const override { return std::shared_ptr<Geometry>( new TriangularMesh(*this) ); };
     void swap(Geometry&) override;
 
     virtual ~TriangularMesh() {}

--- a/projects/geometry/public/LeptonInjector/geometry/Placement.h
+++ b/projects/geometry/public/LeptonInjector/geometry/Placement.h
@@ -40,7 +40,7 @@ public:
     void swap(Placement& placement);
     friend std::ostream& operator<<(std::ostream& os, Placement const& placement);
 
-    std::shared_ptr<const Placement> create() const;
+    std::shared_ptr<Placement> create() const;
 
     //-------------------------------------//
     // getter and setter functions

--- a/projects/geometry/public/LeptonInjector/geometry/Sphere.h
+++ b/projects/geometry/public/LeptonInjector/geometry/Sphere.h
@@ -43,7 +43,7 @@ public:
     }
 
     /* Geometry* clone() const override{ return new Sphere(*this); }; */
-    std::shared_ptr<const Geometry> create() const override{ return std::shared_ptr<const Geometry>( new Sphere(*this) ); }
+    std::shared_ptr<Geometry> create() const override{ return std::shared_ptr<Geometry>( new Sphere(*this) ); }
     void swap(Geometry&) override;
 
     virtual ~Sphere() {}

--- a/python/LIController.py
+++ b/python/LIController.py
@@ -239,45 +239,19 @@ class LIController:
         """
         detector_model_file = _util.get_detector_model_path(self.experiment)
         with open(detector_model_file) as file:
+            fiducial_line = None
+            detector_line = None
             for line in file:
                 data = line.split()
-                if len(data)<=0: continue
-                if(data[0]=="fiducial"):
-                    placement_pos = _math.Vector3D([float(d) for d in data[2:5]])
-                    placement_rot = _math.Quaternion()
-                    placement_rot.SetEulerAnglesZXZr(*[float(d) for d in data[5:8]])
-                    placement = _geometry.Placement(placement_pos, placement_rot)
-                    if(data[1]=="sphere"):
-                        return _geometry.Sphere(placement, float(data[8]), 0)
-                    elif(data[1]=="box"):
-                        return _geometry.Box(placement, *[float(d) for d in data[8:11]])
-                    elif(data[1]=="cylinder"):
-                        return _geometry.Cylinder(placement, *[float(d) for d in data[8:11]])
-                    elif(data[1]=="extr"):
-                        index = 8
-                        num_edges = int(data[index])
-                        edges_max_idx = index + 2*num_edges
-                        edges = []
-                        index += 1
-                        while index < edges_max_idx:
-                            edges.append([float(data[index]),
-                                          float(data[index+1])])
-                            index += 2
-                        num_z_sections = int(data[index])
-                        zsecs_max_idx = index + 4*num_z_sections
-                        zsecs = []
-                        index += 1
-                        while index < zsecs_max_idx:
-                            zpos = float(data[index])
-                            offset = [float(data[index+1]),
-                                      float(data[index+2])]
-                            scale = float(data[index+3])
-                            zsecs.append(_geometry.ZSection(zpos,offset[0],scale)) # TODO: fix offset argument to accept array
-                            index += 4
-                        return _geometry.ExtrPoly(placement, edges, zsecs)
-                    else:
-                        print("Shape %s not recognized for the fiducial volume, exiting..."%data[1])
-                        exit(0)
+                if len(data) <= 0:
+                    continue
+                elif data[0] == "fiducial":
+                    fiducial_line = line
+                elif data[0] == "detector":
+                    detector_line = line
+            if fiducial_line is None or detector_line is None:
+                return None
+            return _detector.DetectorModel.ParseFiducialVolume(fiducial_line, detector_line)
         return None            
 
     def GetDetectorModelTargets(self):

--- a/python/LIController.py
+++ b/python/LIController.py
@@ -417,11 +417,9 @@ class LIController:
                 
                 if self.fid_vol is not None:
                     pos = _math.Vector3D(datasets["vertex"][-1][-1])
-                    geo_pos = self.detector_model.DetPositionToGeoPosition(pos)
                     dir = _math.Vector3D(datasets["primary_momentum"][-1][-1][1:])
                     dir.normalize()
-                    geo_dir = self.detector_model.DetDirectionToGeoDirection(dir)
-                    datasets["in_fiducial"][-1].append(self.fid_vol.IsInside(geo_pos.get(),geo_dir.get()))
+                    datasets["in_fiducial"][-1].append(self.fid_vol.IsInside(pos,dir))
                 else:
                     datasets["in_fiducial"][-1].append(False)
 

--- a/resources/Detectors/densities/CCM/CCM-v1.dat
+++ b/resources/Detectors/densities/CCM/CCM-v1.dat
@@ -79,4 +79,4 @@ object cylinder  23 0 -0.65          0 0 0      0.96 0 1.232   ccm_inner_argon  
 detector 23 0 -0.65
 
 # Fiducial volume
-fiducial cylinder 23 0 -0.65         0 0 0      0.96 0 1.232
+fiducial detector_coords cylinder 0 0 0         0 0 0      0.96 0 1.232


### PR DESCRIPTION
This PR aims to define the fiducial volume in detector coordinates within the SecondaryBoundedVertexDistribution.

Using geometry coordinates would have caused a weighting inconsistency when weighting with a geometry that has a different definition for detector coordinates than the one used for injection.

This PR also factorizes the logic that loads geometry files so that it can be used to load the fiducial volume, fixes the rotations used in the Geometry <--> Detector coordinate transforms, and fixes some issues with the create() methods.