### PR TITLE
CI: wheels script, gitignore, allow underscores in model names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ __pycache__/
 
 # output dirs
 output/
+
+# specific flux directory
+resources/fluxes/Atmospheric
+
+MoveToSpackPython.sh

--- a/tools/wheels/cibw_before_all.sh
+++ b/tools/wheels/cibw_before_all.sh
@@ -32,9 +32,13 @@ ZLIB_VERSION="1.3.1"
 mkdir -p $CI_INSTALL_PREFIX
 
 if [[ $RUNNER_OS == "Linux" ]] ; then
-    :
+    if command -v apk &> /dev/null; then
+        apk add gsl-dev  # musllinux (Alpine)
+    else
+        yum install -y gsl-devel  # manylinux (CentOS/RHEL)
+    fi
 elif [[ $RUNNER_OS == "macOS" ]]; then
-    :
+    brew install gsl
 elif [[ $RUNNER_OS == "Windows" ]]; then
     mkdir -p $CI_DOWNLOAD_PATH
     cd $CI_DOWNLOAD_PATH


### PR DESCRIPTION
## Stack: PR 2 of 14

This PR is part of a 14-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `chore/vendor-crundec3`
- **Head:** `chore/ci-and-packaging`

Merge order: `chore/vendor-crundec3` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - .gitignore
  - tools/wheels

Source commits on dev/HNL_DIS_clean that contributed:
  088b1cd2 (Nicholas Kamp): move around the HNL DIS fits files
  0a8a6e9c (Nicholas Kamp): attempt to get wheels working
  a62ce388 (Nicholas Kamp): quick gitignore change


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
