### PR TITLE
Add PrimaryExternalDistribution and bounded/physical vertex distributions

### DIFF
--- a/projects/dataclasses/private/InteractionRecord.cxx
+++ b/projects/dataclasses/private/InteractionRecord.cxx
@@ -245,6 +245,14 @@ void PrimaryDistributionRecord::SetHelicity(double helicity) {
     this->helicity = helicity;
 }
 
+void PrimaryDistributionRecord::SetInteractionParameters(std::map<std::string, double> const & parameters) {
+    interaction_parameters = parameters;
+}
+
+void PrimaryDistributionRecord::SetInteractionParameter(std::string const & name, double value) {
+    interaction_parameters[name] = value;
+}
+
 void PrimaryDistributionRecord::UpdateMass() const {
     if(mass_set)
         return;
@@ -619,6 +627,9 @@ void PrimaryDistributionRecord::Finalize(InteractionRecord & record) const {
     record.primary_mass = GetMass();
     record.primary_momentum = GetFourMomentum();
     record.primary_helicity = GetHelicity();
+    for (auto x : interaction_parameters) {
+        record.interaction_parameters[x.first] = x.second;
+    }
 }
 
 /////////////////////////////////////////
@@ -965,7 +976,10 @@ void CrossSectionDistributionRecord::Finalize(InteractionRecord & record) const 
     record.target_mass = target_mass;
     record.target_helicity = target_helicity;
 
-    record.interaction_parameters = interaction_parameters;
+    //record.interaction_parameters = interaction_parameters;
+    for (auto x : interaction_parameters) {
+        record.interaction_parameters[x.first] = x.second;
+    }
 
     record.secondary_ids.resize(secondary_particles.size());
     record.secondary_masses.resize(secondary_particles.size());

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
@@ -85,6 +85,7 @@ private:
     mutable double vertex_distance_from_closest_approach;
     mutable double initial_distance_from_closest_approach;
     mutable double helicity = 0;
+    std::map<std::string, double> interaction_parameters;
 public:
     friend std::ostream& ::operator<<(std::ostream& os, siren::dataclasses::PrimaryDistributionRecord const& record);
     friend std::string (::to_str)(siren::dataclasses::PrimaryDistributionRecord const & record);
@@ -130,6 +131,8 @@ public:
     void SetVertexDistanceFromClosestApproach(double vertex_distance_from_closest_approach);
     void SetInitialDistanceFromClosestApproach(double initial_distance_from_closest_approach);
     void SetHelicity(double helicity);
+    void SetInteractionParameters(std::map<std::string, double> const & parameters);
+    void SetInteractionParameter(std::string const & name, double value);
 
     void UpdateMass() const;
     void UpdateEnergy() const;

--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -3,6 +3,8 @@
 LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/Distributions.cxx
 
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/PrimaryExternalDistribution.cxx
+
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/PrimaryDirectionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/IsotropicDirection.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/FixedDirection.cxx
@@ -31,6 +33,8 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/CylinderVolumePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/area/PrimaryAreaDistribution.cxx

--- a/projects/distributions/private/primary/PrimaryExternalDistribution.cxx
+++ b/projects/distributions/private/primary/PrimaryExternalDistribution.cxx
@@ -1,0 +1,171 @@
+#include "SIREN/distributions/primary/PrimaryExternalDistribution.h"
+
+#include <array>                                           // for array
+#include <string>                                          // for basic_string
+
+#include "SIREN/dataclasses/InteractionRecord.h"  // for Interactio...
+#include "SIREN/utilities/Random.h"               // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+//---------------
+// class PrimaryExternalDistribution : PrimaryExternalDistribution
+//---------------
+
+void PrimaryExternalDistribution::LoadInputFile(std::string _filename)
+{filename = _filename;
+    input_file.open(filename);
+    init_pos_set = false;
+    mom_set = false;
+
+    std::string line;
+    if (!input_file.is_open()) {
+        std::cerr << "error: file open failed " << filename << ".\n";
+        exit(0);
+    }
+    std::getline(input_file,line);
+
+    std::stringstream ss(line);
+    std::string key;
+    while (std::getline(ss, key, ',')) {
+        keys.push_back(key);
+        if (key == "x0" ||
+            key == "y0" ||
+            key == "z0") init_pos_set = true;
+        if (key == "px" ||
+            key == "py" ||
+            key == "pz") mom_set = true;
+    }
+
+    std::string value;
+    // fill input data
+    while (std::getline(input_file,line)) {
+        std::vector<double> tmp_data;
+        std::stringstream _ss(line);
+        size_t ikey = 0;
+        bool passed = true;
+        while (std::getline(_ss, value, ',')) {
+            if (keys[ikey]=="E") {
+                if (stod(value) < emin) passed = false;
+            }
+            ++ikey;
+            tmp_data.push_back(stod(value));
+        }
+        if (passed) input_data.push_back(tmp_data);
+    }
+
+}
+
+PrimaryExternalDistribution::PrimaryExternalDistribution(std::string _filename) : emin(0)
+{
+    LoadInputFile(_filename);
+}
+
+PrimaryExternalDistribution::PrimaryExternalDistribution(std::string _filename, double emin) : emin(emin)
+{
+    LoadInputFile(_filename);
+}
+
+PrimaryExternalDistribution::PrimaryExternalDistribution(PrimaryExternalDistribution const & other)
+{
+    PrimaryExternalDistribution(other.filename);
+}
+
+// Accounts for events above threshold only!
+int PrimaryExternalDistribution::GetPhysicalNumEvents()
+{
+    return input_data.size();
+}
+
+void PrimaryExternalDistribution::Sample(
+        std::shared_ptr<siren::utilities::SIREN_random> rand,
+        std::shared_ptr<siren::detector::DetectorModel const> detector_model,
+        std::shared_ptr<siren::interactions::InteractionCollection const> interactions,
+        siren::dataclasses::PrimaryDistributionRecord & record) const {
+
+    size_t max_tries = 1000;
+    size_t num_tries = 0;
+    bool success = false;
+    while(!success && num_tries < max_tries) {
+        ++num_tries;
+        int i = int(rand->Uniform() * input_data.size());
+        int i_key = 0;
+        std::array<double, 3> _initial_position;
+        std::array<double, 3> _momentum;
+        for (auto value : input_data[i]) {
+            if (keys[i_key] == "x0") {
+                _initial_position[0] = value;
+            }
+            else if (keys[i_key] == "y0") {
+                _initial_position[1] = value;
+            }
+            else if (keys[i_key] == "z0") {
+                _initial_position[2] = value;
+            }
+            else if (keys[i_key] == "px") {
+                _momentum[0] = value;
+            }
+            else if (keys[i_key] == "py") {
+                _momentum[1] = value;
+            }
+            else if (keys[i_key] == "pz") {
+                _momentum[2] = value;
+            }
+            else if (keys[i_key] == "E") {
+                if (value > emin) success=true;
+                else success=false;
+                record.SetEnergy(value);
+            }
+            else if (keys[i_key] == "m") {
+                record.SetMass(value);
+            }
+            else {
+                record.SetInteractionParameter(keys[i_key],value);
+            }
+            ++i_key;
+        }
+        if(mom_set) record.SetThreeMomentum(_momentum);
+        if(init_pos_set) record.SetInitialPosition(_initial_position);
+    }
+    if(!success) {
+        std::cout << "Failed to generate a physical primary after " << max_tries << "attempts. Try again\n";
+        exit(0);
+    }
+}
+
+std::vector<std::string> PrimaryExternalDistribution::DensityVariables() const {
+    return std::vector<std::string>{"External"};
+}
+
+std::string PrimaryExternalDistribution::Name() const {
+    return "PrimaryExternalDistribution";
+}
+
+double PrimaryExternalDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model,
+                                                          std::shared_ptr<siren::interactions::InteractionCollection const> interactions,
+                                                          siren::dataclasses::InteractionRecord const & record) const {
+    return 1;
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> PrimaryExternalDistribution::clone() const {
+    return std::shared_ptr<PrimaryInjectionDistribution>(new PrimaryExternalDistribution(*this));
+}
+
+bool PrimaryExternalDistribution::equal(WeightableDistribution const & other) const {
+    const PrimaryExternalDistribution* x = dynamic_cast<const PrimaryExternalDistribution*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return filename == x->filename;
+}
+
+bool PrimaryExternalDistribution::less(WeightableDistribution const & other) const {
+    const PrimaryExternalDistribution* x = dynamic_cast<const PrimaryExternalDistribution*>(&other);
+    return filename != x->filename;
+}
+
+
+} // namespace distributions
+} // namespace sirenREN

--- a/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
@@ -1,0 +1,248 @@
+#include "SIREN/distributions/primary/vertex/PrimaryBoundedVertexDistribution.h"
+
+#include <set>                                                    // for set
+#include <array>                                                  // for array
+#include <cmath>                                                  // for exp
+#include <tuple>                                                  // for tie
+#include <string>                                                 // for bas...
+#include <vector>                                                 // for vector
+
+#include "SIREN/interactions/CrossSection.h"            // for Cro...
+#include "SIREN/interactions/InteractionCollection.h"  // for Cro...
+#include "SIREN/dataclasses/InteractionRecord.h"         // for Int...
+#include "SIREN/dataclasses/InteractionSignature.h"      // for Int...
+#include "SIREN/dataclasses/Particle.h"                  // for Par...
+#include "SIREN/detector/DetectorModel.h"                   // for Ear...
+#include "SIREN/detector/Path.h"                         // for Path
+#include "SIREN/detector/Coordinates.h"
+#include "SIREN/distributions/Distributions.h"           // for Inj...
+#include "SIREN/geometry/Geometry.h"                     // for Geo...
+#include "SIREN/math/Vector3D.h"                         // for Vec...
+#include "SIREN/utilities/Errors.h"                      // for Sec...
+#include "SIREN/utilities/Random.h"                      // for SIREN_...
+
+namespace siren {
+namespace distributions {
+
+using detector::DetectorPosition;
+using detector::DetectorDirection;
+using detector::GeometryPosition;
+using detector::GeometryDirection;
+
+namespace {
+double log_one_minus_exp_of_negative(double x) {
+    if(x < 1e-1) {
+        return std::log(x) - x/2.0 + x*x/24.0 - x*x*x*x/2880.0;
+    } else if(x > 3) {
+        double ex = std::exp(-x);
+        double ex2 = ex * ex;
+        double ex3 = ex2 * ex;
+        double ex4 = ex3 * ex;
+        double ex5 = ex4 * ex;
+        double ex6 = ex5 * ex;
+        return -(ex + ex2 / 2.0 + ex3 / 3.0 + ex4 / 4.0 + ex5 / 5.0 + ex6 / 6.0);
+    } else {
+        return std::log(1.0 - std::exp(-x));
+    }
+}
+}
+
+//---------------
+// class PrimaryBoundedVertexDistribution : public VertexPositionDistribution
+//---------------
+
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryBoundedVertexDistribution::SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    siren::math::Vector3D pos = record.GetInitialPosition();
+    siren::math::Vector3D dir = record.GetDirection();
+
+    siren::math::Vector3D endcap_0 = pos;
+    siren::math::Vector3D endcap_1 = endcap_0 + max_length * dir;
+
+    siren::detector::Path path(detector_model, DetectorPosition(endcap_0), DetectorDirection(dir), max_length);
+    path.ClipToOuterBounds();
+
+    // Check if fiducial volume is provided
+    if(fiducial_volume) {
+        std::vector<siren::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(endcap_0, dir);
+        // If the path intersects the fiducial volume, restrict position to that volume
+        if(!fid_intersections.empty()) {
+            // make sure the first intersection happens before the maximum generation length
+            // and the last intersection happens in front of the generation point
+            bool update_path = (fid_intersections.front().distance < max_length
+                    && fid_intersections.back().distance > 0);
+            if(update_path) {
+                siren::math::Vector3D first_point((fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0);
+                siren::math::Vector3D last_point((fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1);
+                path.SetPoints(DetectorPosition(first_point), DetectorPosition(last_point));
+            }
+        }
+    }
+
+    std::vector<siren::dataclasses::ParticleType> targets(interactions->TargetTypes().begin(), interactions->TargetTypes().end());
+
+    siren::dataclasses::InteractionRecord fake_record;
+    record.FinalizeAvailable(fake_record);
+    std::vector<double> total_cross_sections(targets.size(), 0.0);
+    double total_decay_length = interactions->TotalDecayLength(fake_record);
+    for(unsigned int i=0; i<targets.size(); ++i) {
+        siren::dataclasses::ParticleType const & target = targets[i];
+        fake_record.signature.target_type = target;
+        fake_record.target_mass = detector_model->GetTargetMass(target);
+        for(auto const & cross_section : interactions->GetCrossSectionsForTarget(target)) {
+            total_cross_sections[i] += cross_section->TotalCrossSectionAllFinalStates(fake_record);
+        }
+    }
+
+    double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
+    if(total_interaction_depth == 0) {
+        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+    }
+
+    double traversed_interaction_depth;
+    if(total_interaction_depth < 1e-6) {
+        traversed_interaction_depth = rand->Uniform() * total_interaction_depth;
+    } else {
+        double exp_m_total_interaction_depth = exp(-total_interaction_depth);
+
+        double y = rand->Uniform();
+        traversed_interaction_depth = -log(y * exp_m_total_interaction_depth + (1.0 - y));
+    }
+
+    double dist = path.GetDistanceFromStartAlongPath(traversed_interaction_depth, targets, total_cross_sections, total_decay_length);
+    siren::math::Vector3D vertex = path.GetFirstPoint() + dist * path.GetDirection();
+
+    return {pos, vertex};
+}
+
+double PrimaryBoundedVertexDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    siren::math::Vector3D dir(record.primary_momentum[1], record.primary_momentum[2], record.primary_momentum[3]);
+    dir.normalize();
+    siren::math::Vector3D vertex(record.interaction_vertex);
+
+    siren::math::Vector3D endcap_0 = record.primary_initial_position;
+    siren::math::Vector3D endcap_1 = endcap_0 + max_length * dir;
+
+    siren::detector::Path path(detector_model, DetectorPosition(endcap_0), DetectorDirection(dir), max_length);
+    path.ClipToOuterBounds();
+
+    // Check if fiducial volume is provided
+    if(fiducial_volume) {
+        std::vector<siren::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(endcap_0, dir);
+        // If the path intersects the fiducial volume, restrict position to that volume
+        if(!fid_intersections.empty()) {
+            // make sure the first intersection happens before the maximum generation length
+            // and the last intersection happens in front of the generation point
+            bool update_path = (fid_intersections.front().distance < max_length
+                    && fid_intersections.back().distance > 0);
+            if(update_path) {
+                DetectorPosition first_point((fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0);
+                DetectorPosition last_point((fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1);
+                path.SetPoints(first_point, last_point);
+            }
+        }
+    }
+
+    if(not path.IsWithinBounds(DetectorPosition(vertex)))
+        return 0.0;
+
+    std::set<siren::dataclasses::ParticleType> const & possible_targets = interactions->TargetTypes();
+
+    std::vector<siren::dataclasses::ParticleType> targets(possible_targets.begin(), possible_targets.end());
+    std::vector<double> total_cross_sections(targets.size(), 0.0);
+    double total_decay_length = interactions->TotalDecayLength(record);
+    siren::dataclasses::InteractionRecord fake_record = record;
+    for(unsigned int i=0; i<targets.size(); ++i) {
+        siren::dataclasses::ParticleType const & target = targets[i];
+        fake_record.signature.target_type = target;
+        fake_record.target_mass = detector_model->GetTargetMass(target);
+        for(auto const & cross_section : interactions->GetCrossSectionsForTarget(target)) {
+            total_cross_sections[i] += cross_section->TotalCrossSectionAllFinalStates(fake_record);
+        }
+    }
+    double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
+
+    path.SetPointsWithRay(path.GetFirstPoint(), path.GetDirection(), path.GetDistanceFromStartInBounds(DetectorPosition(vertex)));
+
+    double traversed_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
+
+    double interaction_density = detector_model->GetInteractionDensity(path.GetIntersections(), DetectorPosition(vertex), targets, total_cross_sections, total_decay_length);
+
+    double prob_density;
+    if(total_interaction_depth < 1e-6) {
+        prob_density = interaction_density / total_interaction_depth;
+    } else {
+        prob_density = interaction_density * exp(-log_one_minus_exp_of_negative(total_interaction_depth) - traversed_interaction_depth);
+    }
+
+    return prob_density;
+}
+
+PrimaryBoundedVertexDistribution::PrimaryBoundedVertexDistribution() {}
+
+PrimaryBoundedVertexDistribution::PrimaryBoundedVertexDistribution(double max_length) : max_length(max_length) {}
+
+PrimaryBoundedVertexDistribution::PrimaryBoundedVertexDistribution(std::shared_ptr<siren::geometry::Geometry> fiducial_volume) : fiducial_volume(fiducial_volume) {}
+
+PrimaryBoundedVertexDistribution::PrimaryBoundedVertexDistribution(std::shared_ptr<siren::geometry::Geometry> fiducial_volume, double max_length) : fiducial_volume(fiducial_volume), max_length(max_length) {}
+
+std::string PrimaryBoundedVertexDistribution::Name() const {
+    return "PrimaryBoundedVertexDistribution";
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> PrimaryBoundedVertexDistribution::clone() const {
+    return std::shared_ptr<PrimaryInjectionDistribution>(new PrimaryBoundedVertexDistribution(*this));
+}
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryBoundedVertexDistribution::InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    siren::math::Vector3D dir(record.primary_momentum[1], record.primary_momentum[2], record.primary_momentum[3]);
+    dir.normalize();
+    siren::math::Vector3D vertex(record.interaction_vertex);
+
+    siren::math::Vector3D endcap_0 = record.primary_initial_position;
+    siren::math::Vector3D endcap_1 = endcap_0 + max_length * dir;
+
+    siren::detector::Path path(detector_model, DetectorPosition(endcap_0), DetectorDirection(dir), max_length);
+    path.ClipToOuterBounds();
+
+    // Check if fiducial volume is provided
+    if(fiducial_volume) {
+        std::vector<siren::geometry::Geometry::Intersection> fid_intersections = fiducial_volume->Intersections(endcap_0, dir);
+        // If the path intersects the fiducial volume, restrict position to that volume
+        if(!fid_intersections.empty()) {
+            // make sure the first intersection happens before the maximum generation length
+            // and the last intersection happens in front of the generation point
+            bool update_path = (fid_intersections.front().distance < max_length
+                    && fid_intersections.back().distance > 0);
+            if(update_path) {
+                DetectorPosition first_point((fid_intersections.front().distance > 0) ? fid_intersections.front().position : endcap_0);
+                DetectorPosition last_point((fid_intersections.back().distance < max_length) ? fid_intersections.back().position : endcap_1);
+                path.SetPoints(first_point, last_point);
+            }
+        }
+    }
+
+    if(not path.IsWithinBounds(DetectorPosition(vertex)))
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(siren::math::Vector3D(0, 0, 0), siren::math::Vector3D(0, 0, 0));
+    return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(path.GetFirstPoint(), path.GetLastPoint());
+}
+
+bool PrimaryBoundedVertexDistribution::equal(WeightableDistribution const & other) const {
+    const PrimaryBoundedVertexDistribution* x = dynamic_cast<const PrimaryBoundedVertexDistribution*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return (max_length == x->max_length);
+}
+
+bool PrimaryBoundedVertexDistribution::less(WeightableDistribution const & other) const {
+    const PrimaryBoundedVertexDistribution* x = dynamic_cast<const PrimaryBoundedVertexDistribution*>(&other);
+    return
+        std::tie(max_length)
+        <
+        std::tie(x->max_length);
+}
+
+} // namespace distributions
+} // namespace sirenREN

--- a/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
@@ -1,0 +1,183 @@
+#include "SIREN/distributions/primary/vertex/PrimaryPhysicalVertexDistribution.h"
+
+#include <set>                                                    // for set
+#include <array>                                                  // for array
+#include <cmath>                                                  // for exp
+#include <tuple>                                                  // for tie
+#include <string>                                                 // for bas...
+#include <vector>                                                 // for vector
+
+#include "SIREN/interactions/CrossSection.h"            // for Cro...
+#include "SIREN/interactions/InteractionCollection.h"  // for Cro...
+#include "SIREN/dataclasses/InteractionRecord.h"         // for Int...
+#include "SIREN/dataclasses/InteractionSignature.h"      // for Int...
+#include "SIREN/dataclasses/Particle.h"                  // for Par...
+#include "SIREN/detector/DetectorModel.h"                   // for Ear...
+#include "SIREN/detector/Path.h"                         // for Path
+#include "SIREN/detector/Coordinates.h"
+#include "SIREN/distributions/Distributions.h"           // for Inj...
+#include "SIREN/geometry/Geometry.h"                     // for Geo...
+#include "SIREN/math/Vector3D.h"                         // for Vec...
+#include "SIREN/utilities/Errors.h"                      // for Sec...
+#include "SIREN/utilities/Random.h"                      // for SIREN_...
+
+namespace siren {
+namespace distributions {
+
+using detector::DetectorPosition;
+using detector::DetectorDirection;
+
+namespace {
+double log_one_minus_exp_of_negative(double x) {
+    if(x < 1e-1) {
+        return std::log(x) - x/2.0 + x*x/24.0 - x*x*x*x/2880.0;
+    } else if(x > 3) {
+        double ex = std::exp(-x);
+        double ex2 = ex * ex;
+        double ex3 = ex2 * ex;
+        double ex4 = ex3 * ex;
+        double ex5 = ex4 * ex;
+        double ex6 = ex5 * ex;
+        return -(ex + ex2 / 2.0 + ex3 / 3.0 + ex4 / 4.0 + ex5 / 5.0 + ex6 / 6.0);
+    } else {
+        return std::log(1.0 - std::exp(-x));
+    }
+}
+}
+
+//---------------
+// class PrimaryPhysicalVertexDistribution : public VertexPositionDistribution
+//---------------
+
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryPhysicalVertexDistribution::SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    siren::math::Vector3D pos = record.GetInitialPosition();
+    siren::math::Vector3D dir = record.GetDirection();
+
+    siren::math::Vector3D endcap_0 = pos;
+
+    siren::detector::Path path(detector_model, DetectorPosition(endcap_0), DetectorDirection(dir), std::numeric_limits<double>::infinity());
+    path.ClipToOuterBounds();
+
+    std::vector<siren::dataclasses::ParticleType> targets(interactions->TargetTypes().begin(), interactions->TargetTypes().end());
+
+    siren::dataclasses::InteractionRecord fake_record;
+    record.FinalizeAvailable(fake_record);
+    std::vector<double> total_cross_sections(targets.size(), 0.0);
+    double total_decay_length = interactions->TotalDecayLength(fake_record);
+    for(unsigned int i=0; i<targets.size(); ++i) {
+        siren::dataclasses::ParticleType const & target = targets[i];
+        fake_record.signature.target_type = target;
+        fake_record.target_mass = detector_model->GetTargetMass(target);
+        for(auto const & cross_section : interactions->GetCrossSectionsForTarget(target)) {
+            total_cross_sections[i] += cross_section->TotalCrossSectionAllFinalStates(fake_record);
+        }
+    }
+
+    double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
+    if(total_interaction_depth == 0) {
+        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+    }
+
+    double traversed_interaction_depth;
+    if(total_interaction_depth < 1e-6) {
+        traversed_interaction_depth = rand->Uniform() * total_interaction_depth;
+    } else {
+        double exp_m_total_interaction_depth = exp(-total_interaction_depth);
+
+        double y = rand->Uniform();
+        traversed_interaction_depth = -log(y * exp_m_total_interaction_depth + (1.0 - y));
+    }
+
+    double dist = path.GetDistanceFromStartAlongPath(traversed_interaction_depth, targets, total_cross_sections, total_decay_length);
+    siren::math::Vector3D vertex = path.GetFirstPoint() + dist * path.GetDirection();
+
+    return {pos, vertex};
+}
+
+double PrimaryPhysicalVertexDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    siren::math::Vector3D dir(record.primary_momentum[1], record.primary_momentum[2], record.primary_momentum[3]);
+    dir.normalize();
+    siren::math::Vector3D vertex(record.interaction_vertex);
+
+    siren::math::Vector3D endcap_0 = record.primary_initial_position;
+
+    siren::detector::Path path(detector_model, DetectorPosition(endcap_0), DetectorDirection(dir), std::numeric_limits<double>::infinity());
+    path.ClipToOuterBounds();
+
+    if(not path.IsWithinBounds(DetectorPosition(vertex)))
+        return 0.0;
+
+    std::set<siren::dataclasses::ParticleType> const & possible_targets = interactions->TargetTypes();
+
+    std::vector<siren::dataclasses::ParticleType> targets(possible_targets.begin(), possible_targets.end());
+    std::vector<double> total_cross_sections(targets.size(), 0.0);
+    double total_decay_length = interactions->TotalDecayLength(record);
+    siren::dataclasses::InteractionRecord fake_record = record;
+    for(unsigned int i=0; i<targets.size(); ++i) {
+        siren::dataclasses::ParticleType const & target = targets[i];
+        fake_record.signature.target_type = target;
+        fake_record.target_mass = detector_model->GetTargetMass(target);
+        for(auto const & cross_section : interactions->GetCrossSectionsForTarget(target)) {
+            total_cross_sections[i] += cross_section->TotalCrossSectionAllFinalStates(fake_record);
+        }
+    }
+    double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
+
+    path.SetPointsWithRay(path.GetFirstPoint(), path.GetDirection(), path.GetDistanceFromStartInBounds(DetectorPosition(vertex)));
+
+    double traversed_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
+
+    double interaction_density = detector_model->GetInteractionDensity(path.GetIntersections(), DetectorPosition(vertex), targets, total_cross_sections, total_decay_length);
+
+    double prob_density;
+    if(total_interaction_depth < 1e-6) {
+        prob_density = interaction_density / total_interaction_depth;
+    } else {
+        prob_density = interaction_density * exp(-log_one_minus_exp_of_negative(total_interaction_depth) - traversed_interaction_depth);
+    }
+
+    return prob_density;
+}
+
+PrimaryPhysicalVertexDistribution::PrimaryPhysicalVertexDistribution() {}
+
+std::string PrimaryPhysicalVertexDistribution::Name() const {
+    return "PrimaryPhysicalVertexDistribution";
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> PrimaryPhysicalVertexDistribution::clone() const {
+    return std::shared_ptr<PrimaryInjectionDistribution>(new PrimaryPhysicalVertexDistribution(*this));
+}
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryPhysicalVertexDistribution::InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    siren::math::Vector3D dir(record.primary_momentum[1], record.primary_momentum[2], record.primary_momentum[3]);
+    dir.normalize();
+    siren::math::Vector3D vertex(record.interaction_vertex);
+
+    siren::math::Vector3D endcap_0 = record.primary_initial_position;
+
+    siren::detector::Path path(detector_model, DetectorPosition(endcap_0), DetectorDirection(dir), std::numeric_limits<double>::infinity());
+    path.ClipToOuterBounds();
+
+    if(not path.IsWithinBounds(DetectorPosition(vertex)))
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(siren::math::Vector3D(0, 0, 0), siren::math::Vector3D(0, 0, 0));
+    return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(path.GetFirstPoint(), path.GetLastPoint());
+}
+
+bool PrimaryPhysicalVertexDistribution::equal(WeightableDistribution const & other) const {
+    const PrimaryPhysicalVertexDistribution* x = dynamic_cast<const PrimaryPhysicalVertexDistribution*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return true;
+}
+
+bool PrimaryPhysicalVertexDistribution::less(WeightableDistribution const & other) const {
+    const PrimaryPhysicalVertexDistribution* x = dynamic_cast<const PrimaryPhysicalVertexDistribution*>(&other);
+    return false;
+}
+
+} // namespace distributions
+} // namespace sirenREN

--- a/projects/distributions/private/pybindings/distributions.cxx
+++ b/projects/distributions/private/pybindings/distributions.cxx
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "../../public/SIREN/distributions/Distributions.h"
+#include "../../public/SIREN/distributions/primary/PrimaryExternalDistribution.h"
 #include "../../public/SIREN/distributions/primary/direction/PrimaryDirectionDistribution.h"
 #include "../../public/SIREN/distributions/primary/direction/Cone.h"
 #include "../../public/SIREN/distributions/primary/direction/FixedDirection.h"
@@ -25,6 +26,8 @@
 #include "../../public/SIREN/distributions/primary/vertex/PointSourcePositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/RangeFunction.h"
 #include "../../public/SIREN/distributions/primary/vertex/RangePositionDistribution.h"
+#include "../../public/SIREN/distributions/primary/vertex/PrimaryPhysicalVertexDistribution.h"
+#include "../../public/SIREN/distributions/primary/vertex/PrimaryBoundedVertexDistribution.h"
 #include "../../public/SIREN/distributions/primary/area/PrimaryAreaDistribution.h"
 #include "../../public/SIREN/distributions/primary/area/FixedTargetAreaDistribution.h"
 #include "../../public/SIREN/distributions/secondary/vertex/SecondaryPhysicalVertexDistribution.h"
@@ -63,6 +66,15 @@ PYBIND11_MODULE(distributions,m) {
   class_<PrimaryInjectionDistribution, std::shared_ptr<PrimaryInjectionDistribution>, WeightableDistribution>(m, "PrimaryInjectionDistribution")
     .def("Sample",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::PrimaryDistributionRecord &>(&PrimaryInjectionDistribution::Sample, const_))
     ;
+
+  // External distribution
+  class_<PrimaryExternalDistribution, std::shared_ptr<PrimaryExternalDistribution>, PrimaryInjectionDistribution>(m,"PrimaryExternalDistribution")
+    .def(init<std::string>())
+    .def(init<std::string, double>())
+    .def("Sample",&PrimaryExternalDistribution::Sample)
+    .def("GetPhysicalNumEvents",&PrimaryExternalDistribution::GetPhysicalNumEvents)
+    .def("DensityVariables",&PrimaryExternalDistribution::DensityVariables)
+    .def("GenerationProbability",&PrimaryExternalDistribution::GenerationProbability);
 
   // Direciton distributions
 
@@ -234,6 +246,23 @@ PYBIND11_MODULE(distributions,m) {
     .def("GenerationProbability",&RangePositionDistribution::GenerationProbability)
     .def("InjectionBounds",&RangePositionDistribution::InjectionBounds)
     .def("Name",&RangePositionDistribution::Name);
+
+  class_<PrimaryPhysicalVertexDistribution, std::shared_ptr<PrimaryPhysicalVertexDistribution>, VertexPositionDistribution>(m, "PrimaryPhysicalVertexDistribution")
+    .def(init<>())
+    .def("SamplePosition",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::PrimaryDistributionRecord &>(&PrimaryPhysicalVertexDistribution::SamplePosition, const_))
+    .def("GenerationProbability",overload_cast<std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::InteractionRecord const &>(&PrimaryPhysicalVertexDistribution::GenerationProbability, const_))
+    .def("InjectionBounds",overload_cast<std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::InteractionRecord const &>(&PrimaryPhysicalVertexDistribution::InjectionBounds, const_))
+    .def("Name",&PrimaryPhysicalVertexDistribution::Name);
+
+  class_<PrimaryBoundedVertexDistribution, std::shared_ptr<PrimaryBoundedVertexDistribution>, VertexPositionDistribution>(m, "PrimaryBoundedVertexDistribution")
+    .def(init<>())
+    .def(init<double>())
+    .def(init<std::shared_ptr<siren::geometry::Geometry>>())
+    .def(init<std::shared_ptr<siren::geometry::Geometry>, double>())
+    .def("SamplePosition",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::PrimaryDistributionRecord &>(&PrimaryBoundedVertexDistribution::SamplePosition, const_))
+    .def("GenerationProbability",overload_cast<std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::InteractionRecord const &>(&PrimaryBoundedVertexDistribution::GenerationProbability, const_))
+    .def("InjectionBounds",overload_cast<std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::InteractionRecord const &>(&PrimaryBoundedVertexDistribution::InjectionBounds, const_))
+    .def("Name",&PrimaryBoundedVertexDistribution::Name);
 
   class_<FixedTargetPositionDistribution, std::shared_ptr<FixedTargetPositionDistribution>, VertexPositionDistribution>(m, "FixedTargetPositionDistribution")
     .def(init<>())

--- a/projects/distributions/public/SIREN/distributions/primary/PrimaryExternalDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/PrimaryExternalDistribution.h
@@ -1,0 +1,83 @@
+#pragma once
+#ifndef SIREN_PrimaryExternalDistribution_H
+#define SIREN_PrimaryExternalDistribution_H
+
+#include <memory>                                        // for shared_ptr
+#include <string>                                        // for string
+#include <vector>                                        // for vector
+#include <cstdint>                                       // for uint32_t
+#include <stdexcept>                                     // for runtime_error
+
+#include <cereal/access.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/Distributions.h"  // for WeightableDi...
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+namespace cereal { class access; }
+
+namespace siren {
+namespace distributions {
+
+class PrimaryExternalDistribution : virtual public PrimaryInjectionDistribution {
+friend cereal::access;
+protected:
+    PrimaryExternalDistribution() {};
+    void LoadInputFile(std::string _filename);
+public:
+    ~PrimaryExternalDistribution() {
+        input_file.close();
+    };
+    std::string filename;
+private:
+    std::ifstream input_file;
+    std::vector<std::vector<double>> input_data;
+    std::vector<std::string> keys;
+    std::vector<std::string> possible_keys = {"x0","y0","z0","m","E","px","py","pz"};
+    bool init_pos_set;
+    bool mom_set;
+    double emin;
+public:
+    PrimaryExternalDistribution(std::string _filename);
+    PrimaryExternalDistribution(std::string _filename, double emin);
+    PrimaryExternalDistribution(PrimaryExternalDistribution const & other);
+    int GetPhysicalNumEvents();
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    virtual std::vector<std::string> DensityVariables() const override;
+    virtual std::string Name() const override;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(cereal::virtual_base_class<PrimaryInjectionDistribution>(this));
+        } else {
+            throw std::runtime_error("PrimaryExternalDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    void load(Archive & archive, std::uint32_t const version) {
+        if(version == 0) {
+            archive(cereal::virtual_base_class<PrimaryInjectionDistribution>(this));
+        } else {
+            throw std::runtime_error("PrimaryExternalDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override;
+    virtual bool less(WeightableDistribution const & distribution) const override;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::PrimaryExternalDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::PrimaryExternalDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryInjectionDistribution, siren::distributions::PrimaryExternalDistribution);
+
+#endif // SIREN_PrimaryExternalDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/vertex/PrimaryBoundedVertexDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/vertex/PrimaryBoundedVertexDistribution.h
@@ -1,0 +1,90 @@
+#pragma once
+#ifndef SIREN_PrimaryBoundedVertexDistribution_H
+#define SIREN_PrimaryBoundedVertexDistribution_H
+
+#include <tuple>
+#include <limits>
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <stddef.h>
+#include <stdexcept>
+
+#include <cereal/access.hpp>
+#include <cereal/types/set.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+#include <cereal/types/memory.hpp>
+
+#include "SIREN/dataclasses/InteractionTree.h"
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+#include "SIREN/math/Vector3D.h"
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace distributions { class PrimaryInjectionDistribution; } }
+namespace siren { namespace distributions { class WeightableDistribution; } }
+namespace siren { namespace geometry { class Geometry; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+class PrimaryBoundedVertexDistribution : virtual public VertexPositionDistribution {
+friend cereal::access;
+private:
+    std::shared_ptr<siren::geometry::Geometry> fiducial_volume = nullptr;
+    double max_length = std::numeric_limits<double>::infinity();
+public:
+
+    PrimaryBoundedVertexDistribution();
+    PrimaryBoundedVertexDistribution(const PrimaryBoundedVertexDistribution &) = default;
+    PrimaryBoundedVertexDistribution(double max_length);
+    PrimaryBoundedVertexDistribution(std::shared_ptr<siren::geometry::Geometry> fiducial_volume);
+    PrimaryBoundedVertexDistribution(std::shared_ptr<siren::geometry::Geometry> fiducial_volume, double max_length);
+
+    virtual std::tuple<siren::math::Vector3D, siren::math::Vector3D> SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+
+    std::string Name() const override;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    virtual std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const override;
+
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(::cereal::make_nvp("MaxLength", max_length));
+            archive(::cereal::make_nvp("FidVol", fiducial_volume));
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(this));
+        } else {
+            throw std::runtime_error("PrimaryBoundedVertexDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    static void load_and_construct(Archive & archive, cereal::construct<PrimaryBoundedVertexDistribution> & construct, std::uint32_t const version) {
+        if(version == 0) {
+            double max_length;
+            std::shared_ptr<siren::geometry::Geometry> fiducial_volume;
+            archive(::cereal::make_nvp("MaxLength", max_length));
+            archive(::cereal::make_nvp("FidVol", fiducial_volume));
+            construct(fiducial_volume,max_length);
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(construct.ptr()));
+        } else {
+            throw std::runtime_error("PrimaryBoundedVertexDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override;
+    virtual bool less(WeightableDistribution const & distribution) const override;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::PrimaryBoundedVertexDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::PrimaryBoundedVertexDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::VertexPositionDistribution, siren::distributions::PrimaryBoundedVertexDistribution);
+
+#endif // SIREN_PrimaryBoundedVertexDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/vertex/PrimaryPhysicalVertexDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/vertex/PrimaryPhysicalVertexDistribution.h
@@ -1,0 +1,78 @@
+#pragma once
+#ifndef SIREN_PrimaryPhysicalVertexDistribution_H
+#define SIREN_PrimaryPhysicalVertexDistribution_H
+
+#include <tuple>
+#include <limits>
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <stddef.h>
+#include <stdexcept>
+
+#include <cereal/access.hpp>
+#include <cereal/types/set.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+#include <cereal/types/memory.hpp>
+
+#include "SIREN/dataclasses/InteractionTree.h"
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+#include "SIREN/math/Vector3D.h"
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace distributions { class InjectionDistribution; } }
+namespace siren { namespace distributions { class WeightableDistribution; } }
+namespace siren { namespace geometry { class Geometry; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+class PrimaryPhysicalVertexDistribution : virtual public VertexPositionDistribution {
+friend cereal::access;
+public:
+
+    PrimaryPhysicalVertexDistribution();
+    PrimaryPhysicalVertexDistribution(const PrimaryPhysicalVertexDistribution &) = default;
+
+    virtual std::tuple<siren::math::Vector3D, siren::math::Vector3D> SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+
+    std::string Name() const override;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    virtual std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const override;
+
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(this));
+        } else {
+            throw std::runtime_error("PrimaryPhysicalVertexDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    static void load_and_construct(Archive & archive, cereal::construct<PrimaryPhysicalVertexDistribution> & construct, std::uint32_t const version) {
+        if(version == 0) {
+            construct();
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(construct.ptr()));
+        } else {
+            throw std::runtime_error("PrimaryPhysicalVertexDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override;
+    virtual bool less(WeightableDistribution const & distribution) const override;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::PrimaryPhysicalVertexDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::PrimaryPhysicalVertexDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::VertexPositionDistribution, siren::distributions::PrimaryPhysicalVertexDistribution);
+
+#endif // SIREN_PrimaryPhysicalVertexDistribution_H


### PR DESCRIPTION
## Stack: PR 6 of 14

This PR is part of a 14-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/sphere-distribution`
- **Head:** `feat/primary-external-distribution`

Merge order: `feat/sphere-distribution` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - projects/distributions/private/primary/PrimaryExternalDistribution.cxx
  - projects/distributions/public/SIREN/distributions/primary/PrimaryExternalDistribution.h
  - projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
  - projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
  - projects/distributions/public/SIREN/distributions/primary/vertex/PrimaryBoundedVertexDistribution.h
  - projects/distributions/public/SIREN/distributions/primary/vertex/PrimaryPhysicalVertexDistribution.h

Source commits on dev/HNL_DIS_clean that contributed:
  21451da3 (Nicholas Kamp): first attempt at external list primary injector
  34a229f6 (Nicholas Kamp): changes to fix runtime errors
  455b0730 (Nicholas Kamp): introduce primary bounded and physical vertex distributions to sample vertex in the case that the inital position is already provided from the external distribution
  9098b42e (Nicholas Kamp): fix weighting issue in PrimaryExternalDist
  a79d4408 (Nicholas Kamp): getting HNLs to work for SINE and UNDINE
  d7abebbd (Nicholas Kamp): build fixes to PrimaryExternalDistribution
  e530d339 (Nicholas Kamp): bug fix in PrimaryExternalDistribution


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
