### PR TITLE
Add SphereVolumePositionDistribution and tests

### DIFF
--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -29,6 +29,7 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/DecayRangePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/OrientedCylinderPositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/CylinderVolumePositionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
 

--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -73,6 +73,8 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/projects/distributions/public/"
 package_add_test(UnitTest_PrimaryDirectionDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/PrimaryDirectionDistribution_TEST.cxx)
 package_add_test(UnitTest_PrimaryEnergyDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/PrimaryEnergyDistribution_TEST.cxx)
 package_add_test(UnitTest_WeightableDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/WeightableDistribution_TEST.cxx)
+package_add_test(UnitTest_SphereVolumePositionDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/SphereVolumePositionDistribution_TEST.cxx)
+package_add_test(UnitTest_CylinderVolumePositionDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/CylinderVolumePositionDistribution_TEST.cxx)
 
 pybind11_add_module(distributions ${PROJECT_SOURCE_DIR}/projects/distributions/private/pybindings/distributions.cxx)
 target_link_libraries(distributions PRIVATE SIREN)

--- a/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx
@@ -1,0 +1,124 @@
+#include "SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
+
+#include <array>                                           // for array
+#include <cmath>                                           // for sqrt, cos
+#include <string>                                          // for basic_string
+#include <vector>                                          // for vector
+
+#include "SIREN/dataclasses/InteractionRecord.h"  // for Interactio...
+#include "SIREN/detector/DetectorModel.h"            // for DetectorModel
+#include "SIREN/distributions/Distributions.h"    // for InjectionD...
+#include "SIREN/geometry/Geometry.h"              // for Geometry
+#include "SIREN/math/Vector3D.h"                  // for Vector3D
+#include "SIREN/utilities/Random.h"               // for SIREN_random
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+
+namespace siren {
+namespace distributions {
+
+//---------------
+// class SphereVolumePositionDistribution : public VertexPositionDistribution
+//---------------
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> SphereVolumePositionDistribution::SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+
+    // Sample uniformly within a spherical shell
+    const double outer_radius = sphere.GetRadius();
+    const double inner_radius = sphere.GetInnerRadius();
+
+    // Sample radius with proper volume weighting for uniform distribution
+    double outer_vol = outer_radius * outer_radius * outer_radius;
+    double inner_vol = inner_radius * inner_radius * inner_radius;
+    double r_cubed = rand->Uniform(inner_vol, outer_vol);
+    double r = std::cbrt(r_cubed);
+
+    // Sample angles uniformly on sphere surface
+    double phi = rand->Uniform(0, 2 * M_PI);  // azimuthal angle
+    double cos_theta = rand->Uniform(-1, 1);  // uniform in cos(theta)
+    double sin_theta = std::sqrt(1 - cos_theta * cos_theta);
+
+    // Convert to Cartesian coordinates
+    siren::math::Vector3D pos(
+        r * sin_theta * std::cos(phi),
+        r * sin_theta * std::sin(phi),
+        r * cos_theta
+    );
+
+    siren::math::Vector3D final_pos = sphere.LocalToGlobalPosition(pos);
+
+    siren::math::Vector3D dir = record.GetDirection();
+    std::vector<siren::geometry::Geometry::Intersection> intersections = sphere.Intersections(final_pos, dir);
+    siren::detector::DetectorModel::SortIntersections(intersections);
+
+    siren::math::Vector3D init_pos;
+
+    if(intersections.size() == 0) {
+        init_pos = final_pos;
+    } else if(intersections.size() >= 2) {
+        init_pos = intersections.front().position;
+    } else {
+        throw std::runtime_error("Only found one sphere intersection!");
+    }
+
+    return {init_pos, final_pos};
+}
+
+double SphereVolumePositionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    siren::math::Vector3D pos(sphere.GlobalToLocalPosition(record.interaction_vertex));
+    double r = pos.magnitude();  // Distance from sphere center
+
+    if(r <= sphere.GetInnerRadius() || r >= sphere.GetRadius()) {
+        return 0.0;
+    } else {
+        // Volume of spherical shell: (4/3)π(R³ - r_inner³)
+        double outer_volume = (4.0/3.0) * M_PI * sphere.GetRadius() * sphere.GetRadius() * sphere.GetRadius();
+        double inner_volume = (4.0/3.0) * M_PI * sphere.GetInnerRadius() * sphere.GetInnerRadius() * sphere.GetInnerRadius();
+        return 1.0 / (outer_volume - inner_volume);
+    }
+}
+
+SphereVolumePositionDistribution::SphereVolumePositionDistribution(siren::geometry::Sphere sphere) : sphere(sphere) {}
+
+std::string SphereVolumePositionDistribution::Name() const {
+    return "SphereVolumePositionDistribution";
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> SphereVolumePositionDistribution::clone() const {
+    return std::shared_ptr<PrimaryInjectionDistribution>(new SphereVolumePositionDistribution(*this));
+}
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> SphereVolumePositionDistribution::InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const {
+    siren::math::Vector3D dir(interaction.primary_momentum[1], interaction.primary_momentum[2], interaction.primary_momentum[3]);
+    dir.normalize();
+    siren::math::Vector3D pos(interaction.interaction_vertex);
+    std::vector<siren::geometry::Geometry::Intersection> intersections = sphere.Intersections(pos, dir);
+    siren::detector::DetectorModel::SortIntersections(intersections);
+    if(intersections.size() == 0) {
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(siren::math::Vector3D(0, 0, 0), siren::math::Vector3D(0, 0, 0));
+    } else if(intersections.size() >= 2) {
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>(intersections.front().position, intersections.back().position);
+    } else {
+        throw std::runtime_error("Only found one sphere intersection!");
+    }
+}
+
+bool SphereVolumePositionDistribution::equal(WeightableDistribution const & other) const {
+    const SphereVolumePositionDistribution* x = dynamic_cast<const SphereVolumePositionDistribution*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return (sphere == x->sphere);
+}
+
+bool SphereVolumePositionDistribution::less(WeightableDistribution const & other) const {
+    const SphereVolumePositionDistribution* x = dynamic_cast<const SphereVolumePositionDistribution*>(&other);
+    return sphere < x->sphere;
+}
+
+bool SphereVolumePositionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    return this->operator==(*distribution);
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/pybindings/distributions.cxx
+++ b/projects/distributions/private/pybindings/distributions.cxx
@@ -16,6 +16,7 @@
 #include "../../public/SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/ColumnDepthPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/CylinderVolumePositionDistribution.h"
+#include "../../public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/FixedTargetPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/DecayRangeFunction.h"
 #include "../../public/SIREN/distributions/primary/vertex/DecayRangePositionDistribution.h"
@@ -199,6 +200,12 @@ PYBIND11_MODULE(distributions,m) {
     .def("GenerationProbability",&CylinderVolumePositionDistribution::GenerationProbability)
     .def("InjectionBounds",&CylinderVolumePositionDistribution::InjectionBounds)
     .def("Name",&CylinderVolumePositionDistribution::Name);
+
+  class_<SphereVolumePositionDistribution, std::shared_ptr<SphereVolumePositionDistribution>, VertexPositionDistribution>(m, "SphereVolumePositionDistribution")
+    .def(init<siren::geometry::Sphere>())
+    .def("GenerationProbability",&SphereVolumePositionDistribution::GenerationProbability)
+    .def("InjectionBounds",&SphereVolumePositionDistribution::InjectionBounds)
+    .def("Name",&SphereVolumePositionDistribution::Name);
 
   class_<ColumnDepthPositionDistribution, std::shared_ptr<ColumnDepthPositionDistribution>, VertexPositionDistribution>(m, "ColumnDepthPositionDistribution")
     .def(init<double, double, std::shared_ptr<DepthFunction>>())

--- a/projects/distributions/private/test/CylinderVolumePositionDistribution_TEST.cxx
+++ b/projects/distributions/private/test/CylinderVolumePositionDistribution_TEST.cxx
@@ -1,0 +1,142 @@
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "DistributionTest.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"
+#include "SIREN/distributions/primary/vertex/CylinderVolumePositionDistribution.h"
+#include "SIREN/geometry/Cylinder.h"
+#include "SIREN/utilities/Random.h"
+
+using namespace siren::distributions;
+using siren::geometry::Cylinder;
+
+
+TEST(CylinderVolumePositionDistribution, Constructor) {
+    Cylinder cylinder(10.0, 1.0, 4.0);
+    CylinderVolumePositionDistribution dist(cylinder);
+    EXPECT_EQ(dist.Name(), "CylinderVolumePositionDistribution");
+}
+
+
+TEST(CylinderVolumePositionDistribution, GenerationProbabilityZeroOutsideShell) {
+    double inner = 1.0;
+    double outer = 10.0;
+    double height = 4.0;
+    CylinderVolumePositionDistribution dist(Cylinder(outer, inner, height));
+
+    siren::dataclasses::InteractionRecord record;
+    record.interaction_vertex = {0.5, 0, 0};        // r < inner
+    EXPECT_EQ(dist.GenerationProbability(nullptr, nullptr, record), 0.0);
+    record.interaction_vertex = {15.0, 0, 0};       // r > outer
+    EXPECT_EQ(dist.GenerationProbability(nullptr, nullptr, record), 0.0);
+    record.interaction_vertex = {5.0, 0, height};   // |z| > h/2
+    EXPECT_EQ(dist.GenerationProbability(nullptr, nullptr, record), 0.0);
+}
+
+
+TEST(CylinderVolumePositionDistribution, GenerationProbabilityConstantInsideShell) {
+    double inner = 1.0;
+    double outer = 10.0;
+    double height = 4.0;
+    CylinderVolumePositionDistribution dist(Cylinder(outer, inner, height));
+
+    double V = M_PI * (outer*outer - inner*inner) * height;
+    double expected = 1.0 / V;
+
+    siren::dataclasses::InteractionRecord record;
+    for(double r : {2.0, 5.0, 9.0}) {
+        for(double z : {-1.5, 0.0, 1.5}) {
+            record.interaction_vertex = {r, 0, z};
+            EXPECT_NEAR(dist.GenerationProbability(nullptr, nullptr, record), expected, expected * 1e-9);
+        }
+    }
+}
+
+
+TEST(CylinderVolumePositionDistribution, SamplePositionInsideShell) {
+    double inner = 1.0;
+    double outer = 10.0;
+    double height = 4.0;
+    CylinderVolumePositionDistribution dist(Cylinder(outer, inner, height));
+
+    auto rand = std::make_shared<siren::utilities::SIREN_random>();
+    size_t N = 10000;
+    for(size_t i = 0; i < N; ++i) {
+        siren::dataclasses::PrimaryDistributionRecord record(siren::dataclasses::ParticleType::NuMu);
+        record.SetEnergy(1);
+        record.SetMass(0);
+        record.SetDirection({0, 0, 1});
+        dist.Sample(rand, nullptr, nullptr, record);
+        auto v = record.GetInteractionVertex();
+        double r = std::sqrt(v[0]*v[0] + v[1]*v[1]);
+        EXPECT_GE(r, inner);
+        EXPECT_LE(r, outer);
+        EXPECT_GE(v[2], -height/2.0);
+        EXPECT_LE(v[2],  height/2.0);
+    }
+}
+
+
+// Tier 2: uniform-volume sampling. r^2 should be uniform on [inner^2, outer^2].
+TEST(CylinderVolumePositionDistribution, SamplingIsUniformInRadius) {
+    double inner = 1.0;
+    double outer = 10.0;
+    double height = 4.0;
+    CylinderVolumePositionDistribution dist(Cylinder(outer, inner, height));
+
+    auto rand = std::make_shared<siren::utilities::SIREN_random>();
+    size_t N = 100000;
+    size_t n_bins = 20;
+    DistributionTest test(inner*inner, outer*outer, n_bins);
+
+    for(size_t i = 0; i < N; ++i) {
+        siren::dataclasses::PrimaryDistributionRecord record(siren::dataclasses::ParticleType::NuMu);
+        record.SetEnergy(1);
+        record.SetMass(0);
+        record.SetDirection({0, 0, 1});
+        dist.Sample(rand, nullptr, nullptr, record);
+        auto v = record.GetInteractionVertex();
+        double r2 = v[0]*v[0] + v[1]*v[1];
+        test.AddValue(r2);
+    }
+
+    std::vector<double> expect(n_bins, double(N) / double(n_bins));
+    EXPECT_TRUE(test.TestContents(3, expect));
+}
+
+
+// Tier 2: z should be uniform on [-h/2, h/2].
+TEST(CylinderVolumePositionDistribution, SamplingIsUniformInZ) {
+    double inner = 1.0;
+    double outer = 10.0;
+    double height = 4.0;
+    CylinderVolumePositionDistribution dist(Cylinder(outer, inner, height));
+
+    auto rand = std::make_shared<siren::utilities::SIREN_random>();
+    size_t N = 100000;
+    size_t n_bins = 20;
+    DistributionTest test(-height/2.0, height/2.0, n_bins);
+
+    for(size_t i = 0; i < N; ++i) {
+        siren::dataclasses::PrimaryDistributionRecord record(siren::dataclasses::ParticleType::NuMu);
+        record.SetEnergy(1);
+        record.SetMass(0);
+        record.SetDirection({0, 0, 1});
+        dist.Sample(rand, nullptr, nullptr, record);
+        auto v = record.GetInteractionVertex();
+        test.AddValue(v[2]);
+    }
+
+    std::vector<double> expect(n_bins, double(N) / double(n_bins));
+    EXPECT_TRUE(test.TestContents(3, expect));
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/projects/distributions/private/test/SphereVolumePositionDistribution_TEST.cxx
+++ b/projects/distributions/private/test/SphereVolumePositionDistribution_TEST.cxx
@@ -1,0 +1,105 @@
+#include <cmath>
+#include <memory>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "DistributionTest.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"
+#include "SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
+#include "SIREN/geometry/Sphere.h"
+#include "SIREN/utilities/Random.h"
+
+using namespace siren::distributions;
+using siren::geometry::Sphere;
+
+
+TEST(SphereVolumePositionDistribution, Constructor) {
+    Sphere sphere(10.0, 1.0);
+    SphereVolumePositionDistribution dist(sphere);
+    EXPECT_EQ(dist.Name(), "SphereVolumePositionDistribution");
+}
+
+
+TEST(SphereVolumePositionDistribution, GenerationProbabilityZeroOutsideShell) {
+    double inner = 1.0;
+    double outer = 10.0;
+    SphereVolumePositionDistribution dist(Sphere(outer, inner));
+
+    siren::dataclasses::InteractionRecord record;
+    record.interaction_vertex = {0.5, 0, 0};   // r < inner
+    EXPECT_EQ(dist.GenerationProbability(nullptr, nullptr, record), 0.0);
+    record.interaction_vertex = {15.0, 0, 0};  // r > outer
+    EXPECT_EQ(dist.GenerationProbability(nullptr, nullptr, record), 0.0);
+}
+
+
+TEST(SphereVolumePositionDistribution, GenerationProbabilityConstantInsideShell) {
+    double inner = 1.0;
+    double outer = 10.0;
+    SphereVolumePositionDistribution dist(Sphere(outer, inner));
+
+    double V = (4.0/3.0) * M_PI * (outer*outer*outer - inner*inner*inner);
+    double expected = 1.0 / V;
+
+    siren::dataclasses::InteractionRecord record;
+    for(double r : {2.0, 5.0, 9.0}) {
+        record.interaction_vertex = {r, 0, 0};
+        EXPECT_NEAR(dist.GenerationProbability(nullptr, nullptr, record), expected, expected * 1e-9);
+    }
+}
+
+
+TEST(SphereVolumePositionDistribution, SamplePositionInsideShell) {
+    double inner = 1.0;
+    double outer = 10.0;
+    SphereVolumePositionDistribution dist(Sphere(outer, inner));
+
+    auto rand = std::make_shared<siren::utilities::SIREN_random>();
+    size_t N = 10000;
+    for(size_t i = 0; i < N; ++i) {
+        siren::dataclasses::PrimaryDistributionRecord record(siren::dataclasses::ParticleType::NuMu);
+        record.SetEnergy(1);
+        record.SetMass(0);
+        record.SetDirection({0, 0, 1});
+        dist.Sample(rand, nullptr, nullptr, record);
+        auto v = record.GetInteractionVertex();
+        double r = std::sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+        EXPECT_GE(r, inner);
+        EXPECT_LE(r, outer);
+    }
+}
+
+
+// Tier 2: uniform-volume sampling. r^3 should be uniform on [inner^3, outer^3].
+TEST(SphereVolumePositionDistribution, SamplingIsUniformInVolume) {
+    double inner = 1.0;
+    double outer = 10.0;
+    SphereVolumePositionDistribution dist(Sphere(outer, inner));
+
+    auto rand = std::make_shared<siren::utilities::SIREN_random>();
+    size_t N = 100000;
+    size_t n_bins = 20;
+    DistributionTest test(inner*inner*inner, outer*outer*outer, n_bins);
+
+    for(size_t i = 0; i < N; ++i) {
+        siren::dataclasses::PrimaryDistributionRecord record(siren::dataclasses::ParticleType::NuMu);
+        record.SetEnergy(1);
+        record.SetMass(0);
+        record.SetDirection({0, 0, 1});
+        dist.Sample(rand, nullptr, nullptr, record);
+        auto v = record.GetInteractionVertex();
+        double r = std::sqrt(v[0]*v[0] + v[1]*v[1] + v[2]*v[2]);
+        test.AddValue(r * r * r);
+    }
+
+    std::vector<double> expect(n_bins, double(N) / double(n_bins));
+    EXPECT_TRUE(test.TestContents(3, expect));
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/projects/distributions/public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h
@@ -1,0 +1,76 @@
+#pragma once
+#ifndef SIREN_SphereVolumePositionDistribution_H
+#define SIREN_SphereVolumePositionDistribution_H
+
+#include <tuple>
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <stdexcept>
+
+#include <cereal/access.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+#include "SIREN/geometry/Sphere.h"
+#include "SIREN/math/Vector3D.h"
+
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace distributions { class PrimaryInjectionDistribution; } }
+namespace siren { namespace distributions { class WeightableDistribution; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+class SphereVolumePositionDistribution : virtual public VertexPositionDistribution {
+friend cereal::access;
+protected:
+    SphereVolumePositionDistribution() {};
+private:
+    siren::geometry::Sphere sphere;
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+public:
+    virtual double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    SphereVolumePositionDistribution(siren::geometry::Sphere);
+    std::string Name() const override;
+    virtual std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    virtual std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const override;
+    virtual bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(::cereal::make_nvp("Sphere", sphere));
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(this));
+        } else {
+            throw std::runtime_error("SphereVolumePositionDistribution only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    static void load_and_construct(Archive & archive, cereal::construct<SphereVolumePositionDistribution> & construct, std::uint32_t const version) {
+        if(version == 0) {
+            siren::geometry::Sphere c;
+            archive(::cereal::make_nvp("Sphere", c));
+            construct(c);
+            archive(cereal::virtual_base_class<VertexPositionDistribution>(construct.ptr()));
+        } else {
+            throw std::runtime_error("SphereVolumePositionDistribution only supports version <= 0!");
+        }
+    }
+protected:
+    virtual bool equal(WeightableDistribution const & distribution) const override;
+    virtual bool less(WeightableDistribution const & distribution) const override;
+};
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::SphereVolumePositionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::SphereVolumePositionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::VertexPositionDistribution, siren::distributions::SphereVolumePositionDistribution);
+
+#endif // SIREN_SphereVolumePositionDistribution_H


### PR DESCRIPTION
## Stack: PR 5 of 13

This PR is part of a 13-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `main`
- **Head:** `feat/sphere-distribution`

## Summary

Adds `SphereVolumePositionDistribution`, which samples interaction vertices uniformly within a spherical shell (inner/outer radius) using proper volume-weighted radial sampling. Mirrors the existing `CylinderVolumePositionDistribution` pattern.

Also adds C++ unit tests for both `SphereVolumePositionDistribution` and the pre-existing `CylinderVolumePositionDistribution` (which had no tests).

## What is included

- **SphereVolumePositionDistribution** (.cxx + .h): `SamplePosition` draws r cubed uniform in [r_inner^3, r_outer^3], cos(theta) uniform in [-1, 1], phi uniform in [0, 2pi]. `GenerationProbability` returns 1/V_shell inside, 0 outside. Cereal serialization via `load_and_construct`. Python bindings registered.
- **SphereVolumePositionDistribution_TEST.cxx** (5 tests): constructor, zero probability outside shell, constant probability inside, all samples within bounds, volume-uniform r^3 distribution (chi-squared, 100k samples, 20 bins).
- **CylinderVolumePositionDistribution_TEST.cxx** (6 tests): same coverage for the existing Cylinder class -- constructor, zero outside, constant inside, bounds check, uniform r^2 distribution, uniform z distribution.

## File list

| File | Change |
|---|---|
| `projects/distributions/private/primary/vertex/SphereVolumePositionDistribution.cxx` | New |
| `projects/distributions/public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h` | New |
| `projects/distributions/private/pybindings/distributions.cxx` | Modified -- added Sphere bindings |
| `projects/distributions/CMakeLists.txt` | Modified -- added source + 2 test targets |
| `projects/distributions/private/test/SphereVolumePositionDistribution_TEST.cxx` | New |
| `projects/distributions/private/test/CylinderVolumePositionDistribution_TEST.cxx` | New |

## Notes

- Source commit on `dev/HNL_DIS_clean`: `9dae77ab` (Nicholas Kamp).
- Per-commit history is browsable on `dev/HNL_DIS_clean`.
