### PR TITLE
Add SphereVolumePositionDistribution

### DIFF
--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -29,6 +29,7 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/DecayRangePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/OrientedCylinderPositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/CylinderVolumePositionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
 

--- a/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
@@ -1,0 +1,125 @@
+#include "SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
+
+#include <array>                                           // for array
+#include <cmath>                                           // for sqrt, cos
+#include <string>                                          // for basic_string
+#include <vector>                                          // for vector
+#include <stdlib.h>                                        // for abs
+
+#include "SIREN/dataclasses/InteractionRecord.h"  // for Interactio...
+#include "SIREN/detector/DetectorModel.h"            // for DetectorModel
+#include "SIREN/distributions/Distributions.h"    // for InjectionD...
+#include "SIREN/geometry/Geometry.h"              // for Geometry
+#include "SIREN/math/Vector3D.h"                  // for Vector3D
+#include "SIREN/utilities/Random.h"               // for SIREN_random
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+
+namespace siren {
+namespace distributions {
+
+//---------------
+// class SphereVolumePositionDistribution : public VertexPositionDistribution
+//---------------
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> SphereVolumePositionDistribution::SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+
+    // Sample uniformly within a spherical shell
+    const double outer_radius = sphere.GetRadius();
+    const double inner_radius = sphere.GetInnerRadius();
+
+    // Sample radius with proper volume weighting for uniform distribution
+    double outer_vol = outer_radius * outer_radius * outer_radius;
+    double inner_vol = inner_radius * inner_radius * inner_radius;
+    double r_cubed = rand->Uniform(inner_vol, outer_vol);
+    double r = std::cbrt(r_cubed);
+
+    // Sample angles uniformly on sphere surface
+    double phi = rand->Uniform(0, 2 * M_PI);  // azimuthal angle
+    double cos_theta = rand->Uniform(-1, 1);  // uniform in cos(theta)
+    double sin_theta = std::sqrt(1 - cos_theta * cos_theta);
+
+    // Convert to Cartesian coordinates
+    siren::math::Vector3D pos(
+        r * sin_theta * std::cos(phi),
+        r * sin_theta * std::sin(phi),
+        r * cos_theta
+    );
+
+    siren::math::Vector3D final_pos = sphere.LocalToGlobalPosition(pos);
+
+    siren::math::Vector3D dir = record.GetDirection();
+    std::vector<siren::geometry::Geometry::Intersection> intersections = sphere.Intersections(final_pos, dir);
+    siren::detector::DetectorModel::SortIntersections(intersections);
+
+    siren::math::Vector3D init_pos;
+
+    if(intersections.size() == 0) {
+        init_pos = final_pos;
+    } else if(intersections.size() >= 2) {
+        init_pos = intersections.front().position;
+    } else {
+        throw std::runtime_error("Only found one sphere intersection!");
+    }
+
+    return {init_pos, final_pos};
+}
+
+double SphereVolumePositionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    siren::math::Vector3D pos(sphere.GlobalToLocalPosition(record.interaction_vertex));
+    double r = pos.magnitude();  // Distance from sphere center
+
+    if(r <= sphere.GetInnerRadius() || r >= sphere.GetRadius()) {
+        return 0.0;
+    } else {
+        // Volume of spherical shell: (4/3)π(R³ - r_inner³)
+        double outer_volume = (4.0/3.0) * M_PI * sphere.GetRadius() * sphere.GetRadius() * sphere.GetRadius();
+        double inner_volume = (4.0/3.0) * M_PI * sphere.GetInnerRadius() * sphere.GetInnerRadius() * sphere.GetInnerRadius();
+        return 1.0 / (outer_volume - inner_volume);
+    }
+}
+
+SphereVolumePositionDistribution::SphereVolumePositionDistribution(siren::geometry::Sphere sphere) : sphere(sphere) {}
+
+std::string SphereVolumePositionDistribution::Name() const {
+    return "SphereVolumePositionDistribution";
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> SphereVolumePositionDistribution::clone() const {
+    return std::shared_ptr<PrimaryInjectionDistribution>(new SphereVolumePositionDistribution(*this));
+}
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> SphereVolumePositionDistribution::InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const {
+    siren::math::Vector3D dir(interaction.primary_momentum[1], interaction.primary_momentum[2], interaction.primary_momentum[3]);
+    dir.normalize();
+    siren::math::Vector3D pos(interaction.interaction_vertex);
+    std::vector<siren::geometry::Geometry::Intersection> intersections = sphere.Intersections(pos, dir);
+    siren::detector::DetectorModel::SortIntersections(intersections);
+    if(intersections.size() == 0) {
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(siren::math::Vector3D(0, 0, 0), siren::math::Vector3D(0, 0, 0));
+    } else if(intersections.size() >= 2) {
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(intersections.front().position, intersections.back().position);
+    } else {
+        throw std::runtime_error("Only found one sphere intersection!");
+    }
+}
+
+bool SphereVolumePositionDistribution::equal(WeightableDistribution const & other) const {
+    const SphereVolumePositionDistribution* x = dynamic_cast<const SphereVolumePositionDistribution*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return (sphere == x->sphere);
+}
+
+bool SphereVolumePositionDistribution::less(WeightableDistribution const & other) const {
+    const SphereVolumePositionDistribution* x = dynamic_cast<const SphereVolumePositionDistribution*>(&other);
+    return sphere < x->sphere;
+}
+
+bool SphereVolumePositionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    return this->operator==(*distribution);
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/pybindings/distributions.cxx
+++ b/projects/distributions/private/pybindings/distributions.cxx
@@ -16,6 +16,7 @@
 #include "../../public/SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/ColumnDepthPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/CylinderVolumePositionDistribution.h"
+#include "../../public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/FixedTargetPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/DecayRangeFunction.h"
 #include "../../public/SIREN/distributions/primary/vertex/DecayRangePositionDistribution.h"
@@ -199,6 +200,12 @@ PYBIND11_MODULE(distributions,m) {
     .def("GenerationProbability",&CylinderVolumePositionDistribution::GenerationProbability)
     .def("InjectionBounds",&CylinderVolumePositionDistribution::InjectionBounds)
     .def("Name",&CylinderVolumePositionDistribution::Name);
+
+  class_<SphereVolumePositionDistribution, std::shared_ptr<SphereVolumePositionDistribution>, VertexPositionDistribution>(m, "SphereVolumePositionDistribution")
+    .def(init<siren::geometry::Sphere>())
+    .def("GenerationProbability",&SphereVolumePositionDistribution::GenerationProbability)
+    .def("InjectionBounds",&SphereVolumePositionDistribution::InjectionBounds)
+    .def("Name",&SphereVolumePositionDistribution::Name);
 
   class_<ColumnDepthPositionDistribution, std::shared_ptr<ColumnDepthPositionDistribution>, VertexPositionDistribution>(m, "ColumnDepthPositionDistribution")
     .def(init<double, double, std::shared_ptr<DepthFunction>>())

--- a/projects/distributions/public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h
@@ -1,0 +1,76 @@
+#pragma once
+#ifndef SIREN_SphereVolumePositionDistribution_H
+#define SIREN_SphereVolumePositionDistribution_H
+
+#include <tuple>
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <stdexcept>
+
+#include <cereal/access.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+#include "SIREN/geometry/Sphere.h"
+#include "SIREN/math/Vector3D.h"
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace distributions { class PrimaryInjectionDistribution; } }
+namespace siren { namespace distributions { class WeightableDistribution; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+class SphereVolumePositionDistribution : virtual public VertexPositionDistribution {
+friend cereal::access;
+protected:
+    SphereVolumePositionDistribution() {};
+private:
+    siren::geometry::Sphere sphere;
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+public:
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    SphereVolumePositionDistribution(siren::geometry::Sphere);
+    std::string Name() const override;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    virtual std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const override;
+    virtual bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(::cereal::make_nvp("Sphere", sphere));
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(this));
+        } else {
+            throw std::runtime_error("SphereVolumePositionDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    static void load_and_construct(Archive & archive, cereal::construct<SphereVolumePositionDistribution> & construct, std::uint32_t const version) {
+        if(version == 0) {
+            siren::geometry::Sphere c;
+            archive(::cereal::make_nvp("Sphere", c));
+            construct(c);
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(construct.ptr()));
+        } else {
+            throw std::runtime_error("SphereVolumePositionDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override;
+    virtual bool less(WeightableDistribution const & distribution) const override;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::SphereVolumePositionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::SphereVolumePositionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::VertexPositionDistribution, siren::distributions::SphereVolumePositionDistribution);
+
+#endif // SIREN_SphereVolumePositionDistribution_H


### PR DESCRIPTION
## Stack: PR 5 of 14

This PR is part of a 14-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `chore/file-reorg`
- **Head:** `feat/sphere-distribution`

Merge order: `chore/file-reorg` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
  - projects/distributions/public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h

Source commits on dev/HNL_DIS_clean that contributed:
  9dae77ab (Nicholas Kamp): spherical volume position distribution


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
