### PR TITLE
DetectorModel: query sectors by name, fiducial volume support

### DIFF
--- a/projects/detector/private/Path.cxx
+++ b/projects/detector/private/Path.cxx
@@ -832,6 +832,8 @@ bool Path::IsWithinBounds(DetectorPosition point) {
     if(set_det_points_) {
         double d0 = siren::math::scalar_product(direction_det_, first_point_det_ - point);
         double d1 = siren::math::scalar_product(direction_det_, last_point_det_ - point);
+        // avoid rounding errors for very small decay lengths; assume mm precision is fine
+        if((first_point_det_.get() - point).magnitude() < 1e-3) d0 = 0;
         return d0 <= 0 and d1 >= 0;
     } else if(set_points_ and set_detector_model_) {
         return IsWithinBounds(detector_model_->ToGeo(point));

--- a/projects/detector/private/pybindings/DetectorModel.h
+++ b/projects/detector/private/pybindings/DetectorModel.h
@@ -180,7 +180,14 @@ void register_DetectorModel(pybind11::module_ & m) {
         .def_property("DetectorOrigin", &DetectorModel::GetDetectorOrigin, &DetectorModel::SetDetectorOrigin)
         .def_property("DetectorRotation", &DetectorModel::GetDetectorRotation, &DetectorModel::SetDetectorRotation)
         .def("AddSector", &DetectorModel::AddSector)
-        .def("GetSector", &DetectorModel::GetSector)
+        .def("GetSector", (
+                    DetectorSector (DetectorModel::*)(
+                        int) const
+                    )(&DetectorModel::GetSector))
+        .def("GetSector", (
+                    DetectorSector (DetectorModel::*)(
+                        std::string) const
+                    )(&DetectorModel::GetSector))
         .def("ClearSectors", &DetectorModel::ClearSectors)
         .def("GetIntersections", (
                     siren::geometry::Geometry::IntersectionList (DetectorModel::*)(

--- a/projects/detector/public/SIREN/detector/DetectorModel.h
+++ b/projects/detector/public/SIREN/detector/DetectorModel.h
@@ -260,6 +260,7 @@ public:
 
     void AddSector(DetectorSector sector);
     DetectorSector GetSector(int level) const;
+    DetectorSector GetSector(std::string name) const;
 
     void ClearSectors();
 


### PR DESCRIPTION
## Stack: PR 8 of 14

This PR is part of a 14-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/2d-flux-tables`
- **Head:** `feat/detector-sector-by-name`

Merge order: `feat/2d-flux-tables` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - projects/detector/private/DetectorModel.cxx
  - projects/detector/private/Path.cxx
  - projects/detector/private/pybindings/DetectorModel.h
  - projects/detector/public/SIREN/detector/DetectorModel.h

Source commits on dev/HNL_DIS_clean that contributed:
  521695f3 (Nicholas Kamp): fix issues with 2D tabular integral calculation, sampling errors with very short decay lengths, DarkNews errors, and kinematic erros in Dipole portal HNL DIS
  c4b1ec0d (Nicholas Kamp): add fiducial volume to LG and enable querying of detector sectors by name
  f6f8b46e (Nicholas Kamp): get the decay sampling working


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
