### PR TITLE
HNL 3-body decay sampling

### DIFF
--- a/projects/utilities/private/pybindings/utilities.cxx
+++ b/projects/utilities/private/pybindings/utilities.cxx
@@ -2,6 +2,7 @@
 #include <vector>
 
 #include "../../public/SIREN/utilities/Random.h"
+#include "../../public/SIREN/utilities/Constants.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/operators.h>
@@ -15,6 +16,127 @@ using namespace pybind11;
 
 PYBIND11_MODULE(utilities,m) {
   using namespace siren::utilities;
+
+  module Constants = m.def_submodule("Constants");
+  // geometry
+  Constants.attr("pi") = &Constants::pi;
+  Constants.attr("tau") = &Constants::tau;
+  Constants.attr("degrees") = &Constants::degrees;
+  // This is used since the user will enter a number in degrees, while the c trigonometric functions
+  // expect angles presented in radians.
+  Constants.attr("deg") = &Constants::deg;
+  Constants.attr("radian") = &Constants::radian;
+
+  // meter
+  Constants.attr("m") = &Constants::m;
+  Constants.attr("meter") = &Constants::meter;
+  Constants.attr("cm") = &Constants::cm;
+  Constants.attr("centimeter") = &Constants::centimeter;
+
+  // second is a billion to be consistent with IceCube code
+  Constants.attr("second") = &Constants::second;
+
+  // speed of light
+  Constants.attr("c") = &Constants::c;
+
+  // masses, GeV/c^2
+  Constants.attr("protonMass") = &Constants::protonMass;
+  Constants.attr("neutronMass") = &Constants::neutronMass;
+  Constants.attr("isoscalarMass") = &Constants::isoscalarMass;
+  Constants.attr("electronMass") = &Constants::electronMass;
+  Constants.attr("muonMass") = &Constants::muonMass;
+  Constants.attr("tauMass") = &Constants::tauMass;
+  Constants.attr("lambda0Mass") = &Constants::lambda0Mass;
+  Constants.attr("Pi0Mass") = &Constants::Pi0Mass;
+  Constants.attr("PiPlusMass") = &Constants::PiPlusMass;
+  Constants.attr("PiMinusMass") = &Constants::PiMinusMass;
+  Constants.attr("K0Mass") = &Constants::K0Mass;
+  Constants.attr("KPlusMass") = &Constants::KPlusMass;
+  Constants.attr("KMinusMass") = &Constants::KMinusMass;
+  Constants.attr("KPrime0Mass") = &Constants::KPrime0Mass;
+  Constants.attr("KPrimePlusMass") = &Constants::KPrimePlusMass;
+  Constants.attr("KPrimeMinusMass") = &Constants::KPrimeMinusMass;
+  Constants.attr("D0Mass") = &Constants::D0Mass;
+  Constants.attr("DPlusMass") = &Constants::DPlusMass;
+  Constants.attr("DMinusMass") = &Constants::DMinusMass;
+  Constants.attr("DsPlusMass") = &Constants::DsPlusMass;
+  Constants.attr("DsMinusMass") = &Constants::DsMinusMass;
+  Constants.attr("EtaMass") = &Constants::EtaMass;
+  Constants.attr("EtaPrimeMass") = &Constants::EtaPrimeMass;
+  Constants.attr("Rho0Mass") = &Constants::Rho0Mass;
+  Constants.attr("RhoPlusMass") = &Constants::RhoPlusMass;
+  Constants.attr("RhoMinusMass") = &Constants::RhoMinusMass;
+  Constants.attr("OmegaMass") = &Constants::OmegaMass;
+  Constants.attr("PhiMass") = &Constants::PhiMass;
+  Constants.attr("BPlusMass") = &Constants::BPlusMass;
+  Constants.attr("BMinusMass") = &Constants::BMinusMass;
+  Constants.attr("upMass") = &Constants::upMass;
+  Constants.attr("downMass") = &Constants::downMass;
+  Constants.attr("charmMass") = &Constants::charmMass;
+  Constants.attr("strangeMass") = &Constants::strangeMass;
+  Constants.attr("topMass") = &Constants::topMass;
+  Constants.attr("bottomMass") = &Constants::bottomMass;
+
+  // confusing units
+  // static const double second          = 1.523e15; // [eV^-1 sec^-1]
+  Constants.attr("s") = &Constants::s;
+  Constants.attr("tauLifeTime") = &Constants::tauLifeTime;
+  Constants.attr("MuonLifeTime") = &Constants::MuonLifeTime;
+
+  // GeV/c^2
+  Constants.attr("wMass") = &Constants::wMass;
+  Constants.attr("wWidth") = &Constants::wWidth;
+  Constants.attr("zMass") = &Constants::zMass;
+
+  Constants.attr("WBranchE") = &Constants::WBranchE;
+  Constants.attr("WBranchMuon") = &Constants::WBranchMuon;
+  Constants.attr("WBranchTau") = &Constants::WBranchTau;
+  Constants.attr("WBranchHadronic") = &Constants::WBranchHadronic;
+
+  Constants.attr("nuEMass") = &Constants::nuEMass;
+  Constants.attr("nuMuMass") = &Constants::nuMuMass;
+  Constants.attr("nuTauMass") = &Constants::nuTauMass;
+  /*
+  W boson - http://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
+  Z boson - http://pdg.lbl.gov/2018/listings/rpp2018-list-z-boson.pdf
+  */
+
+  // Unit Conversions
+
+  Constants.attr("elementaryCharge") = &Constants::elementaryCharge;
+
+  Constants.attr("GeV") = &Constants::GeV;
+  Constants.attr("EeV") = &Constants::EeV;
+  Constants.attr("PeV") = &Constants::PeV;
+  Constants.attr("TeV") = &Constants::TeV;
+  Constants.attr("MeV") = &Constants::MeV;
+  Constants.attr("keV") = &Constants::keV;
+  Constants.attr("eV") = &Constants::eV;
+  Constants.attr("Joule") = &Constants::Joule;
+
+  Constants.attr("GeV_per_amu") = &Constants::GeV_per_amu;
+  Constants.attr("invGeVsq_per_cmsq") = &Constants::invGeVsq_per_cmsq;
+
+
+  // may need to fix these after setting GeV to 1.0
+  Constants.attr("FermiConstant") = &Constants::FermiConstant;
+  Constants.attr("avogadro") = &Constants::avogadro;
+  Constants.attr("thetaWeinberg") = &Constants::thetaWeinberg;
+  Constants.attr("gravConstant") = &Constants::gravConstant;
+  Constants.attr("fineStructure") = &Constants::fineStructure;
+  Constants.attr("hbarc") = &Constants::hbarc;
+
+  // CKM matrix elements
+  // from https://pdg.lbl.gov/2020/reviews/rpp2020-rev-ckm-matrix.pdf
+  Constants.attr("Vud") = &Constants::Vud;
+  Constants.attr("Vcd") = &Constants::Vcd;
+  Constants.attr("Vtd") = &Constants::Vtd;
+  Constants.attr("Vus") = &Constants::Vus;
+  Constants.attr("Vcs") = &Constants::Vcs;
+  Constants.attr("Vts") = &Constants::Vts;
+  Constants.attr("Vub") = &Constants::Vub;
+  Constants.attr("Vcb") = &Constants::Vcb;
+  Constants.attr("Vtb") = &Constants::Vtb;
 
   class_<SIREN_random, std::shared_ptr<SIREN_random>>(m, "SIREN_random")
     .def(init<>())

--- a/projects/utilities/private/pybindings/utilities.cxx
+++ b/projects/utilities/private/pybindings/utilities.cxx
@@ -17,85 +17,85 @@ using namespace pybind11;
 PYBIND11_MODULE(utilities,m) {
   using namespace siren::utilities;
 
-  module Constants = m.def_submodule("Constants");
+  auto constants_mod = m.def_submodule("Constants");
   // geometry
-  Constants.attr("pi") = &Constants::pi;
-  Constants.attr("tau") = &Constants::tau;
-  Constants.attr("degrees") = &Constants::degrees;
+  constants_mod.attr("pi") = Constants::pi;
+  constants_mod.attr("tau") = Constants::tau;
+  constants_mod.attr("degrees") = Constants::degrees;
   // This is used since the user will enter a number in degrees, while the c trigonometric functions
   // expect angles presented in radians.
-  Constants.attr("deg") = &Constants::deg;
-  Constants.attr("radian") = &Constants::radian;
+  constants_mod.attr("deg") = Constants::deg;
+  constants_mod.attr("radian") = Constants::radian;
 
   // meter
-  Constants.attr("m") = &Constants::m;
-  Constants.attr("meter") = &Constants::meter;
-  Constants.attr("cm") = &Constants::cm;
-  Constants.attr("centimeter") = &Constants::centimeter;
+  constants_mod.attr("m") = Constants::m;
+  constants_mod.attr("meter") = Constants::meter;
+  constants_mod.attr("cm") = Constants::cm;
+  constants_mod.attr("centimeter") = Constants::centimeter;
 
   // second is a billion to be consistent with IceCube code
-  Constants.attr("second") = &Constants::second;
+  constants_mod.attr("second") = Constants::second;
 
   // speed of light
-  Constants.attr("c") = &Constants::c;
+  constants_mod.attr("c") = Constants::c;
 
   // masses, GeV/c^2
-  Constants.attr("protonMass") = &Constants::protonMass;
-  Constants.attr("neutronMass") = &Constants::neutronMass;
-  Constants.attr("isoscalarMass") = &Constants::isoscalarMass;
-  Constants.attr("electronMass") = &Constants::electronMass;
-  Constants.attr("muonMass") = &Constants::muonMass;
-  Constants.attr("tauMass") = &Constants::tauMass;
-  Constants.attr("lambda0Mass") = &Constants::lambda0Mass;
-  Constants.attr("Pi0Mass") = &Constants::Pi0Mass;
-  Constants.attr("PiPlusMass") = &Constants::PiPlusMass;
-  Constants.attr("PiMinusMass") = &Constants::PiMinusMass;
-  Constants.attr("K0Mass") = &Constants::K0Mass;
-  Constants.attr("KPlusMass") = &Constants::KPlusMass;
-  Constants.attr("KMinusMass") = &Constants::KMinusMass;
-  Constants.attr("KPrime0Mass") = &Constants::KPrime0Mass;
-  Constants.attr("KPrimePlusMass") = &Constants::KPrimePlusMass;
-  Constants.attr("KPrimeMinusMass") = &Constants::KPrimeMinusMass;
-  Constants.attr("D0Mass") = &Constants::D0Mass;
-  Constants.attr("DPlusMass") = &Constants::DPlusMass;
-  Constants.attr("DMinusMass") = &Constants::DMinusMass;
-  Constants.attr("DsPlusMass") = &Constants::DsPlusMass;
-  Constants.attr("DsMinusMass") = &Constants::DsMinusMass;
-  Constants.attr("EtaMass") = &Constants::EtaMass;
-  Constants.attr("EtaPrimeMass") = &Constants::EtaPrimeMass;
-  Constants.attr("Rho0Mass") = &Constants::Rho0Mass;
-  Constants.attr("RhoPlusMass") = &Constants::RhoPlusMass;
-  Constants.attr("RhoMinusMass") = &Constants::RhoMinusMass;
-  Constants.attr("OmegaMass") = &Constants::OmegaMass;
-  Constants.attr("PhiMass") = &Constants::PhiMass;
-  Constants.attr("BPlusMass") = &Constants::BPlusMass;
-  Constants.attr("BMinusMass") = &Constants::BMinusMass;
-  Constants.attr("upMass") = &Constants::upMass;
-  Constants.attr("downMass") = &Constants::downMass;
-  Constants.attr("charmMass") = &Constants::charmMass;
-  Constants.attr("strangeMass") = &Constants::strangeMass;
-  Constants.attr("topMass") = &Constants::topMass;
-  Constants.attr("bottomMass") = &Constants::bottomMass;
+  constants_mod.attr("protonMass") = Constants::protonMass;
+  constants_mod.attr("neutronMass") = Constants::neutronMass;
+  constants_mod.attr("isoscalarMass") = Constants::isoscalarMass;
+  constants_mod.attr("electronMass") = Constants::electronMass;
+  constants_mod.attr("muonMass") = Constants::muonMass;
+  constants_mod.attr("tauMass") = Constants::tauMass;
+  constants_mod.attr("lambda0Mass") = Constants::lambda0Mass;
+  constants_mod.attr("Pi0Mass") = Constants::Pi0Mass;
+  constants_mod.attr("PiPlusMass") = Constants::PiPlusMass;
+  constants_mod.attr("PiMinusMass") = Constants::PiMinusMass;
+  constants_mod.attr("K0Mass") = Constants::K0Mass;
+  constants_mod.attr("KPlusMass") = Constants::KPlusMass;
+  constants_mod.attr("KMinusMass") = Constants::KMinusMass;
+  constants_mod.attr("KPrime0Mass") = Constants::KPrime0Mass;
+  constants_mod.attr("KPrimePlusMass") = Constants::KPrimePlusMass;
+  constants_mod.attr("KPrimeMinusMass") = Constants::KPrimeMinusMass;
+  constants_mod.attr("D0Mass") = Constants::D0Mass;
+  constants_mod.attr("DPlusMass") = Constants::DPlusMass;
+  constants_mod.attr("DMinusMass") = Constants::DMinusMass;
+  constants_mod.attr("DsPlusMass") = Constants::DsPlusMass;
+  constants_mod.attr("DsMinusMass") = Constants::DsMinusMass;
+  constants_mod.attr("EtaMass") = Constants::EtaMass;
+  constants_mod.attr("EtaPrimeMass") = Constants::EtaPrimeMass;
+  constants_mod.attr("Rho0Mass") = Constants::Rho0Mass;
+  constants_mod.attr("RhoPlusMass") = Constants::RhoPlusMass;
+  constants_mod.attr("RhoMinusMass") = Constants::RhoMinusMass;
+  constants_mod.attr("OmegaMass") = Constants::OmegaMass;
+  constants_mod.attr("PhiMass") = Constants::PhiMass;
+  constants_mod.attr("BPlusMass") = Constants::BPlusMass;
+  constants_mod.attr("BMinusMass") = Constants::BMinusMass;
+  constants_mod.attr("upMass") = Constants::upMass;
+  constants_mod.attr("downMass") = Constants::downMass;
+  constants_mod.attr("charmMass") = Constants::charmMass;
+  constants_mod.attr("strangeMass") = Constants::strangeMass;
+  constants_mod.attr("topMass") = Constants::topMass;
+  constants_mod.attr("bottomMass") = Constants::bottomMass;
 
   // confusing units
   // static const double second          = 1.523e15; // [eV^-1 sec^-1]
-  Constants.attr("s") = &Constants::s;
-  Constants.attr("tauLifeTime") = &Constants::tauLifeTime;
-  Constants.attr("MuonLifeTime") = &Constants::MuonLifeTime;
+  constants_mod.attr("s") = Constants::s;
+  constants_mod.attr("tauLifeTime") = Constants::tauLifeTime;
+  constants_mod.attr("MuonLifeTime") = Constants::MuonLifeTime;
 
   // GeV/c^2
-  Constants.attr("wMass") = &Constants::wMass;
-  Constants.attr("wWidth") = &Constants::wWidth;
-  Constants.attr("zMass") = &Constants::zMass;
+  constants_mod.attr("wMass") = Constants::wMass;
+  constants_mod.attr("wWidth") = Constants::wWidth;
+  constants_mod.attr("zMass") = Constants::zMass;
 
-  Constants.attr("WBranchE") = &Constants::WBranchE;
-  Constants.attr("WBranchMuon") = &Constants::WBranchMuon;
-  Constants.attr("WBranchTau") = &Constants::WBranchTau;
-  Constants.attr("WBranchHadronic") = &Constants::WBranchHadronic;
+  constants_mod.attr("WBranchE") = Constants::WBranchE;
+  constants_mod.attr("WBranchMuon") = Constants::WBranchMuon;
+  constants_mod.attr("WBranchTau") = Constants::WBranchTau;
+  constants_mod.attr("WBranchHadronic") = Constants::WBranchHadronic;
 
-  Constants.attr("nuEMass") = &Constants::nuEMass;
-  Constants.attr("nuMuMass") = &Constants::nuMuMass;
-  Constants.attr("nuTauMass") = &Constants::nuTauMass;
+  constants_mod.attr("nuEMass") = Constants::nuEMass;
+  constants_mod.attr("nuMuMass") = Constants::nuMuMass;
+  constants_mod.attr("nuTauMass") = Constants::nuTauMass;
   /*
   W boson - http://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
   Z boson - http://pdg.lbl.gov/2018/listings/rpp2018-list-z-boson.pdf
@@ -103,40 +103,40 @@ PYBIND11_MODULE(utilities,m) {
 
   // Unit Conversions
 
-  Constants.attr("elementaryCharge") = &Constants::elementaryCharge;
+  constants_mod.attr("elementaryCharge") = Constants::elementaryCharge;
 
-  Constants.attr("GeV") = &Constants::GeV;
-  Constants.attr("EeV") = &Constants::EeV;
-  Constants.attr("PeV") = &Constants::PeV;
-  Constants.attr("TeV") = &Constants::TeV;
-  Constants.attr("MeV") = &Constants::MeV;
-  Constants.attr("keV") = &Constants::keV;
-  Constants.attr("eV") = &Constants::eV;
-  Constants.attr("Joule") = &Constants::Joule;
+  constants_mod.attr("GeV") = Constants::GeV;
+  constants_mod.attr("EeV") = Constants::EeV;
+  constants_mod.attr("PeV") = Constants::PeV;
+  constants_mod.attr("TeV") = Constants::TeV;
+  constants_mod.attr("MeV") = Constants::MeV;
+  constants_mod.attr("keV") = Constants::keV;
+  constants_mod.attr("eV") = Constants::eV;
+  constants_mod.attr("Joule") = Constants::Joule;
 
-  Constants.attr("GeV_per_amu") = &Constants::GeV_per_amu;
-  Constants.attr("invGeVsq_per_cmsq") = &Constants::invGeVsq_per_cmsq;
+  constants_mod.attr("GeV_per_amu") = Constants::GeV_per_amu;
+  constants_mod.attr("invGeVsq_per_cmsq") = Constants::invGeVsq_per_cmsq;
 
 
   // may need to fix these after setting GeV to 1.0
-  Constants.attr("FermiConstant") = &Constants::FermiConstant;
-  Constants.attr("avogadro") = &Constants::avogadro;
-  Constants.attr("thetaWeinberg") = &Constants::thetaWeinberg;
-  Constants.attr("gravConstant") = &Constants::gravConstant;
-  Constants.attr("fineStructure") = &Constants::fineStructure;
-  Constants.attr("hbarc") = &Constants::hbarc;
+  constants_mod.attr("FermiConstant") = Constants::FermiConstant;
+  constants_mod.attr("avogadro") = Constants::avogadro;
+  constants_mod.attr("thetaWeinberg") = Constants::thetaWeinberg;
+  constants_mod.attr("gravConstant") = Constants::gravConstant;
+  constants_mod.attr("fineStructure") = Constants::fineStructure;
+  constants_mod.attr("hbarc") = Constants::hbarc;
 
   // CKM matrix elements
   // from https://pdg.lbl.gov/2020/reviews/rpp2020-rev-ckm-matrix.pdf
-  Constants.attr("Vud") = &Constants::Vud;
-  Constants.attr("Vcd") = &Constants::Vcd;
-  Constants.attr("Vtd") = &Constants::Vtd;
-  Constants.attr("Vus") = &Constants::Vus;
-  Constants.attr("Vcs") = &Constants::Vcs;
-  Constants.attr("Vts") = &Constants::Vts;
-  Constants.attr("Vub") = &Constants::Vub;
-  Constants.attr("Vcb") = &Constants::Vcb;
-  Constants.attr("Vtb") = &Constants::Vtb;
+  constants_mod.attr("Vud") = Constants::Vud;
+  constants_mod.attr("Vcd") = Constants::Vcd;
+  constants_mod.attr("Vtd") = Constants::Vtd;
+  constants_mod.attr("Vus") = Constants::Vus;
+  constants_mod.attr("Vcs") = Constants::Vcs;
+  constants_mod.attr("Vts") = Constants::Vts;
+  constants_mod.attr("Vub") = Constants::Vub;
+  constants_mod.attr("Vcb") = Constants::Vcb;
+  constants_mod.attr("Vtb") = Constants::Vtb;
 
   class_<SIREN_random, std::shared_ptr<SIREN_random>>(m, "SIREN_random")
     .def(init<>())

--- a/projects/utilities/private/pybindings/utilities.cxx
+++ b/projects/utilities/private/pybindings/utilities.cxx
@@ -118,13 +118,13 @@ PYBIND11_MODULE(utilities,m) {
   constants_mod.attr("invGeVsq_per_cmsq") = Constants::invGeVsq_per_cmsq;
 
 
-  // may need to fix these after setting GeV to 1.0
   constants_mod.attr("FermiConstant") = Constants::FermiConstant;
   constants_mod.attr("avogadro") = Constants::avogadro;
   constants_mod.attr("thetaWeinberg") = Constants::thetaWeinberg;
   constants_mod.attr("gravConstant") = Constants::gravConstant;
   constants_mod.attr("fineStructure") = Constants::fineStructure;
   constants_mod.attr("hbarc") = Constants::hbarc;
+  constants_mod.attr("gweak") = Constants::gweak;
 
   // CKM matrix elements
   // from https://pdg.lbl.gov/2020/reviews/rpp2020-rev-ckm-matrix.pdf

--- a/tests/python/test_constants.py
+++ b/tests/python/test_constants.py
@@ -1,0 +1,76 @@
+"""Smoke tests for the Constants pybinding submodule."""
+import pytest
+
+siren = pytest.importorskip("siren")
+
+
+@pytest.fixture(scope="module")
+def Constants():
+    from siren.utilities import Constants
+    return Constants
+
+
+class TestConstantsBinding:
+    """Verify that the Constants submodule is importable and exposes all
+    expected attributes with reasonable values."""
+
+    def test_import(self):
+        from siren.utilities import Constants
+        assert Constants is not None
+
+    def test_mathematical_constants(self, Constants):
+        assert Constants.pi == pytest.approx(3.14159265358979, rel=1e-10)
+        assert Constants.tau == pytest.approx(2 * Constants.pi, rel=1e-14)
+        assert Constants.degrees == pytest.approx(Constants.pi / 180.0, rel=1e-14)
+
+    def test_particle_masses_positive(self, Constants):
+        for name in ("protonMass", "neutronMass", "electronMass",
+                     "muonMass", "tauMass", "wMass", "zMass"):
+            val = getattr(Constants, name)
+            assert val > 0, f"{name} should be positive, got {val}"
+
+    def test_proton_mass_value(self, Constants):
+        assert Constants.protonMass == pytest.approx(0.938272, rel=1e-4)
+
+    def test_electron_mass_value(self, Constants):
+        assert Constants.electronMass == pytest.approx(0.000511, rel=1e-2)
+
+    def test_fermi_constant_positive(self, Constants):
+        assert Constants.FermiConstant > 0
+
+    def test_speed_of_light(self, Constants):
+        assert Constants.c > 0
+
+    def test_unit_conversions(self, Constants):
+        # GeV is the base energy unit
+        assert Constants.GeV > 0
+        assert Constants.MeV == pytest.approx(Constants.GeV * 1e-3, rel=1e-10)
+        assert Constants.TeV == pytest.approx(Constants.GeV * 1e3, rel=1e-10)
+
+    def test_gweak_exposed(self, Constants):
+        assert hasattr(Constants, "gweak"), "gweak constant is missing from pybinding"
+        assert Constants.gweak == pytest.approx(0.64, rel=1e-6)
+
+    def test_ckm_elements_exposed(self, Constants):
+        """All nine CKM matrix elements should be bound."""
+        ckm_names = ("Vud", "Vus", "Vub",
+                     "Vcd", "Vcs", "Vcb",
+                     "Vtd", "Vts", "Vtb")
+        for name in ckm_names:
+            val = getattr(Constants, name, None)
+            assert val is not None, f"CKM element {name} is missing"
+            assert 0 < val <= 1, f"CKM element {name}={val} out of [0,1] range"
+
+    def test_ckm_unitarity_first_row(self, Constants):
+        """First row of CKM matrix should satisfy unitarity: sum |V|^2 ~ 1."""
+        row_sum = Constants.Vud**2 + Constants.Vus**2 + Constants.Vub**2
+        assert row_sum == pytest.approx(1.0, abs=0.01)
+
+    def test_weinberg_angle(self, Constants):
+        # sin^2(theta_W) ~ 0.231
+        assert 0.1 < Constants.thetaWeinberg < 0.4
+
+    def test_isoscalar_mass(self, Constants):
+        """isoscalarMass is used by processes.py at runtime; verify it exists."""
+        assert hasattr(Constants, "isoscalarMass")
+        assert Constants.isoscalarMass > 0


### PR DESCRIPTION
## Stack: PR 12 of 13

This PR is part of a 13-PR stack decomposing `dev/HNL_DIS` into reviewable chunks.

- **Base:** `feat/hnl-decays-hadronic-ew`
- **Head:** `feat/hnl-3body-sampling`

Merge order: `feat/hnl-decays-hadronic-ew` should land before this PR.

## What this PR actually does

Exposes the `Constants` namespace to Python via pybindings in `utilities.cxx`. Despite the branch name (`feat/hnl-3body-sampling`), `Sampling.h` was introduced in PR #123 (the base branch) during stack decomposition. This PR only touches `utilities.cxx`.

This also fixes a pre-existing runtime error: `resources/processes/HNLDISSplines/.../processes.py` imports `siren.utilities.Constants.isoscalarMass`, but the Constants pybinding did not exist on `main`.

## Changes

- `projects/utilities/private/pybindings/utilities.cxx`: Bind all constants from `Constants.h` to Python, including CKM matrix elements and `gweak`
- `tests/python/test_constants.py`: Smoke tests for the Constants submodule (import, value spot-checks, CKM unitarity, `gweak` presence)

## Squashed contents

Squashed diff for path:
  - projects/utilities/private/pybindings/utilities.cxx

Source commits on dev/HNL_DIS_clean that contributed:
  c6f922d5 (Nicholas Kamp): Add pybinding constants, fix bug in charged pseudoscalar decays

## Notes

- This branch is the squashed cumulative diff of the listed source commits. Per-commit history is browsable on `dev/HNL_DIS_clean`.
- Large `.fits` data files have been removed from the branch and are packaged separately.
- This PR replaces an earlier copy that was opened from a different account; closed PRs in the project history are intentional duplicates.