### PR TITLE
Patch broken DarkNews ModelContainer

### DIFF
--- a/python/SIREN_DarkNews.py
+++ b/python/SIREN_DarkNews.py
@@ -6,7 +6,6 @@ import json
 import ntpath
 import pickle
 import functools
-import logging
 from scipy.interpolate import LinearNDInterpolator,PchipInterpolator
 
 # SIREN methods
@@ -70,7 +69,7 @@ class PyDarkNewsInteractionCollection:
         else:
             try:
                 os.makedirs(self.table_dir, exist_ok=False)
-                print("Directory '%s' created successfully" % self.table_dir)
+                #print("Directory '%s' created successfully" % self.table_dir)
             except OSError as error:
                 print("Directory '%s' cannot be created" % self.table_dir)
                 exit(0)
@@ -667,6 +666,7 @@ class PyDarkNewsDecay(DarkNewsDecay):
 
         # Some variables for storing the decay phase space integrator
         self.decay_integrator = None
+        self.decay_dict = None
         self.decay_norm = None
         self.PS_samples = None
         self.PS_weights = None
@@ -700,6 +700,7 @@ class PyDarkNewsDecay(DarkNewsDecay):
     # serialization method
     def get_representation(self):
         return {"decay_integrator":self.decay_integrator,
+                "decay_dict":self.decay_dict,
                 "decay_norm":self.decay_norm,
                 "dec_case":self.dec_case,
                 "PS_samples":self.PS_samples,
@@ -714,7 +715,7 @@ class PyDarkNewsDecay(DarkNewsDecay):
         int_file = os.path.join(self.table_dir, "decay_integrator.pkl")
         if os.path.isfile(int_file):
             with open(int_file, "rb") as ifile:
-                _, self.decay_integrator = pickle.load(ifile)
+                self.decay_dict, self.decay_integrator = pickle.load(ifile)
         # Try to find the normalization information
         norm_file = os.path.join(self.table_dir, "decay_norm.json")
         if os.path.isfile(norm_file):
@@ -830,7 +831,7 @@ class PyDarkNewsDecay(DarkNewsDecay):
                     self.SetIntegratorAndNorm()
                 else:
                     self.total_width = (
-                        self.decay_integrator["diff_decay_rate_0"].mean
+                        self.decay_dict["diff_decay_rate_0"].mean
                         * self.decay_norm["diff_decay_rate_0"]
                     )
             else:
@@ -853,8 +854,7 @@ class PyDarkNewsDecay(DarkNewsDecay):
             )
         ):
             return 0
-        ret = self.dec_case.total_width()
-        return ret
+        return self.TotalDecayWidth(record)
 
     def DensityVariables(self):
         if type(self.dec_case) == FermionSinglePhotonDecay:
@@ -912,7 +912,7 @@ class PyDarkNewsDecay(DarkNewsDecay):
         # Find the four-momenta associated with this point
         # Expand dims required to call DarkNews function on signle sample
         four_momenta = get_decay_momenta_from_vegas_samples(
-            np.expand_dims(PS, 0),
+            np.expand_dims(PS, 0).T,
             self.dec_case,
             np.expand_dims(np.array(record.primary_momentum), 0),
         )

--- a/python/SIREN_DarkNews.py
+++ b/python/SIREN_DarkNews.py
@@ -69,7 +69,6 @@ class PyDarkNewsInteractionCollection:
         else:
             try:
                 os.makedirs(self.table_dir, exist_ok=False)
-                #print("Directory '%s' created successfully" % self.table_dir)
             except OSError as error:
                 print("Directory '%s' cannot be created" % self.table_dir)
                 exit(0)


### PR DESCRIPTION
## Stack: PR 9 of 13

This PR is part of a 13-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/detector-sector-by-name`
- **Head:** `fix/darknews-modelcontainer`

Merge order: `feat/detector-sector-by-name` should land before this PR.

## Squashed contents

Squashed diff for paths:
  - python/SIREN_DarkNews.py

Source commits on dev/HNL_DIS_clean that contributed:
  521695f3 (Nicholas Kamp): fix issues with 2D tabular integral calculation, sampling errors with very short decay lengths, DarkNews errors, and kinematic erros in Dipole portal HNL DIS
  ac0ce244 (Nicholas Kamp): changes to facilitate hadronic and W/Z HNL decays
  f1831919 (Nicholas Kamp): more complex logic for adding darknews interactions, fix some errors in SIREN_DarkNews


## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
- This PR replaces an earlier copy that was opened from a different account; closed PRs in the project history are intentional duplicates.

## Notes from Nick
 
- This fixes some errors due to DarkNews changes that occurred in ModelContainer
