### PR TITLE
Add 2D atmospheric flux tables and tabulated trapezoid integration

### DIFF
--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -17,6 +17,9 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/Monoenergetic.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/PiDARNuEDistribution.cxx
 
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy_direction/PrimaryEnergyDirectionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy_direction/Tabulated2DFluxDistribution.cxx
+
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/helicity/PrimaryNeutrinoHelicityDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/mass/PrimaryMass.cxx

--- a/projects/distributions/private/primary/energy_direction/PrimaryEnergyDirectionDistribution.cxx
+++ b/projects/distributions/private/primary/energy_direction/PrimaryEnergyDirectionDistribution.cxx
@@ -1,0 +1,30 @@
+#include "SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h"
+
+#include <array>                                           // for array
+#include <string>                                          // for basic_string
+
+#include "SIREN/dataclasses/InteractionRecord.h"  // for Interactio...
+
+namespace siren {
+namespace distributions {
+
+//---------------
+// class PrimaryEnergyDirectionDistribution : PrimaryInjectionDistribution
+//---------------
+void PrimaryEnergyDirectionDistribution::Sample(
+        std::shared_ptr<siren::utilities::SIREN_random> rand,
+        std::shared_ptr<siren::detector::DetectorModel const> detector_model,
+        std::shared_ptr<siren::interactions::InteractionCollection const> interactions,
+        siren::dataclasses::PrimaryDistributionRecord & record) const {
+
+    std::pair<double,siren::math::Vector3D> energy_and_direction = SampleEnergyAndDirection(rand, detector_model, interactions, record);
+    record.SetEnergy(energy_and_direction.first);
+    record.SetDirection(energy_and_direction.second);
+}
+
+std::vector<std::string> PrimaryEnergyDirectionDistribution::DensityVariables() const {
+    return std::vector<std::string>{"PrimaryEnergy","PrimaryDirection"};
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/primary/energy_direction/Tabulated2DFluxDistribution.cxx
+++ b/projects/distributions/private/primary/energy_direction/Tabulated2DFluxDistribution.cxx
@@ -1,0 +1,353 @@
+#include "SIREN/distributions/primary/energy_direction/Tabulated2DFluxDistribution.h"
+#include <array>                                           // for array
+#include <tuple>                                           // for tie, opera...
+#include <vector>                                          // for vector
+#include <fstream>                                         // for basic_istream
+#include <functional>                                      // for function
+#include <math.h>                                        // for M_PI, cos, sin
+
+#include "SIREN/dataclasses/InteractionRecord.h"  // for Interactio...
+#include "SIREN/distributions/Distributions.h"    // for InjectionD...
+#include "SIREN/utilities/Integration.h"          // for rombergInt...
+#include "SIREN/utilities/Interpolator.h"         // for TableData1D
+#include "SIREN/utilities/Random.h"               // for SIREN_random
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace detector { class DetectorModel; } }
+
+namespace siren {
+namespace distributions {
+namespace {
+    bool fexists(const std::string filename)
+    {
+            std::ifstream ifile(filename.c_str());
+            return (bool)ifile;
+    }
+}
+
+//---------------
+// class Tabulated2DFluxDistribution : PrimaryEnergyDirectionDistribution
+//---------------
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution() {}
+
+void Tabulated2DFluxDistribution::ComputeIntegral() {
+    // Check if the table is log in x (energy). If so, compute the integral in log space
+    // assuing we are never log in y (zenith)
+    double eMin = energyMin;
+    double eMax = energyMax;
+    std::function<double(double, double)> integrand = [&] (double x, double y) -> double {
+       return unnormed_pdf(x,y);
+    };
+    if (fluxTable.IsLogX()) {
+        eMin = log10(energyMin);
+        eMax = log10(energyMax);
+        integrand =  [&] (double x, double y) -> double {
+            return log(10)*pow(10,x)*unnormed_pdf(pow(10,x),y);
+        };
+    }
+
+    integral = siren::utilities::simpsonIntegrate2D(integrand, eMin, eMax, zenithMin, zenithMax);
+}
+
+void Tabulated2DFluxDistribution::LoadFluxTable() {
+    if(fexists(fluxTableFilename)) {
+        std::ifstream in(fluxTableFilename.c_str());
+        std::string buf;
+        std::string::size_type pos;
+        siren::utilities::TableData2D<double> table_data;
+
+        while(std::getline(in, buf)) {
+            // Ignore comments and blank lines
+            if((pos = buf.find('#')) != std::string::npos)
+                buf.erase(pos);
+            const char* whitespace=" \n\r\t\v";
+            if((pos=buf.find_first_not_of(whitespace))!=0)
+                buf.erase(0,pos);
+            if(!buf.empty() && (pos=buf.find_last_not_of(whitespace))!=buf.size()-1)
+                buf.erase(pos+1);
+            if(buf.empty())
+                continue;
+
+            std::stringstream ss(buf);
+            double x, y, f;
+            ss >> x >> y >> f;
+            table_data.x.push_back(x);
+            table_data.y.push_back(y);
+            table_data.f.push_back(f);
+
+            energy_nodes.push_back(x);
+            zenith_nodes.push_back(y);
+        }
+        // If no physical are manually set, use first/last entry of table
+        if(not energy_bounds_set) {
+            energyMin = table_data.x[0];
+            energyMax = table_data.x[table_data.x.size()-1];
+        }
+        if(not zenith_bounds_set) {
+            zenithMin = table_data.y[0];
+            zenithMax = table_data.y[table_data.y.size()-1];
+        }
+        fluxTable = siren::utilities::Interpolator2D<double>(table_data);
+    } else {
+        throw std::runtime_error("Failed to open flux table file!");
+    }
+}
+
+void Tabulated2DFluxDistribution::LoadFluxTable(std::vector<double> & energies, std::vector<double> & zeniths, std::vector<double> & flux) {
+
+    assert(energies.size()==flux.size());
+    assert(zeniths.size()==flux.size());
+
+    siren::utilities::TableData2D<double> table_data;
+
+    table_data.x = energies;
+    table_data.y = zeniths;
+    table_data.f = flux;
+    energy_nodes = energies;
+    zenith_nodes = zeniths;
+
+    // If no physical are manually set, use first/last entry of table
+    if(not energy_bounds_set) {
+        energyMin = table_data.x[0];
+        energyMax = table_data.x[table_data.x.size()-1];
+    }
+    if(not zenith_bounds_set) {
+        zenithMin = table_data.y[0];
+        zenithMax = table_data.y[table_data.y.size()-1];
+    }
+    fluxTable = siren::utilities::Interpolator2D<double>(table_data);
+}
+
+double Tabulated2DFluxDistribution::unnormed_pdf(double energy, double zenith) const {
+    return fluxTable(energy, zenith);
+}
+
+double Tabulated2DFluxDistribution::SampleUnnormedPDF(double energy, double zenith) const {
+    return unnormed_pdf(energy, zenith);
+}
+
+double Tabulated2DFluxDistribution::GetIntegral() const {
+    return integral;
+}
+
+std::vector<double> Tabulated2DFluxDistribution::GetEnergyNodes() const {
+    return energy_nodes;
+}
+
+std::vector<double> Tabulated2DFluxDistribution::GetZenithNodes() const {
+    return zenith_nodes;
+}
+
+double Tabulated2DFluxDistribution::pdf(double energy, double zenith) const {
+    return unnormed_pdf(energy,zenith) / integral;
+}
+
+double Tabulated2DFluxDistribution::SamplePDF(double energy, double zenith) const {
+    return pdf(energy, zenith);
+}
+
+void Tabulated2DFluxDistribution::SetEnergyBounds(double eMin, double eMax) {
+    energyMin = eMin;
+    energyMax = eMax;
+    energy_bounds_set = true;
+    ComputeIntegral();
+}
+
+void Tabulated2DFluxDistribution::SetZenithBounds(double zMin, double zMax) {
+    zenithMin = zMin;
+    zenithMax = zMax;
+    zenith_bounds_set = true;
+    ComputeIntegral();
+}
+
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution(std::string fluxTableFilename, bool has_physical_normalization)
+    : energy_bounds_set(false)
+    , zenith_bounds_set(false)
+    , fluxTableFilename(fluxTableFilename)
+{
+    LoadFluxTable();
+    ComputeIntegral();
+    if(has_physical_normalization)
+        SetNormalization(integral);
+}
+
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution(double energyMin, double energyMax, std::string fluxTableFilename, bool has_physical_normalization)
+    : energyMin(energyMin)
+    , energyMax(energyMax)
+    , energy_bounds_set(true)
+    , zenith_bounds_set(false)
+    , fluxTableFilename(fluxTableFilename)
+{
+    LoadFluxTable();
+    ComputeIntegral();
+    if(has_physical_normalization)
+        SetNormalization(integral);
+}
+
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution(double energyMin, double energyMax, double zenithMin, double zenithMax, std::string fluxTableFilename, bool has_physical_normalization)
+    : energyMin(energyMin)
+    , energyMax(energyMax)
+    , zenithMin(zenithMin)
+    , zenithMax(zenithMax)
+    , energy_bounds_set(true)
+    , zenith_bounds_set(true)
+    , fluxTableFilename(fluxTableFilename)
+{
+    LoadFluxTable();
+    ComputeIntegral();
+    if(has_physical_normalization)
+        SetNormalization(integral);
+}
+
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution(std::vector<double> energies, std::vector<double> zeniths, std::vector<double> flux, bool has_physical_normalization)
+    : energy_bounds_set(false)
+    , zenith_bounds_set(false)
+{
+    LoadFluxTable(energies,zeniths,flux);
+    ComputeIntegral();
+    if(has_physical_normalization)
+        SetNormalization(integral);
+}
+
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution(double energyMin, double energyMax, std::vector<double> energies, std::vector<double> zeniths, std::vector<double> flux, bool has_physical_normalization)
+    : energyMin(energyMin)
+    , energyMax(energyMax)
+    , energy_bounds_set(true)
+    , zenith_bounds_set(false)
+{
+    LoadFluxTable(energies,zeniths,flux);
+    ComputeIntegral();
+    if(has_physical_normalization)
+        SetNormalization(integral);
+}
+
+Tabulated2DFluxDistribution::Tabulated2DFluxDistribution(double energyMin, double energyMax, double zenithMin, double zenithMax, std::vector<double> energies, std::vector<double> zeniths, std::vector<double> flux, bool has_physical_normalization)
+    : energyMin(energyMin)
+    , energyMax(energyMax)
+    , zenithMin(zenithMin)
+    , zenithMax(zenithMax)
+    , energy_bounds_set(true)
+    , zenith_bounds_set(true)
+{
+    LoadFluxTable(energies,zeniths,flux);
+    ComputeIntegral();
+    if(has_physical_normalization)
+        SetNormalization(integral);
+}
+
+std::pair<double, double> Tabulated2DFluxDistribution::SampleTablePoint(std::shared_ptr<siren::utilities::SIREN_random> rand) const {
+    // sample uniformly in linear or log space depending on the table
+    double u1 = rand->Uniform();
+    double u2 = rand->Uniform();
+    double energy, zenith;
+    if (fluxTable.IsLogX()) {
+        double logEnergyMin = log10(energyMin);
+        double logEnergyMax = log10(energyMax);
+        energy = pow(10,logEnergyMin + u1 * (logEnergyMax - logEnergyMin));
+    }
+    else {
+        energy = energyMin + u1 * (energyMax - energyMin);
+    }
+    if (fluxTable.IsLogY()) {
+        double logZenithMin = log10(zenithMin);
+        double logZenithMax = log10(zenithMax);
+        zenith = pow(10,logZenithMin + u2 * (logZenithMax - logZenithMin));
+    }
+    else {
+        zenith = zenithMin + u2 * (zenithMax - zenithMin);
+    }
+    return std::make_pair(energy,zenith);
+}
+
+std::pair<double,siren::math::Vector3D> Tabulated2DFluxDistribution::SampleEnergyAndDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+
+    // Use metropolis hastings
+    double energy, zenith, test_density, odds;
+    bool accept;
+    std::pair<double,double> energy_zenith;
+
+    // Metropolis-Hastings algorithm
+
+    // ensure burn in has completed
+    while (MH_sampled_points <= burnin) {
+        energy_zenith = SampleTablePoint(rand);
+        energy = energy_zenith.first;
+        zenith = energy_zenith.second;
+        test_density = pdf(energy, zenith);
+        odds = test_density / MH_density;
+        accept = (MH_density == 0 || (odds > 1.) || rand->Uniform() < odds);
+        if(accept) {
+            MH_density = test_density;
+            MH_sampled_points++;
+        }
+    }
+    // now sample one more point
+    accept = false;
+    while(!accept) {
+        energy_zenith = SampleTablePoint(rand);
+        energy = energy_zenith.first;
+        zenith = energy_zenith.second;
+        test_density = pdf(energy, zenith);
+        odds = test_density / MH_density;
+        accept = (MH_density == 0 || (odds > 1.) || rand->Uniform() < odds);
+        if(accept) {
+            MH_density = test_density;
+            MH_sampled_points++;
+        }
+    }
+    // Now compute the direction given the sampled zenith
+    double nr = sqrt(1.0 - zenith*zenith);
+    double phi = rand->Uniform(-M_PI, M_PI);
+    double nx = nr * cos(phi);
+    double ny = nr * sin(phi);
+    siren::math::Vector3D dir(nx, ny, zenith);
+    dir.normalize();
+    return std::make_pair(energy,dir);
+
+}
+
+
+double Tabulated2DFluxDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    double const & energy = record.primary_momentum[0];
+    double zenith = record.primary_momentum[3] / sqrt(pow(record.primary_momentum[1], 2) + pow(record.primary_momentum[2],2) + pow(record.primary_momentum[3],2));
+    if(energy < energyMin or energy > energyMax)
+        return 0.0;
+    // TODO: check zenith
+    else if(zenith < zenithMin or zenith > zenithMax)
+        return 0.0;
+    else
+        return pdf(energy,zenith);
+}
+
+std::string Tabulated2DFluxDistribution::Name() const {
+    return "Tabulated2DFluxDistribution";
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> Tabulated2DFluxDistribution::clone() const {
+    return std::shared_ptr<PrimaryInjectionDistribution>(new Tabulated2DFluxDistribution(*this));
+}
+
+bool Tabulated2DFluxDistribution::equal(WeightableDistribution const & other) const {
+    const Tabulated2DFluxDistribution* x = dynamic_cast<const Tabulated2DFluxDistribution*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return
+            std::tie(energyMin, energyMax, zenithMin, zenithMax, fluxTable)
+            ==
+            std::tie(x->energyMin, x->energyMax, x->zenithMin, x->zenithMax, x->fluxTable);
+}
+
+bool Tabulated2DFluxDistribution::less(WeightableDistribution const & other) const {
+    const Tabulated2DFluxDistribution* x = dynamic_cast<const Tabulated2DFluxDistribution*>(&other);
+    return
+        std::tie(energyMin, energyMax, zenithMin, zenithMax, fluxTable)
+        <
+        std::tie(x->energyMin, x->energyMax, x->zenithMin, x->zenithMax, x->fluxTable);
+}
+
+} // namespace distributions
+
+} // namespace siren
+

--- a/projects/distributions/private/pybindings/distributions.cxx
+++ b/projects/distributions/private/pybindings/distributions.cxx
@@ -8,10 +8,13 @@
 #include "../../public/SIREN/distributions/primary/direction/Cone.h"
 #include "../../public/SIREN/distributions/primary/direction/FixedDirection.h"
 #include "../../public/SIREN/distributions/primary/direction/IsotropicDirection.h"
+#include "../../public/SIREN/distributions/primary/energy/PrimaryEnergyDistribution.h"
 #include "../../public/SIREN/distributions/primary/energy/Monoenergetic.h"
 #include "../../public/SIREN/distributions/primary/energy/PowerLaw.h"
 #include "../../public/SIREN/distributions/primary/energy/PiDARNuEDistribution.h"
 #include "../../public/SIREN/distributions/primary/energy/TabulatedFluxDistribution.h"
+#include "../../public/SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h"
+#include "../../public/SIREN/distributions/primary/energy_direction/Tabulated2DFluxDistribution.h"
 #include "../../public/SIREN/distributions/primary/helicity/PrimaryNeutrinoHelicityDistribution.h"
 #include "../../public/SIREN/distributions/primary/mass/PrimaryMass.h"
 #include "../../public/SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
@@ -116,10 +119,10 @@ PYBIND11_MODULE(distributions,m) {
     .def("Name",&PowerLaw::Name);
 
   class_<TabulatedFluxDistribution, std::shared_ptr<TabulatedFluxDistribution>, PrimaryEnergyDistribution>(m, "TabulatedFluxDistribution")
-    .def(init<std::string, bool>())
-    .def(init<double, double, std::string, bool>())
-    .def(init<std::vector<double>, std::vector<double>, bool>())
-    .def(init<double, double, std::vector<double>, std::vector<double>, bool>())
+    .def(init<std::string, bool, bool>())
+    .def(init<double, double, std::string, bool, bool>())
+    .def(init<std::vector<double>, std::vector<double>, bool, bool>())
+    .def(init<double, double, std::vector<double>, std::vector<double>, bool, bool>())
     .def("InverseCDF",&TabulatedFluxDistribution::InverseCDF)
     .def("SampleEnergy",&TabulatedFluxDistribution::SampleEnergy)
     .def("GenerationProbability",&TabulatedFluxDistribution::GenerationProbability)
@@ -141,6 +144,29 @@ PYBIND11_MODULE(distributions,m) {
     .def("SampleEnergy",&PiDARNuEDistribution::SampleEnergy)
     .def("GenerationProbability",&PiDARNuEDistribution::GenerationProbability)
     .def("Name",&PiDARNuEDistribution::Name);
+
+  // Energy Direction distributions
+
+  class_<PrimaryEnergyDirectionDistribution, std::shared_ptr<PrimaryEnergyDirectionDistribution>, PrimaryInjectionDistribution, PhysicallyNormalizedDistribution>(m, "PrimaryEnergyDirectionDistribution")
+    .def("Sample",&PrimaryEnergyDirectionDistribution::Sample);
+
+  class_<Tabulated2DFluxDistribution, std::shared_ptr<Tabulated2DFluxDistribution>, PrimaryEnergyDirectionDistribution>(m, "Tabulated2DFluxDistribution")
+    .def(init<std::string, bool>())
+    .def(init<double, double, std::string, bool>())
+    .def(init<double, double, double, double, std::string, bool>())
+    .def(init<std::vector<double>, std::vector<double>, std::vector<double>, bool>())
+    .def(init<double, double, std::vector<double>, std::vector<double>, std::vector<double>, bool>())
+    .def(init<double, double, double, double, std::vector<double>, std::vector<double>, std::vector<double>, bool>())
+    .def("SampleEnergyAndDirection",&Tabulated2DFluxDistribution::SampleEnergyAndDirection)
+    .def("GenerationProbability",&Tabulated2DFluxDistribution::GenerationProbability)
+    .def("SetEnergyBounds",&Tabulated2DFluxDistribution::SetEnergyBounds)
+    .def("SetZenithBounds",&Tabulated2DFluxDistribution::SetZenithBounds)
+    .def("Name",&Tabulated2DFluxDistribution::Name)
+    .def("GetIntegral",&Tabulated2DFluxDistribution::GetIntegral)
+    .def("SamplePDF",&Tabulated2DFluxDistribution::SamplePDF)
+    .def("SampleUnnormedPDF",&Tabulated2DFluxDistribution::SampleUnnormedPDF)
+    .def("GetEnergyNodes",&Tabulated2DFluxDistribution::GetEnergyNodes)
+    .def("GetZenithNodes",&Tabulated2DFluxDistribution::GetZenithNodes);
 
   // Helicity distributions
 
@@ -201,7 +227,7 @@ PYBIND11_MODULE(distributions,m) {
     .def("GetTauAlpha",&LeptonDepthFunction::GetTauAlpha)
     .def("GetTauBeta",&LeptonDepthFunction::GetTauBeta)
     .def("GetScale",&LeptonDepthFunction::GetScale)
-    .def("GetMaxDepth",&LeptonDepthFunction::GetMaxDepth) 
+    .def("GetMaxDepth",&LeptonDepthFunction::GetMaxDepth)
     .def("GetLeptonDepthFunctionReturnValue",&LeptonDepthFunction::GetLeptonDepthFunctionReturnValue);
     //.def((siren::dataclasses::InteractionSignature const &, double));
 

--- a/projects/distributions/public/SIREN/distributions/primary/energy/TabulatedFluxDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/energy/TabulatedFluxDistribution.h
@@ -28,11 +28,11 @@ namespace siren {
 namespace distributions {
 
 class TabulatedFluxDistribution : virtual public PrimaryEnergyDistribution {
-// Assumes table is in units of nu cm^-2 GeV^-1 Livetime^-1
+// Assumes table is in units of nu m^-2 GeV^-1 Livetime^-1
 friend cereal::access;
 protected:
     TabulatedFluxDistribution();
-    void ComputeIntegral();
+    void ComputeIntegral(bool romberg=true);
 private:
     double energyMin;
     double energyMax;
@@ -43,6 +43,7 @@ private:
     double integral;
     std::vector<double> cdf;
     std::vector<double> energy_nodes;
+    std::vector<double> pdf_nodes;
     std::vector<double> cdf_energy_nodes;
     const size_t burnin = 40; //original burnin parameter for MH sampling
     double unnormed_pdf(double energy) const;
@@ -50,9 +51,9 @@ private:
     void LoadFluxTable();
     void LoadFluxTable(std::vector<double> & energies, std::vector<double> & flux);
 public:
-    double SamplePDF(double energy) const; 
-    double SampleUnnormedPDF(double energy) const; 
-    double GetIntegral() const; 
+    double SamplePDF(double energy) const;
+    double SampleUnnormedPDF(double energy) const;
+    double GetIntegral() const;
     void ComputeCDF();
     std::vector<double> GetCDF() const;
     std::vector<double> GetEnergyNodes() const;
@@ -61,10 +62,10 @@ public:
     double SampleEnergy(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
     virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
     void SetEnergyBounds(double energyMin, double energyMax);
-    TabulatedFluxDistribution(std::string fluxTableFilename, bool has_physical_normalization=false);
-    TabulatedFluxDistribution(double energyMin, double energyMax, std::string fluxTableFilename, bool has_physical_normalization=false);
-    TabulatedFluxDistribution(std::vector<double> energies, std::vector<double> flux, bool has_physical_normalization=false);
-    TabulatedFluxDistribution(double energyMin, double energyMax, std::vector<double> energies, std::vector<double> flux, bool has_physical_normalization=false);
+    TabulatedFluxDistribution(std::string fluxTableFilename, bool has_physical_normalization=false, bool romberg=true);
+    TabulatedFluxDistribution(double energyMin, double energyMax, std::string fluxTableFilename, bool has_physical_normalization=false, bool romberg=true);
+    TabulatedFluxDistribution(std::vector<double> energies, std::vector<double> flux, bool has_physical_normalization=false, bool romberg=true);
+    TabulatedFluxDistribution(double energyMin, double energyMax, std::vector<double> energies, std::vector<double> flux, bool has_physical_normalization=false, bool romberg=true);
     std::string Name() const override;
     virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
     template<typename Archive>

--- a/projects/distributions/public/SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h
@@ -1,0 +1,71 @@
+#pragma once
+#ifndef SIREN_PrimaryEnergyDirectionDistribution_H
+#define SIREN_PrimaryEnergyDirectionDistribution_H
+
+#include <memory>                                        // for shared_ptr
+#include <string>                                        // for string
+#include <vector>                                        // for vector
+#include <cstdint>                                       // for uint32_t
+#include <stdexcept>                                     // for runtime_error
+
+#include <cereal/access.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/Distributions.h"  // for WeightableDi...
+#include "SIREN/math/Vector3D.h"  // for Vector3D
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+namespace cereal { class access; }
+
+namespace siren {
+namespace distributions {
+
+class PrimaryEnergyDirectionDistribution : virtual public PrimaryInjectionDistribution, virtual public PhysicallyNormalizedDistribution {
+friend cereal::access;
+public:
+    virtual ~PrimaryEnergyDirectionDistribution() {};
+private:
+    virtual std::pair<double,siren::math::Vector3D> SampleEnergyAndDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const = 0;
+public:
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override = 0;
+    virtual std::vector<std::string> DensityVariables() const override;
+    virtual std::string Name() const override = 0;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override = 0;
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(cereal::virtual_base_class<PrimaryInjectionDistribution>(this));
+            archive(cereal::virtual_base_class<PhysicallyNormalizedDistribution>(this));
+        } else {
+            throw std::runtime_error("PrimaryEnergyDirectionDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    void load(Archive & archive, std::uint32_t const version) {
+        if(version == 0) {
+            archive(cereal::virtual_base_class<PrimaryInjectionDistribution>(this));
+            archive(cereal::virtual_base_class<PhysicallyNormalizedDistribution>(this));
+        } else {
+            throw std::runtime_error("PrimaryEnergyDirectionDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override = 0;
+    virtual bool less(WeightableDistribution const & distribution) const override = 0;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::PrimaryEnergyDirectionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::PrimaryEnergyDirectionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryInjectionDistribution, siren::distributions::PrimaryEnergyDirectionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PhysicallyNormalizedDistribution, siren::distributions::PrimaryEnergyDirectionDistribution);
+
+#endif // SIREN_PrimaryEnergyDirectionDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/energy_direction/Tabulated2DFluxDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/energy_direction/Tabulated2DFluxDistribution.h
@@ -1,0 +1,118 @@
+#pragma once
+#ifndef SIREN_Tabulated2DFluxDistribution_H
+#define SIREN_Tabulated2DFluxDistribution_H
+
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <stddef.h>
+#include <stdexcept>
+#include <vector>
+
+#include <cereal/access.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h"
+#include "SIREN/utilities/Interpolator.h"
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace distributions { class PrimaryInjectionDistribution; } }
+namespace siren { namespace distributions { class WeightableDistribution; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+class Tabulated2DFluxDistribution : virtual public PrimaryEnergyDirectionDistribution {
+// Assumes table is in units of nu cm^-2 GeV^-1 Livetime^-1 sr^-1
+friend cereal::access;
+protected:
+    Tabulated2DFluxDistribution();
+    void ComputeIntegral();
+    std::pair<double, double> SampleTablePoint(std::shared_ptr<siren::utilities::SIREN_random> rand) const;
+private:
+    double energyMin;
+    double energyMax;
+    double zenithMin;
+    double zenithMax;
+    bool energy_bounds_set;
+    bool zenith_bounds_set;
+    std::string fluxTableFilename;
+    siren::utilities::Interpolator2D<double> fluxTable;
+    double integral;
+    std::vector<double> energy_nodes;
+    std::vector<double> zenith_nodes;
+    // metropolis hastings variables
+    const size_t burnin = 40; // burnin parameter for MH sampling
+    mutable size_t MH_sampled_points = 0; // to track the number of samples
+    mutable double MH_density;
+
+    double unnormed_pdf(double energy, double zenith) const;
+    double pdf(double energy, double zenith) const;
+    void LoadFluxTable();
+    void LoadFluxTable(std::vector<double> & energies, std::vector<double> & zeniths, std::vector<double> & flux);
+public:
+    double SamplePDF(double energy, double zenith) const;
+    double SampleUnnormedPDF(double energy, double zenith) const;
+    double GetIntegral() const;
+    std::vector<double> GetEnergyNodes() const;
+    std::vector<double> GetZenithNodes() const;
+    std::pair<double,siren::math::Vector3D> SampleEnergyAndDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    void SetEnergyBounds(double energyMin, double energyMax);
+    void SetZenithBounds(double zenithMin, double zenithMax);
+    Tabulated2DFluxDistribution(std::string fluxTableFilename, bool has_physical_normalization=false);
+    Tabulated2DFluxDistribution(double energyMin, double energyMax, std::string fluxTableFilename, bool has_physical_normalization=false);
+    Tabulated2DFluxDistribution(double energyMin, double energyMax, double zenithMin, double zenithMax, std::string fluxTableFilename, bool has_physical_normalization=false);
+    Tabulated2DFluxDistribution(std::vector<double> energies, std::vector<double> zeniths, std::vector<double> flux, bool has_physical_normalization=false);
+    Tabulated2DFluxDistribution(double energyMin, double energyMax, std::vector<double> energies, std::vector<double> zeniths, std::vector<double> flux, bool has_physical_normalization=false);
+    Tabulated2DFluxDistribution(double energyMin, double energyMax, double zenithMin, double zenithMax, std::vector<double> energies, std::vector<double> zeniths, std::vector<double> flux, bool has_physical_normalization=false);
+    std::string Name() const override;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(::cereal::make_nvp("EnergyMin", energyMin));
+            archive(::cereal::make_nvp("EnergyMax", energyMax));
+            archive(::cereal::make_nvp("ZenithMin", zenithMin));
+            archive(::cereal::make_nvp("ZenithMax", zenithMax));
+            archive(::cereal::make_nvp("FluxTable", fluxTable));
+            archive(cereal::virtual_base_class<PrimaryEnergyDirectionDistribution>(this));
+        } else {
+            throw std::runtime_error("Tabulated2DFluxDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    void load(Archive & archive, std::uint32_t const version) {
+        if(version == 0) {
+            archive(::cereal::make_nvp("EnergyMin", energyMin));
+            archive(::cereal::make_nvp("EnergyMax", energyMax));
+            archive(::cereal::make_nvp("ZenithMin", zenithMin));
+            archive(::cereal::make_nvp("ZenithMax", zenithMax));
+            archive(::cereal::make_nvp("FluxTable", fluxTable));
+            archive(cereal::virtual_base_class<PrimaryEnergyDirectionDistribution>(this));
+            energy_bounds_set = true;
+            zenith_bounds_set = true;
+            ComputeIntegral();
+        } else {
+            throw std::runtime_error("Tabulated2DFluxDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override;
+    virtual bool less(WeightableDistribution const & distribution) const override;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::Tabulated2DFluxDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::Tabulated2DFluxDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryEnergyDirectionDistribution, siren::distributions::Tabulated2DFluxDistribution);
+
+#endif // SIREN_Tabulated2DFluxDistribution_H
+

--- a/projects/utilities/public/SIREN/utilities/Integration.h
+++ b/projects/utilities/public/SIREN/utilities/Integration.h
@@ -150,6 +150,82 @@ double rombergIntegrate(const FuncType& func, double a, double b, double tol=1e-
   throw(std::runtime_error("Integral failed to converge"));
 }
 
+/**
+* @brief Performs a 2D simpson integration of a function
+*
+*
+* @param func the function to integrate
+* @param a the lower bound of integration for the first dimension
+* @param b the upper bound of integration for the first dimension
+* @param c the lower bound of integration for the second dimension
+* @param d the upper bound of integration for the second dimension
+* @param tol the (absolute) tolerance on the error of the integral per dimension
+*/
+template<typename FuncType>
+double simpsonIntegrate2D(const FuncType& func, double a1, double b1, double a2, double b2,
+                          double tol=1e-3, const unsigned int N1 = 10, const unsigned int N2=10, const unsigned int maxIter=15){
+
+  if(tol<0)
+     throw(std::runtime_error("Integration tolerance must be positive"));
+
+
+  double prev_estimate = 0;
+  double estimate;
+  unsigned int N1i,N2i;
+  double h1i,h2i,c1,c2;
+
+  // std::cout << a1 << " " << b1 << " " << a2 << " " << b2 << std::endl;
+
+  for(unsigned int i=0; i<maxIter; i++){
+     N1i = pow(2,i)*N1;
+     N2i = pow(2,i)*N2;
+     h1i = (b1-a1)/N1i;
+     h2i = (b2-a2)/N2i;
+     estimate = 0;
+     for(unsigned int j = 0; j < N1i+1; j++) {
+       if (j==0 || j==N1i) c1 = 1;
+       else if (j%2==0) c1 = 2;
+       else if (j%2==1) c1 = 4;
+       double x = a1 + j*h1i;
+       for(unsigned int k = 0; k < N2i+1; k++) {
+         if (k==0 || k==N2i) c2 = 1;
+         else if (k%2==0) c2 = 2;
+         else if (k%2==1) c2 = 4;
+         double y = a2 + k*h2i;
+         estimate += c1*c2*func(x, y);
+       }
+     }
+     estimate *= h1i*h2i/9;
+     if(std::abs((estimate-prev_estimate)/estimate) < tol) {
+      return estimate;
+     }
+     prev_estimate = estimate;
+  }
+  throw(std::runtime_error("Simpson 2D integral failed to converge"));
+}
+
+/**
+* @brief Performs a simple trapezoid integration given a set of points.
+*
+* This routine is simple and not suitable for complicated functions, and relies on fixed points
+* provided by the user in contrast to the TrapezoidalIntegrator class.
+*
+* @param x the x points of the integration
+* @param y the y points of the integration
+*/
+inline double trapezoidIntegrate(std::vector<double>& x, std::vector<double>& y){
+   if(x.size()!=y.size())
+       throw(std::runtime_error("Integration x and y vectors must be the same size"));
+
+   double integral = 0;
+   for(unsigned int i=1; i<x.size(); i++){
+      double dx = x[i]-x[i-1];
+      double avg = 0.5*(y[i]+y[i-1]);
+      integral += dx*avg;
+   }
+   return integral;
+}
+
 }
 }
 

--- a/projects/utilities/public/SIREN/utilities/Interpolator.h
+++ b/projects/utilities/public/SIREN/utilities/Interpolator.h
@@ -689,6 +689,10 @@ public:
         return indexer_x.Max();
     }
 
+    bool IsLogX() const {
+        return indexer_x.IsLog();
+    }
+
     T MinY() const {
         return indexer_y.Min();
     }
@@ -699,6 +703,10 @@ public:
 
     T MaxY() const {
         return indexer_y.Max();
+    }
+
+    bool IsLogY() const {
+        return indexer_y.IsLog();
     }
 };
 


### PR DESCRIPTION
## Stack: PR 7 of 14

This PR is part of a 14-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/primary-external-distribution`
- **Head:** `feat/2d-flux-tables`

Merge order: `feat/primary-external-distribution` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - projects/distributions/private/primary/energy/TabulatedFluxDistribution.cxx
  - projects/distributions/private/primary/energy_direction/PrimaryEnergyDirectionDistribution.cxx
  - projects/distributions/private/primary/energy_direction/Tabulated2DFluxDistribution.cxx
  - projects/distributions/public/SIREN/distributions/primary/energy/TabulatedFluxDistribution.h
  - projects/distributions/public/SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h
  - projects/distributions/public/SIREN/distributions/primary/energy_direction/Tabulated2DFluxDistribution.h
  - projects/utilities/public/SIREN/utilities/Integration.h
  - projects/utilities/public/SIREN/utilities/Interpolator.h
  - projects/distributions/private/pybindings/distributions.cxx
  - projects/distributions/CMakeLists.txt

Source commits on dev/HNL_DIS_clean that contributed:
  21451da3 (Nicholas Kamp): first attempt at external list primary injector
  455b0730 (Nicholas Kamp): introduce primary bounded and physical vertex distributions to sample vertex in the case that the inital position is already provided from the external distribution
  521695f3 (Nicholas Kamp): fix issues with 2D tabular integral calculation, sampling errors with very short decay lengths, DarkNews errors, and kinematic erros in Dipole portal HNL DIS
  73bc1195 (Nicholas Kamp): sphere build fixes
  82b4fdc8 (Nicholas Kamp): add ability to trapezoid integrate tabulated 1D fluxes
  9098b42e (Nicholas Kamp): fix weighting issue in PrimaryExternalDist
  9968ff78 (Nicholas Kamp): Start implementing 2D flux table for atmospheric fluxes
  9dae77ab (Nicholas Kamp): spherical volume position distribution
  a79d4408 (Nicholas Kamp): getting HNLs to work for SINE and UNDINE
  a9aebd36 (Nicholas Kamp): fix log integration
  c7cff6c5 (Nicholas Kamp): fixing build and runtime errors on 2D flux distribution


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
