### PR TITLE
CI: install GSL system package for cibuildwheel and bump GitHub Action versions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
       version: ${{ steps.cfitsio.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Read cfitsio version
         id: cfitsio
@@ -20,7 +20,7 @@ jobs:
 
       - name: Cache cfitsio source tarball
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .cfitsio-cache
           key: cfitsio-${{ steps.cfitsio.outputs.version }}-v1
@@ -54,29 +54,29 @@ jobs:
             arch: arm64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # IMPORTANT: CPython 3.8 on arm64 uses an x86_64 Python under Rosetta by default.
       # Installing a native arm64 Python 3.8 avoids CMake thinking it's x86_64.
       - name: Install native Python 3.8 (arm64 runner only)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         if: runner.os == 'macOS' && runner.arch == 'ARM64' && matrix.py == 'cp38'
         with:
           python-version: '3.8'
 
       - name: Restore cfitsio source tarball
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .cfitsio-cache
           key: cfitsio-${{ needs.populate_cfitsio_cache.outputs.version }}-v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.py }}-*
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.py }}
           path: ./wheelhouse/*.whl
@@ -101,21 +101,21 @@ jobs:
             os: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Restore cfitsio source tarball
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .cfitsio-cache
           key: cfitsio-${{ needs.populate_cfitsio_cache.outputs.version }}-v1
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
+        uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_BUILD: ${{ matrix.py }}-${{ matrix.image }}_${{ matrix.arch }}
           CIBW_ARCHS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ matrix.py }}-${{ matrix.image }}_${{ matrix.arch }}
           path: ./wheelhouse/*.whl
@@ -125,6 +125,6 @@ jobs:
     needs: [build_wheels_macos, build_wheels_linux]
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v6
         with:
           delete-merged: true

--- a/tools/wheels/cibw_before_all.sh
+++ b/tools/wheels/cibw_before_all.sh
@@ -32,9 +32,14 @@ ZLIB_VERSION="1.3.1"
 mkdir -p $CI_INSTALL_PREFIX
 
 if [[ $RUNNER_OS == "Linux" ]] ; then
-    :
+    if command -v apk >/dev/null 2>&1; then
+        apk add --no-cache gsl-dev || { echo "Failed to install GSL (apk)"; exit 1; }  # musllinux (Alpine)
+    else
+        (yum install -y gsl-devel || dnf install -y gsl-devel || microdnf install -y gsl-devel) || { echo "Failed to install GSL (yum/dnf/microdnf)"; exit 1; }  # manylinux
+    fi
 elif [[ $RUNNER_OS == "macOS" ]]; then
-    :
+    export HOMEBREW_NO_AUTO_UPDATE=1
+    brew list gsl >/dev/null 2>&1 || brew install gsl || { echo "Failed to install GSL (brew)"; exit 1; }
 elif [[ $RUNNER_OS == "Windows" ]]; then
     mkdir -p $CI_DOWNLOAD_PATH
     cd $CI_DOWNLOAD_PATH
@@ -48,7 +53,7 @@ elif [[ $RUNNER_OS == "Windows" ]]; then
 
     pip install delvewheel
 else
-    echo "Unknown runner OS: $RUNNER OS" 1>&2
+    echo "Unknown runner OS: $RUNNER_OS" 1>&2
     exit 1
 fi
 


### PR DESCRIPTION
## Stack: PR 2 of 13

This PR is part of a 13-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `chore/vendor-crundec3`
- **Head:** `chore/ci-and-packaging`

Merge order: `chore/vendor-crundec3` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - .gitignore
  - tools/wheels

Source commits on dev/HNL_DIS_clean that contributed:
  088b1cd2 (Nicholas Kamp): move around the HNL DIS fits files
  0a8a6e9c (Nicholas Kamp): attempt to get wheels working
  a62ce388 (Nicholas Kamp): quick gitignore change


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
- This PR replaces an earlier copy that was opened from a different account; closed PRs in the project history are intentional duplicates.

## Notes from Nick

- these changes were attempts to get crundec3 to install in the CI wheels. the gitignore additions are local and can be removed
