### PR TITLE
DetectorModel: query sectors by name, fiducial volume support

### DIFF
--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -44,25 +44,6 @@ namespace {
 void string_to_lower(std::string & data) {
     std::transform(data.begin(), data.end(), data.begin(), [](unsigned char c){ return std::tolower(c); });
 }
-double estimateDotError(const std::array<double, 3>& p0, const std::array<double, 3>& p1, const std::array<double, 3>& int_dir) {
-    constexpr double epsilon = std::numeric_limits<double>::epsilon();
-
-    double dot_product = 0.0;
-    double error_sum = 0.0;
-
-    for (int i = 0; i < 3; ++i) {
-        double diff = p1[i] - p0[i];
-        double prod = int_dir[i] * diff;
-        dot_product += prod;
-        error_sum += std::fabs(int_dir[i] * diff);
-    }
-
-    // Estimated error of the expression
-    double error_estimate = epsilon * error_sum;
-
-    return error_estimate;
-}
-
 template <class InIt>
 typename std::iterator_traits<InIt>::value_type accumulate(InIt begin, InIt end) {
     typedef typename std::iterator_traits<InIt>::value_type real;
@@ -262,12 +243,11 @@ DetectorSector DetectorModel::GetSector(int heirarchy) const {
     return sectors_[index];
 }
 
-DetectorSector DetectorModel::GetSector(std::string name) const {
-    for (auto sector : sectors_) {
-        if (sector.name==name) return sector;
+DetectorSector DetectorModel::GetSector(std::string const & name) const {
+    for (auto const & sector : sectors_) {
+        if (sector.name == name) return sector;
     }
-    std::cout << "Sector " << name << " not found, returning empty sector\n";
-    return DetectorSector();
+    throw std::runtime_error("Sector not found: " + name);
 }
 
 void DetectorModel::ClearSectors() {
@@ -729,7 +709,6 @@ double DetectorModel::GetInteractionDensity(Geometry::IntersectionList const & i
         dot = 1;
     }
 
-
     double interaction_density = std::numeric_limits<double>::quiet_NaN();
 
     std::function<bool(std::vector<Geometry::Intersection>::const_iterator, std::vector<Geometry::Intersection>::const_iterator, double)> callback =
@@ -1009,22 +988,18 @@ double DetectorModel::GetInteractionDepthInCGS(Geometry::IntersectionList const 
     }
     Vector3D direction = p1 - p0;
     double distance = direction.magnitude();
-    // this dot error turned out to be much smaller than 1e-6 for event that failed the assertion below
-    // double dot_error = estimateDotError(std::array<double, 3>(p0.get()),
-    //                                     std::array<double, 3>(p1.get()),
-    //                                     std::array<double, 3>(intersections.direction));
 
-    // If we have only decays, avoid the sector loop
+    // If we have only decays, avoid the sector loop.
+    // This must be checked before normalize()/dot-assertion since short decay
+    // paths produce degenerate direction vectors.
     if(targets.empty()) {
-      return distance/total_decay_length; // m / m --> dimensionless
+      return distance / total_decay_length; // m / m --> dimensionless
     }
     if(distance == 0.0) {
         return 0.0;
     }
     direction.normalize();
 
-    // TODO: a better numerical precision check when the traversed distance is very small
-    // this functionally only happens for decays right now, so we just check for decays at the top
     double dot = intersections.direction * direction;
     assert(std::abs(1.0 - std::abs(dot)) < 1e-6);
     double offset = (intersections.position - p0) * direction;
@@ -1378,7 +1353,6 @@ double DetectorModel::DistanceForInteractionDepthFromPoint(Geometry::Intersectio
     } else {
         dot = 1;
     }
-
 
     // Recast decay length to cm for density integral
     double total_decay_length_cm = total_decay_length / siren::utilities::Constants::cm;

--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -227,10 +227,16 @@ void DetectorModel::AddSector(DetectorSector sector) {
     if(sector_map_.count(sector.level) > 0) {
         throw(std::runtime_error("Already have a sector of that heirarchy!"));
     }
-    else {
-        sector_map_[sector.level] = sectors_.size();
-        sectors_.push_back(sector);
+    // Enforce unique non-empty sector names for name-based lookup
+    if(!sector.name.empty()) {
+        for(auto const & s : sectors_) {
+            if(s.name == sector.name) {
+                throw std::runtime_error("Already have a sector named: " + sector.name);
+            }
+        }
     }
+    sector_map_[sector.level] = sectors_.size();
+    sectors_.push_back(sector);
 }
 
 DetectorSector DetectorModel::GetSector(int heirarchy) const {

--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -178,9 +178,9 @@ DetectorModel::DetectorModel(std::string const & path, std::string const & detec
 
 bool DetectorModel::operator==(DetectorModel const & o) const {
     return
-        std::tie(materials_, sectors_, sector_map_, detector_origin_)
+        std::tie(materials_, sectors_, sector_map_, sector_name_map_, detector_origin_)
         ==
-        std::tie(o.materials_, o.sectors_, o.sector_map_, o.detector_origin_);
+        std::tie(o.materials_, o.sectors_, o.sector_map_, o.sector_name_map_, o.detector_origin_);
 }
 
 std::string DetectorModel::GetPath() const {
@@ -205,6 +205,19 @@ std::vector<DetectorSector> const & DetectorModel::GetSectors() const {
 
 void DetectorModel::SetSectors(std::vector<DetectorSector> const & sectors) {
     sectors_ = sectors;
+    sector_map_.clear();
+    sector_name_map_.clear();
+    for(unsigned int i=0; i<sectors.size(); ++i) {
+        if(sector_map_.count(sectors[i].level) > 0) {
+            throw(std::runtime_error("Already have a sector of that heirarchy!"));
+        }
+        // Enforce unique sector names for name-based lookup
+        if(sector_name_map_.count(sectors[i].name) > 0) {
+            throw(std::runtime_error("Already have a sector named: " + sectors[i].name));
+        }
+        sector_name_map_[sectors[i].name] = i;
+        sector_map_[sectors[i].level] = i;
+    }
 }
 
 GeometryPosition DetectorModel::GetDetectorOrigin() const {
@@ -227,14 +240,11 @@ void DetectorModel::AddSector(DetectorSector sector) {
     if(sector_map_.count(sector.level) > 0) {
         throw(std::runtime_error("Already have a sector of that heirarchy!"));
     }
-    // Enforce unique non-empty sector names for name-based lookup
-    if(!sector.name.empty()) {
-        for(auto const & s : sectors_) {
-            if(s.name == sector.name) {
-                throw std::runtime_error("Already have a sector named: " + sector.name);
-            }
-        }
+    // Enforce unique sector names for name-based lookup
+    if(sector_name_map_.count(sector.name) > 0) {
+        throw(std::runtime_error("Already have a sector named: " + sector.name));
     }
+    sector_name_map_[sector.name] = sectors_.size();
     sector_map_[sector.level] = sectors_.size();
     sectors_.push_back(sector);
 }
@@ -250,15 +260,19 @@ DetectorSector DetectorModel::GetSector(int heirarchy) const {
 }
 
 DetectorSector DetectorModel::GetSector(std::string const & name) const {
-    for (auto const & sector : sectors_) {
-        if (sector.name == name) return sector;
+    auto const iter = sector_name_map_.find(name);
+    if(iter == sector_name_map_.end()) {
+        throw(std::runtime_error("Sector not found: " + name));
     }
-    throw std::runtime_error("Sector not found: " + name);
+    unsigned int index = iter->second;
+    assert(index < sectors_.size());
+    return sectors_[index];
 }
 
 void DetectorModel::ClearSectors() {
     sectors_.clear();
     sector_map_.clear();
+    sector_name_map_.clear();
 }
 
 namespace {
@@ -584,6 +598,7 @@ void DetectorModel::LoadDefaultMaterials() {
 
 void DetectorModel::LoadDefaultSectors() {
     DetectorSector sector;
+    sector.name = "UNIVERSE";
     sector.material_id = materials_.GetMaterialId("VACUUM");
     sector.level = std::numeric_limits<int>::min();
     sector.geo = Sphere(std::numeric_limits<double>::infinity(), 0).create();

--- a/projects/detector/private/Path.cxx
+++ b/projects/detector/private/Path.cxx
@@ -832,6 +832,8 @@ bool Path::IsWithinBounds(DetectorPosition point) {
     if(set_det_points_) {
         double d0 = siren::math::scalar_product(direction_det_, first_point_det_ - point);
         double d1 = siren::math::scalar_product(direction_det_, last_point_det_ - point);
+        // avoid rounding errors for very small decay lengths; assume mm precision is fine
+        if((first_point_det_.get() - point).magnitude() < 1e-3) d0 = 0;
         return d0 <= 0 and d1 >= 0;
     } else if(set_points_ and set_detector_model_) {
         return IsWithinBounds(detector_model_->ToGeo(point));

--- a/projects/detector/private/Path.cxx
+++ b/projects/detector/private/Path.cxx
@@ -832,8 +832,11 @@ bool Path::IsWithinBounds(DetectorPosition point) {
     if(set_det_points_) {
         double d0 = siren::math::scalar_product(direction_det_, first_point_det_ - point);
         double d1 = siren::math::scalar_product(direction_det_, last_point_det_ - point);
-        // avoid rounding errors for very small decay lengths; assume mm precision is fine
-        if((first_point_det_.get() - point).magnitude() < 1e-3) d0 = 0;
+        // Avoid rounding errors for very short paths (e.g. decay lengths).
+        // When the point is within 1mm of either endpoint, treat it as on-boundary.
+        constexpr double kBoundsTolerance = 1e-3; // meters
+        if((first_point_det_ - point)->magnitude() < kBoundsTolerance) d0 = 0;
+        if((last_point_det_ - point)->magnitude() < kBoundsTolerance) d1 = 0;
         return d0 <= 0 and d1 >= 0;
     } else if(set_points_ and set_detector_model_) {
         return IsWithinBounds(detector_model_->ToGeo(point));

--- a/projects/detector/private/Path.cxx
+++ b/projects/detector/private/Path.cxx
@@ -832,11 +832,13 @@ bool Path::IsWithinBounds(DetectorPosition point) {
     if(set_det_points_) {
         double d0 = siren::math::scalar_product(direction_det_, first_point_det_ - point);
         double d1 = siren::math::scalar_product(direction_det_, last_point_det_ - point);
-        // Avoid rounding errors for very short paths (e.g. decay lengths).
-        // When the point is within 1mm of either endpoint, treat it as on-boundary.
+        // Tolerance on the projected distance along the path direction.
+        // Allows points that are within 1mm (in projection) of either
+        // endpoint to be treated as on-boundary, avoiding rounding errors
+        // for very short paths (e.g. sub-mm decay lengths).
         constexpr double kBoundsTolerance = 1e-3; // meters
-        if((first_point_det_ - point)->magnitude() < kBoundsTolerance) d0 = 0;
-        if((last_point_det_ - point)->magnitude() < kBoundsTolerance) d1 = 0;
+        if(d0 > 0 && d0 < kBoundsTolerance) d0 = 0;
+        if(d1 < 0 && d1 > -kBoundsTolerance) d1 = 0;
         return d0 <= 0 and d1 >= 0;
     } else if(set_points_ and set_detector_model_) {
         return IsWithinBounds(detector_model_->ToGeo(point));

--- a/projects/detector/private/pybindings/DetectorModel.h
+++ b/projects/detector/private/pybindings/DetectorModel.h
@@ -180,7 +180,14 @@ void register_DetectorModel(pybind11::module_ & m) {
         .def_property("DetectorOrigin", &DetectorModel::GetDetectorOrigin, &DetectorModel::SetDetectorOrigin)
         .def_property("DetectorRotation", &DetectorModel::GetDetectorRotation, &DetectorModel::SetDetectorRotation)
         .def("AddSector", &DetectorModel::AddSector)
-        .def("GetSector", &DetectorModel::GetSector)
+        .def("GetSector", (
+                    DetectorSector (DetectorModel::*)(
+                        int) const
+                    )(&DetectorModel::GetSector))
+        .def("GetSector", (
+                    DetectorSector (DetectorModel::*)(
+                        std::string) const
+                    )(&DetectorModel::GetSector))
         .def("ClearSectors", &DetectorModel::ClearSectors)
         .def("GetIntersections", (
                     siren::geometry::Geometry::IntersectionList (DetectorModel::*)(

--- a/projects/detector/private/pybindings/DetectorModel.h
+++ b/projects/detector/private/pybindings/DetectorModel.h
@@ -186,7 +186,7 @@ void register_DetectorModel(pybind11::module_ & m) {
                     )(&DetectorModel::GetSector))
         .def("GetSector", (
                     DetectorSector (DetectorModel::*)(
-                        std::string) const
+                        std::string const &) const
                     )(&DetectorModel::GetSector))
         .def("ClearSectors", &DetectorModel::ClearSectors)
         .def("GetIntersections", (

--- a/projects/detector/private/test/DetectorModel_TEST.cxx
+++ b/projects/detector/private/test/DetectorModel_TEST.cxx
@@ -1440,6 +1440,47 @@ TEST(GetSectorByName, MultipleSectors) {
     EXPECT_EQ(A.GetSector("Beta").level, 2);
 }
 
+TEST(GetSectorByName, DuplicateNameThrows) {
+    DetectorModel A;
+
+    DetectorSector s1;
+    s1.name = "MyDetector";
+    s1.material_id = 1;
+    s1.level = 1;
+    s1.geo = Sphere(Vector3D(0,0,0), 50.0, 0).create();
+    s1.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    A.AddSector(s1);
+
+    DetectorSector s2;
+    s2.name = "MyDetector";  // same name
+    s2.material_id = 2;
+    s2.level = 2;
+    s2.geo = Sphere(Vector3D(0,0,0), 100.0, 0).create();
+    s2.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    EXPECT_THROW(A.AddSector(s2), std::runtime_error);
+}
+
+TEST(GetSectorByName, EmptyNameAllowsDuplicates) {
+    // Empty-named sectors (like the default vacuum) should not trigger the check
+    DetectorModel A;
+
+    DetectorSector s1;
+    s1.name = "";
+    s1.material_id = 1;
+    s1.level = 1;
+    s1.geo = Sphere(Vector3D(0,0,0), 50.0, 0).create();
+    s1.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    EXPECT_NO_THROW(A.AddSector(s1));
+
+    DetectorSector s2;
+    s2.name = "";
+    s2.material_id = 2;
+    s2.level = 2;
+    s2.geo = Sphere(Vector3D(0,0,0), 100.0, 0).create();
+    s2.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    EXPECT_NO_THROW(A.AddSector(s2));
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/projects/detector/private/test/DetectorModel_TEST.cxx
+++ b/projects/detector/private/test/DetectorModel_TEST.cxx
@@ -1392,6 +1392,54 @@ TEST_F(FakeDetectorModelTest, FileLoad)
     }
 }
 
+// ---------------------------------------------------------------------------
+// GetSector by name
+// ---------------------------------------------------------------------------
+
+TEST(GetSectorByName, Found) {
+    DetectorModel A;
+    DetectorSector sector;
+    sector.name = "InnerDetector";
+    sector.material_id = 1;
+    sector.level = 1;
+    sector.geo = Sphere(Vector3D(0,0,0), 100.0, 0).create();
+    sector.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    A.AddSector(sector);
+
+    DetectorSector result = A.GetSector("InnerDetector");
+    EXPECT_EQ(result.name, "InnerDetector");
+    EXPECT_EQ(result.material_id, 1);
+    EXPECT_EQ(result.level, 1);
+}
+
+TEST(GetSectorByName, NotFoundThrows) {
+    DetectorModel A;
+    EXPECT_THROW(A.GetSector("NonexistentSector"), std::runtime_error);
+}
+
+TEST(GetSectorByName, MultipleSectors) {
+    DetectorModel A;
+
+    DetectorSector s1;
+    s1.name = "Alpha";
+    s1.material_id = 1;
+    s1.level = 1;
+    s1.geo = Sphere(Vector3D(0,0,0), 50.0, 0).create();
+    s1.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    A.AddSector(s1);
+
+    DetectorSector s2;
+    s2.name = "Beta";
+    s2.material_id = 2;
+    s2.level = 2;
+    s2.geo = Sphere(Vector3D(0,0,0), 100.0, 0).create();
+    s2.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
+    A.AddSector(s2);
+
+    EXPECT_EQ(A.GetSector("Alpha").level, 1);
+    EXPECT_EQ(A.GetSector("Beta").level, 2);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/projects/detector/private/test/DetectorModel_TEST.cxx
+++ b/projects/detector/private/test/DetectorModel_TEST.cxx
@@ -1460,20 +1460,29 @@ TEST(GetSectorByName, DuplicateNameThrows) {
     EXPECT_THROW(A.AddSector(s2), std::runtime_error);
 }
 
-TEST(GetSectorByName, EmptyNameAllowsDuplicates) {
-    // Empty-named sectors (like the default vacuum) should not trigger the check
+TEST(GetSectorByName, DefaultSectorNamedUniverse) {
+    DetectorModel A;
+    DetectorSector sector = A.GetSector("UNIVERSE");
+    EXPECT_EQ(sector.name, "UNIVERSE");
+    EXPECT_EQ(std::numeric_limits<int>::min(), sector.level);
+}
+
+TEST(GetSectorByName, ClearSectorsAllowsReuse) {
     DetectorModel A;
 
     DetectorSector s1;
-    s1.name = "";
+    s1.name = "TestSector";
     s1.material_id = 1;
     s1.level = 1;
     s1.geo = Sphere(Vector3D(0,0,0), 50.0, 0).create();
     s1.density = DensityDistribution1D<CartesianAxis1D,ConstantDistribution1D>().create();
-    EXPECT_NO_THROW(A.AddSector(s1));
+    A.AddSector(s1);
 
+    A.ClearSectors();
+
+    // After clear, the same name can be reused
     DetectorSector s2;
-    s2.name = "";
+    s2.name = "TestSector";
     s2.material_id = 2;
     s2.level = 2;
     s2.geo = Sphere(Vector3D(0,0,0), 100.0, 0).create();

--- a/projects/detector/private/test/FakeDetectorModel.h
+++ b/projects/detector/private/test/FakeDetectorModel.h
@@ -414,7 +414,7 @@ protected:
     }
 
     std::string random_name() {
-        unsigned int n_chars = RandomDouble()*46 + 1;
+        unsigned int n_chars = RandomDouble()*46 + 6;
         std::stringstream s;
         for(unsigned int i=0; i<n_chars; ++i)
             s << name_char_set[(unsigned int)(RandomDouble()*name_char_set.size())];
@@ -595,7 +595,7 @@ protected:
     }
 
     std::string random_name() {
-        unsigned int n_chars = RandomDouble()*46 + 1;
+        unsigned int n_chars = RandomDouble()*46 + 6;
         std::stringstream s;
         for(unsigned int i=0; i<n_chars; ++i)
             s << name_char_set[(unsigned int)(RandomDouble()*name_char_set.size())];

--- a/projects/detector/private/test/Path_TEST.cxx
+++ b/projects/detector/private/test/Path_TEST.cxx
@@ -2019,7 +2019,60 @@ TEST_F(FakeLegacyDetectorModelTest, GetDistanceFromEndInReverse)
 }
 
 
-// TEST()
+// ---------------------------------------------------------------------------
+// IsWithinBounds tolerance for short paths
+// ---------------------------------------------------------------------------
+
+TEST(IsWithinBounds, PointAtStart) {
+    // A path from (0,0,0) to (0,0,1) along z-axis.
+    // A point exactly at the start should be within bounds.
+    std::shared_ptr<const DetectorModel> model(new DetectorModel());
+    Vector3D start(0, 0, 0);
+    Vector3D end(0, 0, 1);
+    Path path(model, DetectorPosition(start), DetectorPosition(end));
+    EXPECT_TRUE(path.IsWithinBounds(DetectorPosition(start)));
+}
+
+TEST(IsWithinBounds, PointAtEnd) {
+    std::shared_ptr<const DetectorModel> model(new DetectorModel());
+    Vector3D start(0, 0, 0);
+    Vector3D end(0, 0, 1);
+    Path path(model, DetectorPosition(start), DetectorPosition(end));
+    EXPECT_TRUE(path.IsWithinBounds(DetectorPosition(end)));
+}
+
+TEST(IsWithinBounds, ShortPathPointAtStart) {
+    // Very short path (1e-6 m = 1 micron), simulating a short decay length.
+    // The point at the start should be within bounds despite rounding.
+    std::shared_ptr<const DetectorModel> model(new DetectorModel());
+    Vector3D start(100.0, 200.0, 300.0);
+    Vector3D dir(0, 0, 1);
+    double distance = 1e-6;  // 1 micron
+    Vector3D end = start + distance * dir;
+    Path path(model, DetectorPosition(start), DetectorPosition(end));
+    EXPECT_TRUE(path.IsWithinBounds(DetectorPosition(start)));
+}
+
+TEST(IsWithinBounds, ShortPathPointAtEnd) {
+    std::shared_ptr<const DetectorModel> model(new DetectorModel());
+    Vector3D start(100.0, 200.0, 300.0);
+    Vector3D dir(0, 0, 1);
+    double distance = 1e-6;
+    Vector3D end = start + distance * dir;
+    Path path(model, DetectorPosition(start), DetectorPosition(end));
+    EXPECT_TRUE(path.IsWithinBounds(DetectorPosition(end)));
+}
+
+TEST(IsWithinBounds, PointOutside) {
+    std::shared_ptr<const DetectorModel> model(new DetectorModel());
+    Vector3D start(0, 0, 0);
+    Vector3D end(0, 0, 1);
+    Path path(model, DetectorPosition(start), DetectorPosition(end));
+    // Point behind the start
+    EXPECT_FALSE(path.IsWithinBounds(DetectorPosition(Vector3D(0, 0, -0.1))));
+    // Point beyond the end
+    EXPECT_FALSE(path.IsWithinBounds(DetectorPosition(Vector3D(0, 0, 1.1))));
+}
 
 int main(int argc, char** argv)
 {

--- a/projects/detector/public/SIREN/detector/DetectorModel.h
+++ b/projects/detector/public/SIREN/detector/DetectorModel.h
@@ -260,6 +260,7 @@ public:
 
     void AddSector(DetectorSector sector);
     DetectorSector GetSector(int level) const;
+    DetectorSector GetSector(std::string name) const;
 
     void ClearSectors();
 

--- a/projects/detector/public/SIREN/detector/DetectorModel.h
+++ b/projects/detector/public/SIREN/detector/DetectorModel.h
@@ -68,6 +68,7 @@ friend siren::detector::Path;
     MaterialModel materials_;
     std::vector<DetectorSector> sectors_;
     std::map<int, unsigned int> sector_map_;
+    std::map<std::string, unsigned int> sector_name_map_;
     math::Vector3D detector_origin_;
     math::Quaternion detector_rotation_;
 public:
@@ -84,6 +85,7 @@ public:
             archive(cereal::make_nvp("MaterialModel", materials_));
             archive(cereal::make_nvp("Sectors", sectors_));
             archive(cereal::make_nvp("SectorMap", sector_map_));
+            archive(cereal::make_nvp("SectorNameMap", sector_name_map_));
             archive(cereal::make_nvp("DetectorOrigin", detector_origin_));
         } else {
             throw std::runtime_error("DetectorModel only supports version <= 0!");

--- a/projects/detector/public/SIREN/detector/DetectorModel.h
+++ b/projects/detector/public/SIREN/detector/DetectorModel.h
@@ -260,7 +260,7 @@ public:
 
     void AddSector(DetectorSector sector);
     DetectorSector GetSector(int level) const;
-    DetectorSector GetSector(std::string name) const;
+    DetectorSector GetSector(std::string const & name) const;
 
     void ClearSectors();
 

--- a/resources/detectors/CCM/CCM-v1/densities.dat
+++ b/resources/detectors/CCM/CCM-v1/densities.dat
@@ -55,8 +55,8 @@ object box       18.5 0 -0.5       0 0 0      1 5 3         det_steel_shielding 
 # Concrete shielding in front of detector (start with 2 m, suspect there is more)
 object box       20.0 0 -0.5       0 0 0      2 5 3         det_concrete_shielding CONCRETE  constant   2.4   
 # Concrete shielding on sides of detector (guess based on https://docdb.lns.mit.edu/cgi-bin/captainmills/ShowDocument?docid=292)
-object box       23.0  4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding CONCRETE  constant   2.4   
-object box       23.0 -4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding CONCRETE  constant   2.4   
+object box       23.0  4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding_2 CONCRETE  constant   2.4
+object box       23.0 -4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding_3 CONCRETE  constant   2.4
 
 #############################################
 # CCM Detector

--- a/resources/detectors/CCM/CCM-v2/densities.dat
+++ b/resources/detectors/CCM/CCM-v2/densities.dat
@@ -57,8 +57,8 @@ object box       18.5 0 -0.5       0 0 0      1 5 3         det_steel_shielding 
 # Concrete shielding in front of detector (start with 2 m, suspect there is more)
 object box       20.0 0 -0.5       0 0 0      2 5 3         det_concrete_shielding CONCRETE  constant   2.4
 # Concrete shielding on sides of detector (guess based on https://docdb.lns.mit.edu/cgi-bin/captainmills/ShowDocument?docid=292)
-object box       23.0  4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding CONCRETE  constant   2.4
-object box       23.0 -4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding CONCRETE  constant   2.4
+object box       23.0  4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding_2 CONCRETE  constant   2.4
+object box       23.0 -4.5 -0.5    0 0 0      4 1 3         det_concrete_shielding_3 CONCRETE  constant   2.4
 
 #############################################
 # CCM Detector

--- a/resources/detectors/ND280/ND280-v1/densities.dat
+++ b/resources/detectors/ND280/ND280-v1/densities.dat
@@ -32,148 +32,148 @@ object box      0 0 0    0 0 0      3.5 3.6 7.0      UA1_chamber_2       AIR    
 object box       0 0 -0.87725       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
 object box       0 0 -0.898875      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
 
-object box       0 0 -0.9205        0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -0.942125      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -0.9205        0 0 0      2.212 2.348 0.0045        lead_plate_2            LEAD                 constant   10.6
+object box       0 0 -0.942125      0 0 0      2.212 2.348 0.03875       pod_2                   SCINT                constant   1.05
 
-object box       0 0 -0.96375       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -0.985375      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -0.96375       0 0 0      2.212 2.348 0.0045        lead_plate_3            LEAD                 constant   10.6
+object box       0 0 -0.985375      0 0 0      2.212 2.348 0.03875       pod_3                   SCINT                constant   1.05
 
-object box       0 0 -1.007         0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -1.028625      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -1.007         0 0 0      2.212 2.348 0.0045        lead_plate_4            LEAD                 constant   10.6
+object box       0 0 -1.028625      0 0 0      2.212 2.348 0.03875       pod_4                   SCINT                constant   1.05
 
-object box       0 0 -1.05025       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -1.071875      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -1.05025       0 0 0      2.212 2.348 0.0045        lead_plate_5            LEAD                 constant   10.6
+object box       0 0 -1.071875      0 0 0      2.212 2.348 0.03875       pod_5                   SCINT                constant   1.05
 
-object box       0 0 -1.0935        0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -1.115125      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -1.0935        0 0 0      2.212 2.348 0.0045        lead_plate_6            LEAD                 constant   10.6
+object box       0 0 -1.115125      0 0 0      2.212 2.348 0.03875       pod_6                   SCINT                constant   1.05
 
-object box       0 0 -1.13675       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -1.158375      0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -1.13675       0 0 0      2.212 2.348 0.0045        lead_plate_7            LEAD                 constant   10.6
+object box       0 0 -1.158375      0 0 0      2.212 2.348 0.03875       pod_7                   SCINT                constant   1.05
 
 # 25 layers of water targets (pod + water + brass)
 
 object box       0 0 -1.191750      0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
 object box       0 0 -1.206390      0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.226405      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.226405      0 0 0      2.212 2.348 0.03875        pod_8                   SCINT               constant   1.05
 
-object box       0 0 -1.25978       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.274420      0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.294435      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.25978       0 0 0      2.212 2.348 0.028          water_bag_2             WATER               constant   1
+object box       0 0 -1.274420      0 0 0      2.212 2.348 0.00128        brass_plate_2           BRASS               constant   8.73
+object box       0 0 -1.294435      0 0 0      2.212 2.348 0.03875        pod_9                   SCINT               constant   1.05
 
-object box       0 0 -1.32781       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.34245       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.362465      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.32781       0 0 0      2.212 2.348 0.028          water_bag_3             WATER               constant   1
+object box       0 0 -1.34245       0 0 0      2.212 2.348 0.00128        brass_plate_3           BRASS               constant   8.73
+object box       0 0 -1.362465      0 0 0      2.212 2.348 0.03875        pod_10                   SCINT               constant   1.05
 
-object box       0 0 -1.39584       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.41048       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.430495      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.39584       0 0 0      2.212 2.348 0.028          water_bag_4             WATER               constant   1
+object box       0 0 -1.41048       0 0 0      2.212 2.348 0.00128        brass_plate_4           BRASS               constant   8.73
+object box       0 0 -1.430495      0 0 0      2.212 2.348 0.03875        pod_11                   SCINT               constant   1.05
 
-object box       0 0 -1.46387       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.47851       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.498525      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.46387       0 0 0      2.212 2.348 0.028          water_bag_5             WATER               constant   1
+object box       0 0 -1.47851       0 0 0      2.212 2.348 0.00128        brass_plate_5           BRASS               constant   8.73
+object box       0 0 -1.498525      0 0 0      2.212 2.348 0.03875        pod_12                   SCINT               constant   1.05
 
-object box       0 0 -1.531900      0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.546540      0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.566555      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.531900      0 0 0      2.212 2.348 0.028          water_bag_6             WATER               constant   1
+object box       0 0 -1.546540      0 0 0      2.212 2.348 0.00128        brass_plate_6           BRASS               constant   8.73
+object box       0 0 -1.566555      0 0 0      2.212 2.348 0.03875        pod_13                   SCINT               constant   1.05
 
-object box       0 0 -1.599930      0 0 0       2.212 2.348 0.028         water_bag             WATER               constant   1
-object box       0 0 -1.614570      0 0 0       2.212 2.348 0.00128       brass_plate           BRASS               constant   8.73
-object box       0 0 -1.634585      0 0 0       2.212 2.348 0.03875       pod                   SCINT               constant   1.05
+object box       0 0 -1.599930      0 0 0       2.212 2.348 0.028         water_bag_7             WATER               constant   1
+object box       0 0 -1.614570      0 0 0       2.212 2.348 0.00128       brass_plate_7           BRASS               constant   8.73
+object box       0 0 -1.634585      0 0 0       2.212 2.348 0.03875       pod_14                   SCINT               constant   1.05
 
-object box       0 0 -1.667960      0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.682600      0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.702615      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.667960      0 0 0      2.212 2.348 0.028          water_bag_8             WATER               constant   1
+object box       0 0 -1.682600      0 0 0      2.212 2.348 0.00128        brass_plate_8           BRASS               constant   8.73
+object box       0 0 -1.702615      0 0 0      2.212 2.348 0.03875        pod_15                   SCINT               constant   1.05
 
-object box       0 0 -1.73599       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.75063       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.770645      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.73599       0 0 0      2.212 2.348 0.028          water_bag_9             WATER               constant   1
+object box       0 0 -1.75063       0 0 0      2.212 2.348 0.00128        brass_plate_9           BRASS               constant   8.73
+object box       0 0 -1.770645      0 0 0      2.212 2.348 0.03875        pod_16                   SCINT               constant   1.05
 
-object box       0 0 -1.80402       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.81866       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.838675      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.80402       0 0 0      2.212 2.348 0.028          water_bag_10             WATER               constant   1
+object box       0 0 -1.81866       0 0 0      2.212 2.348 0.00128        brass_plate_10           BRASS               constant   8.73
+object box       0 0 -1.838675      0 0 0      2.212 2.348 0.03875        pod_17                   SCINT               constant   1.05
 
-object box       0 0 -1.87205       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.88669       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.906705      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.87205       0 0 0      2.212 2.348 0.028          water_bag_11             WATER               constant   1
+object box       0 0 -1.88669       0 0 0      2.212 2.348 0.00128        brass_plate_11           BRASS               constant   8.73
+object box       0 0 -1.906705      0 0 0      2.212 2.348 0.03875        pod_18                   SCINT               constant   1.05
 
-object box       0 0 -1.94008       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -1.95472       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -1.974735      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -1.94008       0 0 0      2.212 2.348 0.028          water_bag_12             WATER               constant   1
+object box       0 0 -1.95472       0 0 0      2.212 2.348 0.00128        brass_plate_12           BRASS               constant   8.73
+object box       0 0 -1.974735      0 0 0      2.212 2.348 0.03875        pod_19                   SCINT               constant   1.05
 
-object box       0 0 -2.00811       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.02275       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.042765      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.00811       0 0 0      2.212 2.348 0.028          water_bag_13             WATER               constant   1
+object box       0 0 -2.02275       0 0 0      2.212 2.348 0.00128        brass_plate_13           BRASS               constant   8.73
+object box       0 0 -2.042765      0 0 0      2.212 2.348 0.03875        pod_20                   SCINT               constant   1.05
 
-object box       0 0 -2.07614       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.09078       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.110795      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.07614       0 0 0      2.212 2.348 0.028          water_bag_14             WATER               constant   1
+object box       0 0 -2.09078       0 0 0      2.212 2.348 0.00128        brass_plate_14           BRASS               constant   8.73
+object box       0 0 -2.110795      0 0 0      2.212 2.348 0.03875        pod_21                   SCINT               constant   1.05
 
-object box       0 0 -2.14417       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.15881       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.178825      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.14417       0 0 0      2.212 2.348 0.028          water_bag_15             WATER               constant   1
+object box       0 0 -2.15881       0 0 0      2.212 2.348 0.00128        brass_plate_15           BRASS               constant   8.73
+object box       0 0 -2.178825      0 0 0      2.212 2.348 0.03875        pod_22                   SCINT               constant   1.05
 
-object box       0 0 -2.2122        0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.22684       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.246855      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.2122        0 0 0      2.212 2.348 0.028          water_bag_16             WATER               constant   1
+object box       0 0 -2.22684       0 0 0      2.212 2.348 0.00128        brass_plate_16           BRASS               constant   8.73
+object box       0 0 -2.246855      0 0 0      2.212 2.348 0.03875        pod_23                   SCINT               constant   1.05
 
-object box       0 0 -2.28023       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.29487       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.314885      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.28023       0 0 0      2.212 2.348 0.028          water_bag_17             WATER               constant   1
+object box       0 0 -2.29487       0 0 0      2.212 2.348 0.00128        brass_plate_17           BRASS               constant   8.73
+object box       0 0 -2.314885      0 0 0      2.212 2.348 0.03875        pod_24                   SCINT               constant   1.05
 
-object box       0 0 -2.34826       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.3629        0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.382915      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.34826       0 0 0      2.212 2.348 0.028          water_bag_18             WATER               constant   1
+object box       0 0 -2.3629        0 0 0      2.212 2.348 0.00128        brass_plate_18           BRASS               constant   8.73
+object box       0 0 -2.382915      0 0 0      2.212 2.348 0.03875        pod_25                   SCINT               constant   1.05
 
-object box       0 0 -2.41629       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.43093       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.450945      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.41629       0 0 0      2.212 2.348 0.028          water_bag_19             WATER               constant   1
+object box       0 0 -2.43093       0 0 0      2.212 2.348 0.00128        brass_plate_19           BRASS               constant   8.73
+object box       0 0 -2.450945      0 0 0      2.212 2.348 0.03875        pod_26                   SCINT               constant   1.05
 
-object box       0 0 -2.484320      0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.498960      0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.518975      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.484320      0 0 0      2.212 2.348 0.028          water_bag_20             WATER               constant   1
+object box       0 0 -2.498960      0 0 0      2.212 2.348 0.00128        brass_plate_20           BRASS               constant   8.73
+object box       0 0 -2.518975      0 0 0      2.212 2.348 0.03875        pod_27                   SCINT               constant   1.05
 
-object box       0 0 -2.55235       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.56699       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.587005      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.55235       0 0 0      2.212 2.348 0.028          water_bag_21             WATER               constant   1
+object box       0 0 -2.56699       0 0 0      2.212 2.348 0.00128        brass_plate_21           BRASS               constant   8.73
+object box       0 0 -2.587005      0 0 0      2.212 2.348 0.03875        pod_28                   SCINT               constant   1.05
 
-object box       0 0 -2.62038       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.63502       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.655035      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.62038       0 0 0      2.212 2.348 0.028          water_bag_22             WATER               constant   1
+object box       0 0 -2.63502       0 0 0      2.212 2.348 0.00128        brass_plate_22           BRASS               constant   8.73
+object box       0 0 -2.655035      0 0 0      2.212 2.348 0.03875        pod_29                   SCINT               constant   1.05
 
-object box       0 0 -2.68841       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.70305       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.723065      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.68841       0 0 0      2.212 2.348 0.028          water_bag_23             WATER               constant   1
+object box       0 0 -2.70305       0 0 0      2.212 2.348 0.00128        brass_plate_23           BRASS               constant   8.73
+object box       0 0 -2.723065      0 0 0      2.212 2.348 0.03875        pod_30                   SCINT               constant   1.05
 
-object box       0 0 -2.75644       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.77108       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.791095      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.75644       0 0 0      2.212 2.348 0.028          water_bag_24             WATER               constant   1
+object box       0 0 -2.77108       0 0 0      2.212 2.348 0.00128        brass_plate_24           BRASS               constant   8.73
+object box       0 0 -2.791095      0 0 0      2.212 2.348 0.03875        pod_31                   SCINT               constant   1.05
 
-object box       0 0 -2.82447       0 0 0      2.212 2.348 0.028          water_bag             WATER               constant   1
-object box       0 0 -2.83911       0 0 0      2.212 2.348 0.00128        brass_plate           BRASS               constant   8.73
-object box       0 0 -2.859125      0 0 0      2.212 2.348 0.03875        pod                   SCINT               constant   1.05
+object box       0 0 -2.82447       0 0 0      2.212 2.348 0.028          water_bag_25             WATER               constant   1
+object box       0 0 -2.83911       0 0 0      2.212 2.348 0.00128        brass_plate_25           BRASS               constant   8.73
+object box       0 0 -2.859125      0 0 0      2.212 2.348 0.03875        pod_32                   SCINT               constant   1.05
 
 # 7 layers in upstream ECAL
 
-object box       0 0 -2.88075       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -2.90238       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -2.88075       0 0 0      2.212 2.348 0.0045        lead_plate_8            LEAD                 constant   10.6
+object box       0 0 -2.90238       0 0 0      2.212 2.348 0.03875       pod_33                   SCINT                constant   1.05
 
-object box       0 0 -2.924         0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -2.94563       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -2.924         0 0 0      2.212 2.348 0.0045        lead_plate_9            LEAD                 constant   10.6
+object box       0 0 -2.94563       0 0 0      2.212 2.348 0.03875       pod_34                   SCINT                constant   1.05
 
-object box       0 0 -2.96725       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -2.98888       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -2.96725       0 0 0      2.212 2.348 0.0045        lead_plate_10            LEAD                 constant   10.6
+object box       0 0 -2.98888       0 0 0      2.212 2.348 0.03875       pod_35                   SCINT                constant   1.05
 
-object box       0 0 -3.0105        0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -3.03213       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -3.0105        0 0 0      2.212 2.348 0.0045        lead_plate_11            LEAD                 constant   10.6
+object box       0 0 -3.03213       0 0 0      2.212 2.348 0.03875       pod_36                   SCINT                constant   1.05
 
-object box       0 0 -3.05375       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -3.07538       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -3.05375       0 0 0      2.212 2.348 0.0045        lead_plate_12            LEAD                 constant   10.6
+object box       0 0 -3.07538       0 0 0      2.212 2.348 0.03875       pod_37                   SCINT                constant   1.05
 
-object box       0 0 -3.097         0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -3.11863       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -3.097         0 0 0      2.212 2.348 0.0045        lead_plate_13            LEAD                 constant   10.6
+object box       0 0 -3.11863       0 0 0      2.212 2.348 0.03875       pod_38                   SCINT                constant   1.05
 
-object box       0 0 -3.14025       0 0 0      2.212 2.348 0.0045        lead_plate            LEAD                 constant   10.6
-object box       0 0 -3.16188       0 0 0      2.212 2.348 0.03875       pod                   SCINT                constant   1.05
+object box       0 0 -3.14025       0 0 0      2.212 2.348 0.0045        lead_plate_14            LEAD                 constant   10.6
+object box       0 0 -3.16188       0 0 0      2.212 2.348 0.03875       pod_39                   SCINT                constant   1.05
 
 
 
@@ -184,11 +184,11 @@ object box       0 0 -3.16188       0 0 0      2.212 2.348 0.03875       pod    
 object box       0 0 -0.375    0 0 0      2.5 2.5 1.0        old_TPC_shell       old_TPC_padding      constant   0.685   
 object box       0 0 -0.375    0 0 0      2.47 2.47 0.97     new_TPC_gas         GAS                  constant   0.001855   
 
-object box       0 0 0.99    0 0 0      2.5 2.5 1.0        old_TPC_shell         old_TPC_padding      constant   0.685   
-object box       0 0 0.99    0 0 0      2.47 2.47 0.97     new_TPC_gas           GAS                  constant   0.001855   
+object box       0 0 0.99    0 0 0      2.5 2.5 1.0        old_TPC_shell_2         old_TPC_padding      constant   0.685
+object box       0 0 0.99    0 0 0      2.47 2.47 0.97     new_TPC_gas_2           GAS                  constant   0.001855
 
-object box       0 0 2.355    0 0 0      2.5 2.5 1.0        old_TPC_shell       old_TPC_padding      constant   0.685   
-object box       0 0 2.355    0 0 0      2.47 2.47 0.97     new_TPC_gas         GAS                  constant   0.001855   
+object box       0 0 2.355    0 0 0      2.5 2.5 1.0        old_TPC_shell_3       old_TPC_padding      constant   0.685
+object box       0 0 2.355    0 0 0      2.47 2.47 0.97     new_TPC_gas_3         GAS                  constant   0.001855
 
 # 2x FGD
 object box       0 0 0.3075    0 0 0      2.300 2.400 0.365     FGDXYBox           FGDbox      constant   0.06     # XY MODULE

--- a/resources/detectors/ND280UPGRD/ND280UPGRD-v1/densities.dat
+++ b/resources/detectors/ND280UPGRD/ND280UPGRD-v1/densities.dat
@@ -39,11 +39,11 @@ object box       0 0 -2.205    0 0 0     1.920 0.56 1.920     sFGD_cubes        
 
 # 6 new TOF
 object box       0 1.165 -2.205      0 0 0      2.3 0.01 2.3         TOF              TOF_scint     constant     1.023
-object box       0 -1.165 -2.205     0 0 0      2.3 0.01 2.3         TOF              TOF_scint     constant     1.023
-object box       1.195 0 -2.205      0 0 0      0.01 2.3 2.3         TOF              TOF_scint     constant     1.023
-object box       -1.195 0 -2.205     0 0 0      0.01 2.3 2.3         TOF              TOF_scint     constant     1.023
-object box       0 0 -3.26           0 0 0      2.3 2.3 0.01         TOF              TOF_scint     constant     1.023
-object box       0 0 -1.17           0 0 0      2.3 2.3 0.01         TOF              TOF_scint     constant     1.023
+object box       0 -1.165 -2.205     0 0 0      2.3 0.01 2.3         TOF_2              TOF_scint     constant     1.023
+object box       1.195 0 -2.205      0 0 0      0.01 2.3 2.3         TOF_3              TOF_scint     constant     1.023
+object box       -1.195 0 -2.205     0 0 0      0.01 2.3 2.3         TOF_4              TOF_scint     constant     1.023
+object box       0 0 -3.26           0 0 0      2.3 2.3 0.01         TOF_5              TOF_scint     constant     1.023
+object box       0 0 -1.17           0 0 0      2.3 2.3 0.01         TOF_6              TOF_scint     constant     1.023
 
 #        OLD MODULES       
 #  4x ECAL, 3x TPC, 2x FGD 
@@ -52,11 +52,11 @@ object box       0 0 -1.17           0 0 0      2.3 2.3 0.01         TOF        
 object box       0 0 -0.375    0 0 0      2.5 2.5 1.0        old_TPC_shell       old_TPC_padding      constant   0.685   
 object box       0 0 -0.375    0 0 0      2.47 2.47 0.97     new_TPC_gas         GAS                  constant   1.855   
 
-object box       0 0 0.99    0 0 0      2.5 2.5 1.0        old_TPC_shell         old_TPC_padding      constant   0.685   
-object box       0 0 0.99    0 0 0      2.47 2.47 0.97     new_TPC_gas           GAS                  constant   1.855   
+object box       0 0 0.99    0 0 0      2.5 2.5 1.0        old_TPC_shell_2         old_TPC_padding      constant   0.685
+object box       0 0 0.99    0 0 0      2.47 2.47 0.97     new_TPC_gas_2           GAS                  constant   1.855
 
-object box       0 0 2.355    0 0 0      2.5 2.5 1.0        old_TPC_shell       old_TPC_padding      constant   0.685   
-object box       0 0 2.355    0 0 0      2.47 2.47 0.97     new_TPC_gas         GAS                  constant   1.855   
+object box       0 0 2.355    0 0 0      2.5 2.5 1.0        old_TPC_shell_3       old_TPC_padding      constant   0.685
+object box       0 0 2.355    0 0 0      2.47 2.47 0.97     new_TPC_gas_3         GAS                  constant   1.855
 
 # 4x ECAL
 object box       0 0 -3.5       0 0 0      2.04 2.04 0.5     ECAL_Upstream          SCINT      constant   1.05   # Upstream


### PR DESCRIPTION
## Stack: PR 8 of 13

This PR is part of a 13-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/2d-flux-tables`
- **Head:** `feat/detector-sector-by-name`

Merge order: `feat/2d-flux-tables` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - projects/detector/private/DetectorModel.cxx
  - projects/detector/private/Path.cxx
  - projects/detector/private/pybindings/DetectorModel.h
  - projects/detector/public/SIREN/detector/DetectorModel.h

Source commits on dev/HNL_DIS_clean that contributed:
  521695f3 (Nicholas Kamp): fix issues with 2D tabular integral calculation, sampling errors with very short decay lengths, DarkNews errors, and kinematic erros in Dipole portal HNL DIS
  c4b1ec0d (Nicholas Kamp): add fiducial volume to LG and enable querying of detector sectors by name
  f6f8b46e (Nicholas Kamp): get the decay sampling working


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
- This PR replaces an earlier copy that was opened from a different account; closed PRs in the project history are intentional duplicates.

## Notes from Nick

- This PR allows the user to query individual sectors of the detector model by name
- It also adds some checks to avoid runtime errors in DetectorModel that happen when only decays are available. an attempt was made to do a smart numerical precision check with estimateDotError, but it turned out it fail in some cases and so hard-coded thresholds were taken in the end 