### PR TITLE
Controller output features and integration fixes

### DIFF
--- a/cmake/Packages/CFITSIO.cmake
+++ b/cmake/Packages/CFITSIO.cmake
@@ -28,6 +28,10 @@ if (NOT CFITSIO_FOUND)
     list(PREPEND CFITSIO_INCLUDE_SEARCH_PATH_LIST
         $ENV{CFITSIOROOT}/include
     )
+    # Also search CMAKE_PREFIX_PATH
+    foreach(_prefix ${CMAKE_PREFIX_PATH})
+        list(APPEND CFITSIO_INCLUDE_SEARCH_PATH_LIST "${_prefix}/include")
+    endforeach()
 
     # Search user environment for headers, then default paths; extract version
     find_path(CFITSIO_INCLUDE_DIR fitsio.h
@@ -72,6 +76,12 @@ if (NOT CFITSIO_FOUND)
     else()
         set(CFITSIO_LIBRARY_SEARCH_PATH_LIST "")
     endif()
+
+    # Also search CMAKE_PREFIX_PATH
+    foreach(_prefix ${CMAKE_PREFIX_PATH})
+        list(APPEND CFITSIO_LIBRARY_SEARCH_PATH_LIST "${_prefix}/lib")
+        list(APPEND CFITSIO_LIBRARY_SEARCH_PATH_LIST "${_prefix}/lib64")
+    endforeach()
 
     # Search user environment for libraries, then default paths
     find_library(CFITSIO_LIBRARIES cfitsio

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -104,7 +104,7 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
     // Thus, the two will cancel out and we are left with only the unnormalized position probability
     //  w = p_physCommon / (\sum_i p_gen^i / p_physPosNonNorm^i)
 
-    
+
 
     double inv_weight = 0;
     for(unsigned int idx = 0; idx < injectors.size(); ++idx) {
@@ -133,6 +133,58 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
         inv_weight += generation_probability / physical_probability;
     }
     return 1./inv_weight;
+}
+
+std::vector<double> Weighter::GetInteractionProbabilities(siren::dataclasses::InteractionTree const & tree, int i_inj) const {
+    // Returns the vector of interaction physical probabilities for each process
+    // Since we are concerned only with the physical probability, we use the first injector since physical processes are the same for all injectors
+    // HOWEVER the injection bounds will change based on the injector
+    // so, we allow the user to specify which injector they are interseted in
+
+    std::vector<double> int_probs;
+    for(auto const & datum : tree.tree) {
+        std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
+        if(datum->depth() == 0) {
+            bounds = injectors[i_inj]->PrimaryInjectionBounds(datum->record);
+            int_probs.push_back(primary_process_weighters[i_inj]->InteractionProbability(bounds, datum->record));
+        }
+        else {
+            try {
+                bounds = injectors[i_inj]->SecondaryInjectionBounds(datum->record);
+                int_probs.push_back(secondary_process_weighter_maps[i_inj].at(datum->record.signature.primary_type)->InteractionProbability(bounds, datum->record));
+            } catch(const std::out_of_range& oor) {
+                std::cout << "Out of Range error: " << oor.what() << '\n';
+                return {};
+            }
+        }
+    }
+    return int_probs;
+}
+
+std::vector<double> Weighter::GetSurvivalProbabilities(siren::dataclasses::InteractionTree const & tree, int i_inj) const {
+    // This allows the user to get the survival probabilities for each interaction
+    // Useful in the case that secondary interactions are restricted to fiducial volumes
+
+    std::vector<double> survival_probs;
+    for(auto const & datum : tree.tree) {
+        std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
+        if(datum->depth() == 0) {
+            std::get<0>(bounds) = datum->record.primary_initial_position; // start location
+            std::get<1>(bounds) = std::get<0>(injectors[i_inj]->PrimaryInjectionBounds(datum->record)); // start of injection bounds
+            survival_probs.push_back(1 - primary_process_weighters[i_inj]->InteractionProbability(bounds, datum->record));
+        }
+        else {
+            try {
+                std::get<0>(bounds) = datum->record.primary_initial_position; // start location
+                std::get<1>(bounds) = std::get<0>(injectors[i_inj]->SecondaryInjectionBounds(datum->record)); // start of injection bounds
+                survival_probs.push_back(1 - secondary_process_weighter_maps[i_inj].at(datum->record.signature.primary_type)->InteractionProbability(bounds, datum->record));
+            } catch(const std::out_of_range& oor) {
+                std::cout << "Out of Range error: " << oor.what() << '\n';
+                return {};
+            }
+        }
+    }
+    return survival_probs;
 }
 
 void Weighter::SaveWeighter(std::string const & filename) const {

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -154,6 +154,8 @@ PYBIND11_MODULE(injection,m) {
     .def(init<std::vector<std::shared_ptr<Injector>>, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PhysicalProcess>>())
     .def(init<std::vector<std::shared_ptr<Injector>>, std::string>())
     .def("EventWeight",&Weighter::EventWeight)
+    .def("GetInteractionProbabilities",&Weighter::GetInteractionProbabilities, arg("tree"), arg("i_inj")=0)
+    .def("GetSurvivalProbabilities",&Weighter::GetSurvivalProbabilities, arg("tree"), arg("i_inj")=0)
     .def("SaveWeighter",&Weighter::SaveWeighter)
     .def("LoadWeighter",&Weighter::LoadWeighter)
     .def(pybind11::pickle(

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -50,6 +50,7 @@ private:
     double normalization;
 public:
     double InteractionProbability(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionRecord const & record) const;
+    double SurvivalProbability(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionRecord const & record) const;
     double NormalizedPositionProbability(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionRecord const & record) const;
     double PhysicalProbability(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionRecord const & record) const;
     double GenerationProbability(siren::dataclasses::InteractionTreeDatum const & datum) const;
@@ -83,6 +84,8 @@ private:
     void Initialize();
 public:
     double EventWeight(siren::dataclasses::InteractionTree const & tree) const;
+    std::vector<double> GetInteractionProbabilities(siren::dataclasses::InteractionTree const & tree, int i_inj = 0) const;
+    std::vector<double> GetSurvivalProbabilities(siren::dataclasses::InteractionTree const & tree, int i_inj = 0) const;
     Weighter(std::vector<std::shared_ptr<Injector>> injectors, std::shared_ptr<siren::detector::DetectorModel> detector_model, std::shared_ptr<siren::injection::PhysicalProcess> primary_physical_process, std::vector<std::shared_ptr<siren::injection::PhysicalProcess>> secondary_physical_processes);
     Weighter(std::vector<std::shared_ptr<Injector>> injectors, std::shared_ptr<siren::detector::DetectorModel> detector_model, std::shared_ptr<siren::injection::PhysicalProcess> primary_physical_process);
     Weighter(std::vector<std::shared_ptr<Injector>> injectors, std::string filename);

--- a/python/SIREN_Controller.py
+++ b/python/SIREN_Controller.py
@@ -39,12 +39,15 @@ def MergeInteractionCollections(primary_type,int_col_list):
 
 # Parent python class for handling event generation and weighting
 class SIREN_Controller:
-    def __init__(self, events_to_inject, experiment, seed=0):
+
+    def __init__(self, events_to_inject, experiment=None, detector_model_file=None, materials_model_file=None, seed=0):
         """
         SIREN controller class constructor.
         :param int event_to_inject: number of events to generate
-        :param str experiment: experiment name in string
-        :param int seed: Optional random number generator seed
+        :param str experiment: experiment name in string (default None)
+        :param str detector_model_file: path to the detector model file (default None)
+        :param str materials_model_file: path to the materials model file (default None)
+        :param int seed: Optional random number generator seed (default 0)
         """
 
         self.global_start = time.time()
@@ -61,13 +64,20 @@ class SIREN_Controller:
         # Empty list for our interaction trees
         self.events = []
 
-        # Find the density and materials files
-        materials_file = _util.get_material_model_path(experiment)
-        detector_model_file = _util.get_detector_model_path(experiment)
+
+        self.detector_model_file = detector_model_file
+        self.materials_model_file = materials_model_file
+        if experiment is not None:
+            # Find the density and materials files
+            self.materials_model_file = _util.get_material_model_path(experiment)
+            self.detector_model_file = _util.get_detector_model_path(experiment)
+        elif (self.detector_model_file is None or self.materials_model_file is None):
+            print("Must provide either an experiment name or both a detector model file and materials model file. Exiting")
+            exit(0)
 
         self.detector_model = _detector.DetectorModel()
-        self.detector_model.LoadMaterialModel(materials_file)
-        self.detector_model.LoadDetectorModel(detector_model_file)
+        self.detector_model.LoadMaterialModel(self.materials_model_file)
+        self.detector_model.LoadDetectorModel(self.detector_model_file)
 
         # Define the primary injection and physical process
         self.primary_injection_process = _injection.PrimaryInjectionProcess()
@@ -92,6 +102,7 @@ class SIREN_Controller:
         primary_injection_distributions,
         secondary_types=[],
         secondary_injection_distributions=[],
+        fid_vol_secondary=True,
     ):
         """
         SIREN injection process setter.
@@ -99,6 +110,7 @@ class SIREN_Controller:
         :param dict<str,InjectionDistribution> primary_injection_distributions: The dict of injection distributions for the primary process
         :param list<ParticleType> secondary_types: The secondary particles being generated
         :param list<dict<str,InjectionDistribution> secondary_injection_distributions: List of dict of injection distributions for each secondary process
+        :param bool fid_vol_secondary: whether to restrict secondary interactions to fiducial volume
         """
 
         # Define the primary injection process primary type
@@ -129,7 +141,7 @@ class SIREN_Controller:
                 secondary_injection_process.AddSecondaryInjectionDistribution(idist)
 
             # Add the position distribution
-            if self.fid_vol is not None:
+            if fid_vol_secondary and self.fid_vol is not None:
                 secondary_injection_process.AddSecondaryInjectionDistribution(
                     _distributions.SecondaryBoundedVertexDistribution(self.fid_vol)
                 )
@@ -192,6 +204,7 @@ class SIREN_Controller:
         secondary_types=[],
         secondary_injection_distributions=[],
         secondary_physical_distributions=[],
+        fid_vol_secondary=True,
     ):
         """
         SIREN process setter.
@@ -201,18 +214,21 @@ class SIREN_Controller:
         :param list<ParticleType> secondary_types: The secondary particles being generated
         :param list<dict<str,InjectionDistribution> secondary_injection_distributions: List of dict of injection distributions for each secondary process
         :param list<dict<str,PhysicalDistribution> secondary_physical_distributions: List of dict of physical distributions for each secondary process
+        :param bool fid_vol_secondary: whether to restrict secondary interactions to fiducial volume
         """
-        self.SetInjectionProcesses(primary_type,primary_injection_distributions,secondary_types,secondary_injection_distributions)
+        self.SetInjectionProcesses(primary_type,primary_injection_distributions,secondary_types,secondary_injection_distributions,fid_vol_secondary)
         self.SetPhysicalProcesses(primary_type,primary_physical_distributions,secondary_types,secondary_physical_distributions)
 
-    def InputDarkNewsModel(self, primary_type, table_dir, fill_tables_at_start=False, Emax=None, **kwargs):
+    def InputDarkNewsModel(self, primary_type, table_dir, upscattering=True, decay=True, fill_tables_at_start=False, Emax=None, fid_vol_secondary=True, **kwargs):
         """
         Sets up the relevant processes and cross section/decay objects related to a provided DarkNews model dictionary.
         Will handle the primary cross section collection as well as the entire list of secondary processes
 
         :param _dataclasses.Particle.ParticleType primary_type: primary particle to be generated
         :param string table_dir: Directory for storing cross section and decay tables
-        :param string fill_tables_at_start: Flag to fill total/differential cross section tables upon initialization
+        :param bool upscattering: Flag to set upscattering interactions
+        :param bool decay: Flag to set decay interactions
+        :param bool fill_tables_at_start: Flag to fill total/differential cross section tables upon initialization
         :param float Emax: maximum energy for cross section tables
         :param dict<str,val> kwargs: The dict of DarkNews model and cross section parameters
         """
@@ -260,14 +276,24 @@ class SIREN_Controller:
         # Add new secondary injection and physical processes at the same time
         secondary_interaction_collections = []
         for secondary_type, decay_list in secondary_decays.items():
-            # Define a sedcondary injection distribution
+
+            # Define a sedcondary injection distribution if necessary
+            inj_sec_defined = False
+            phys_sec_defined = False
+            for secondary_injection_process in self.secondary_injection_processes:
+                if secondary_injection_process.primary_type == secondary_type:
+                    inj_sec_defined = True
+            for secondary_physical_process in self.secondary_physical_processes:
+                if secondary_physical_process.primary_type == secondary_type:
+                    phys_sec_defined = True
+
             secondary_injection_process = _injection.SecondaryInjectionProcess()
             secondary_physical_process = _injection.PhysicalProcess()
             secondary_injection_process.primary_type = secondary_type
             secondary_physical_process.primary_type = secondary_type
 
             # Add the secondary position distribution
-            if self.fid_vol is not None:
+            if fid_vol_secondary and self.fid_vol is not None:
                 secondary_injection_process.AddSecondaryInjectionDistribution(
                     _distributions.SecondaryBoundedVertexDistribution(self.fid_vol)
                 )
@@ -276,23 +302,63 @@ class SIREN_Controller:
                     _distributions.SecondaryPhysicalVertexDistribution()
                 )
 
-            self.secondary_injection_processes.append(secondary_injection_process)
-            self.secondary_physical_processes.append(secondary_physical_process)
+            if not inj_sec_defined: self.secondary_injection_processes.append(secondary_injection_process)
+            if not phys_sec_defined: self.secondary_physical_processes.append(secondary_physical_process)
 
             secondary_interaction_collections.append(
                 _interactions.InteractionCollection(secondary_type, decay_list)
             )
 
+        # check whether to not include either process
+        if not upscattering: primary_interaction_collection = None
+        if not decay: secondary_interaction_collections = None
         self.SetInteractions(
-            primary_interaction_collection, secondary_interaction_collections
+            primary_interaction_collection=primary_interaction_collection,
+            secondary_interaction_collections=secondary_interaction_collections
+        )
+
+    def InputDarkNewsDecay(self, primary_type, table_dir, **kwargs):
+        """
+        Sets up the relevant processes and decay objects related to a provided DarkNews model dictionary.
+        Will handle the primary decay collection
+
+        :param _dataclasses.Particle.ParticleType primary_type: primary particle to be generated
+        :param string table_dir: Directory for storing cross section and decay tables
+        :param dict<str,val> kwargs: The dict of DarkNews model and cross section parameters
+        """
+        # Add nuclear targets to the model arguments
+        kwargs["nuclear_targets"] = self.GetDetectorModelTargets()[1]
+        # Initialize DarkNews cross sections and decays
+        self.DN_processes = PyDarkNewsInteractionCollection(
+            table_dir=table_dir, **kwargs
+        )
+
+        # Initialize primary InteractionCollection
+        # Loop over available cross sections and save those which match primary type
+        primary_decays = []
+        # Also keep track of the minimum decay width for defining the position distribution later
+        self.DN_min_decay_width = np.inf
+        for decay in self.DN_processes.decays:
+            if primary_type == _dataclasses.Particle.ParticleType(
+                decay.dec_case.nu_parent.pdgid
+            ):
+                primary_decays.append(decay)
+            total_decay_width = decay.TotalDecayWidth(primary_type)
+            if total_decay_width < self.DN_min_decay_width:
+                self.DN_min_decay_width = total_decay_width
+        primary_interaction_collection = _interactions.InteractionCollection(
+            primary_type, primary_decays
+        )
+
+        self.SetInteractions(
+            primary_interaction_collection=primary_interaction_collection
         )
 
     def GetFiducialVolume(self):
         """
         :return: identified fiducial volume for the experiment, None if not found
         """
-        detector_model_file = _util.get_detector_model_path(self.experiment)
-        with open(detector_model_file) as file:
+        with open(self.detector_model_file) as file:
             fiducial_line = None
             detector_line = None
             for line in file:
@@ -308,18 +374,25 @@ class SIREN_Controller:
             return _detector.DetectorModel.ParseFiducialVolume(fiducial_line, detector_line)
         return None
 
-    def GetCylinderVolumePositionDistributionFromSector(self, sector_name):
+    def GetVolumePositionDistributionFromSector(self, sector_name):
         geo = self.GetDetectorSectorGeometry(sector_name)
         if geo is None:
             print("Sector %s not found. Exiting"%sector_name)
             exit(0)
-        # the position of this cylinder is in geometry coordinates
+        # the position is in geometry coordinates
         # must update to detector coordintes
         det_position = self.detector_model.GeoPositionToDetPosition(_detector.GeometryPosition(geo.placement.Position))
         det_rotation = geo.placement.Quaternion
         det_placement = _geometry.Placement(det_position.get(), det_rotation)
-        cylinder = _geometry.Cylinder(det_placement,geo.Radius,geo.InnerRadius,geo.Z)
-        return _distributions.CylinderVolumePositionDistribution(cylinder)
+        if type(geo)==_geometry.Cylinder:
+            cylinder = _geometry.Cylinder(det_placement,geo.Radius,geo.InnerRadius,geo.Z)
+            return _distributions.CylinderVolumePositionDistribution(cylinder)
+        elif type(geo)==_geometry.Sphere:
+            sphere = _geometry.Sphere(det_placement,geo.Radius,geo.InnerRadius)
+            return _distributions.SphereVolumePositionDistribution(sphere)
+        else:
+            print("Geometry type %s not supported for position distribution. Exiting"%str(type(geo)))
+            exit(0)
 
     def GetDetectorModelTargets(self):
         """
@@ -348,7 +421,7 @@ class SIREN_Controller:
         return targets, target_strs
 
     def SetInteractions(
-        self, primary_interaction_collection, secondary_interaction_collections=None, injection=True, physical=True
+        self, primary_interaction_collection=None, secondary_interaction_collections=None, injection=True, physical=True
     ):
         """
         Set cross sections for the primary and secondary processes
@@ -358,55 +431,64 @@ class SIREN_Controller:
         :param bool injection: whether to apply these interaction collections to the injection processes
         :param bool physical: whether to apply these interaction collections to the physical processes
         """
-        if secondary_interaction_collections is None:
-            secondary_interaction_collections = []
 
-        # Set primary cross sections
-        if injection:
-            if self.primary_injection_process.interactions is None:
-                self.primary_injection_process.interactions = primary_interaction_collection
-            else:
-                self.primary_injection_process.interactions = MergeInteractionCollections(self.primary_injection_process.primary_type,
-                                                                                        [self.primary_injection_process.interactions, primary_interaction_collection])
-        if physical:
-            if self.primary_physical_process.interactions is None:
-                self.primary_physical_process.interactions = primary_interaction_collection
-            else:
-                self.primary_physical_process.interactions = MergeInteractionCollections(self.primary_physical_process.primary_type,
-                                                                                        [self.primary_physical_process.interactions, primary_interaction_collection])
+        if primary_interaction_collection is not None:
+            # Set primary cross sections
+            if injection:
+                # set the primary type if doesn't exist
+                if self.primary_injection_process.primary_type == _dataclasses.Particle.ParticleType.unknown:
+                    self.primary_injection_process.primary_type = primary_interaction_collection.GetPrimaryType()
+                else:
+                    assert(self.primary_injection_process.primary_type == primary_interaction_collection.GetPrimaryType())
+                if self.primary_injection_process.interactions is None:
+                    self.primary_injection_process.interactions = primary_interaction_collection
+                else:
+                    self.primary_injection_process.interactions = MergeInteractionCollections(self.primary_injection_process.primary_type,
+                                                                                            [self.primary_injection_process.interactions, primary_interaction_collection])
+            if physical:
+                if self.primary_physical_process.primary_type == _dataclasses.Particle.ParticleType.unknown:
+                    self.primary_physical_process.primary_type = primary_interaction_collection.GetPrimaryType()
+                else:
+                    assert(self.primary_injection_process.primary_type == primary_interaction_collection.GetPrimaryType())
+                if self.primary_physical_process.interactions is None:
+                    self.primary_physical_process.interactions = primary_interaction_collection
+                else:
+                    self.primary_physical_process.interactions = MergeInteractionCollections(self.primary_physical_process.primary_type,
+                                                                                            [self.primary_physical_process.interactions, primary_interaction_collection])
 
-        # Loop through secondary processes
-        for sec_inj, sec_phys in zip(
-            self.secondary_injection_processes, self.secondary_physical_processes
-        ):
-            assert sec_inj.primary_type == sec_phys.primary_type
-            record = _dataclasses.InteractionRecord()
-            record.signature.primary_type = sec_inj.primary_type
-            found_collection = False
-            # Loop through possible seconday cross sections
-            for sec_ints in secondary_interaction_collections:
-                # Match cross section collection on the primary type
-                if sec_ints.MatchesPrimary(record):
-                    # Set secondary cross sections
-                    if injection:
-                        if sec_inj.interactions is None:
-                            sec_inj.interactions = sec_ints
-                        else:
-                            sec_inj.interactions = MergeInteractionCollections(sec_inj.primary_type,
-                                                                            [sec_inj.interactions, sec_ints])
-                    if physical:
-                        if sec_phys.interactions is None:
-                            sec_phys.interactions = sec_ints
-                        else:
-                            sec_phys.interactions = MergeInteractionCollections(sec_phys.primary_type,
-                                                                                [sec_phys.interactions, sec_ints])
-                    found_collection = True
-            if not found_collection and(sec_inj.interactions is None or sec_phys.interactions is None):
-                print(
-                    "Couldn't find cross section collection for secondary particle %s; Exiting"
-                    % record.primary_type
-                )
-                exit(0)
+        if secondary_interaction_collections is not None:
+            # Loop through secondary processes
+            for sec_inj, sec_phys in zip(
+                self.secondary_injection_processes, self.secondary_physical_processes
+            ):
+                assert sec_inj.primary_type == sec_phys.primary_type
+                record = _dataclasses.InteractionRecord()
+                record.signature.primary_type = sec_inj.primary_type
+                found_collection = False
+                # Loop through possible seconday cross sections
+                for sec_ints in secondary_interaction_collections:
+                    # Match cross section collection on the primary type
+                    if sec_ints.MatchesPrimary(record):
+                        # Set secondary cross sections
+                        if injection:
+                            if sec_inj.interactions is None:
+                                sec_inj.interactions = sec_ints
+                            else:
+                                sec_inj.interactions = MergeInteractionCollections(sec_inj.primary_type,
+                                                                                [sec_inj.interactions, sec_ints])
+                        if physical:
+                            if sec_phys.interactions is None:
+                                sec_phys.interactions = sec_ints
+                            else:
+                                sec_phys.interactions = MergeInteractionCollections(sec_phys.primary_type,
+                                                                                    [sec_phys.interactions, sec_ints])
+                        found_collection = True
+                if not found_collection and(sec_inj.interactions is None or sec_phys.interactions is None):
+                    print(
+                        "Couldn't find cross section collection for secondary particle %s; Exiting"
+                        % record.signature.primary_type
+                    )
+                    exit(0)
 
     # set the stopping condition of the injector with a python function
     # must accept two arguments, assumes first is datum and the second is the index of the secondary particle
@@ -475,14 +557,14 @@ class SIREN_Controller:
         self.InitializeWeighter(filename=weighter_filename)
 
     # Generate events using the self.injector object
-    def GenerateEvents(self, N=None, fill_tables_at_exit=True):
+    def GenerateEvents(self, N=None, fill_tables_at_exit=True, verbose=True):
         if N is None:
             N = self.events_to_inject
         count = 0
         self.gen_times,self.global_times = [],[]
         prev_time = time.time()
         while (self.injector.InjectedEvents() < self.events_to_inject) and (count < N):
-            print("Injecting Event %d/%d  " % (count, N), end="\r")
+            if verbose: print("Injecting Event %d/%d  " % (count, N), end="\r")
             event = self.injector.GenerateEvent()
             self.events.append(event)
             t = time.time()
@@ -503,8 +585,9 @@ class SIREN_Controller:
     # Save events to hdf5, parquet, and/or custom SIREN filetypes
     # if the weighter exists, calculate the event weight too
     def SaveEvents(self, filename, fill_tables_at_exit=True,
-                   hdf5=True, parquet=True, siren_events=True # filetypes to save events
-                   ):
+                   hdf5=True, parquet=True, siren_events=True, # filetypes to save events
+                   save_int_probs=False,save_int_params=False,save_survival_probs=False,
+                   verbose=True):
 
         if siren_events:
             _dataclasses.SaveInteractionTrees(self.events, filename)
@@ -515,7 +598,8 @@ class SIREN_Controller:
             "event_weight_time":[], # weight calculation time of each event
             "event_global_time":[], # global time of each event
             "num_interactions":[], # number of interactions per event
-            "vertex":[], # vertex of each interaction in an event
+            "vertex":[], # vertex of each interaction of an event
+            "primary_initial_position":[], # initial position of primary in each interaction of an event
             "in_fiducial":[], # whether or not each vertex is in the fiducial volume
             "primary_type":[], # primary type of each interaction
             "target_type":[], # target type of each interaction
@@ -524,16 +608,24 @@ class SIREN_Controller:
             "primary_momentum":[], # primary momentum of each interaction
             "secondary_momenta":[], # secondary momentum of each interaction
             "parent_idx":[], # index of the parent interaction
+            "num_daughters":[], # number of daughter interactions
         }
+        if save_int_probs: datasets["int_probs"] = []
+        if save_survival_probs: datasets["survival_probs"] = []
         for ie, event in enumerate(self.events):
-            print("Saving Event %d/%d  " % (ie, len(self.events)), end="\r")
+            if verbose: print("Saving Event %d/%d  " % (ie, len(self.events)), end="\r")
             t0 = time.time()
             datasets["event_weight"].append(self.weighter.EventWeight(event) if hasattr(self,"weighter") else 0)
+            if save_int_probs:
+                datasets["int_probs"].append(self.weighter.GetInteractionProbabilities(event)if hasattr(self,"weighter") else [])
+            if save_survival_probs:
+                datasets["survival_probs"].append(self.weighter.GetSurvivalProbabilities(event)if hasattr(self,"weighter") else [])
             datasets["event_weight_time"].append(time.time()-t0)
             datasets["event_gen_time"].append(self.gen_times[ie])
             datasets["event_global_time"].append(self.global_times[ie])
             # add empty lists for each per interaction dataset
             for k in ["vertex",
+                      "primary_initial_position",
                       "in_fiducial",
                       "primary_type",
                       "target_type",
@@ -541,15 +633,22 @@ class SIREN_Controller:
                       "secondary_types",
                       "primary_momentum",
                       "secondary_momenta",
-                      "parent_idx"]:
+                      "parent_idx",
+                      "num_daughters"]:
                 datasets[k].append([])
             # loop over interactions
             for id, datum in enumerate(event.tree):
+                if save_int_params:
+                    for param_name,param_value in datum.record.interaction_parameters.items():
+                        if ie==0: datasets[param_name] = []
+                        datasets[param_name].append(param_value)
                 datasets["vertex"][-1].append(np.array(datum.record.interaction_vertex,dtype=float))
+                datasets["primary_initial_position"][-1].append(np.array(datum.record.primary_initial_position,dtype=float))
 
                  # primary particle stuff
                 datasets["primary_type"][-1].append(int(datum.record.signature.primary_type))
                 datasets["primary_momentum"][-1].append(np.array(datum.record.primary_momentum, dtype=float))
+                datasets["num_daughters"][-1].append(len(datum.daughters))
 
                 # check parent idx; match on secondary momenta
                 if datum.depth()==0:


### PR DESCRIPTION
## Stack: PR 14 of 14

This PR is part of a 14-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/hnl-3body-sampling`
- **Head:** `feat/controller-output`

Merge order: `feat/hnl-3body-sampling` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - python/SIREN_Controller.py
  - projects/injection/private/Weighter.cxx
  - projects/injection/public/SIREN/injection/Weighter.h
  - projects/injection/private/pybindings/injection.cxx
  - cmake/Packages/CFITSIO.cmake
  - vendor/googletest

Source commits on dev/HNL_DIS_clean that contributed:
  088b1cd2 (Nicholas Kamp): move around the HNL DIS fits files
  0a9c9aa4 (Nicholas Kamp): ability to save interaction probabilities for each process
  0c7ad93e (Nicholas Kamp): support sphere volume distributions in python interface
  197bf14d (Nicholas Kamp): fixing build errors from the merge
  1d68f307 (Nicholas Kamp): fix runtime errors on HNL generation related to particle types
  4f113a14 (Nicholas Kamp): add survival probability function
  521695f3 (Nicholas Kamp): fix issues with 2D tabular integral calculation, sampling errors with very short decay lengths, DarkNews errors, and kinematic erros in Dipole portal HNL DIS
  631c12a8 (Nicholas Kamp): add ability to save interaction parameters to output file
  82bcb806 (Nicholas Kamp): fix error in loading mat/det files
  ac0ce244 (Nicholas Kamp): changes to facilitate hadronic and W/Z HNL decays
  cf24f42a (Nicholas Kamp): add secondary fid vol flag in controller
  da5f6b2d (Nicholas Kamp): detector changes, functionality to save initial position of interaction_record, and fix to HNLDISFromSpline.cxx
  f1831919 (Nicholas Kamp): more complex logic for adding darknews interactions, fix some errors in SIREN_DarkNews


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
