### PR TITLE
Fix weightable distribution typeid comparison

### DIFF
--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -71,6 +71,7 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/projects/distributions/public/"
 
 package_add_test(UnitTest_PrimaryDirectionDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/PrimaryDirectionDistribution_TEST.cxx)
 package_add_test(UnitTest_PrimaryEnergyDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/PrimaryEnergyDistribution_TEST.cxx)
+package_add_test(UnitTest_WeightableDistribution ${PROJECT_SOURCE_DIR}/projects/distributions/private/test/WeightableDistribution_TEST.cxx)
 
 pybind11_add_module(distributions ${PROJECT_SOURCE_DIR}/projects/distributions/private/pybindings/distributions.cxx)
 target_link_libraries(distributions PRIVATE SIREN)

--- a/projects/distributions/private/Distributions.cxx
+++ b/projects/distributions/private/Distributions.cxx
@@ -47,10 +47,10 @@ bool WeightableDistribution::operator==(WeightableDistribution const & distribut
 }
 
 bool WeightableDistribution::operator<(WeightableDistribution const & distribution) const {
-    if(typeid(this) == typeid(&distribution))
+    if(typeid(*this) == typeid(distribution))
         return this->less(distribution);
     else
-        return std::type_index(typeid(this)) < std::type_index(typeid(&distribution));
+        return std::type_index(typeid(*this)) < std::type_index(typeid(distribution));
 }
 
 bool WeightableDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {

--- a/projects/distributions/private/test/WeightableDistribution_TEST.cxx
+++ b/projects/distributions/private/test/WeightableDistribution_TEST.cxx
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "SIREN/distributions/Distributions.h"
+#include "SIREN/distributions/primary/energy/Monoenergetic.h"
+#include "SIREN/distributions/primary/energy/PowerLaw.h"
+#include "SIREN/distributions/primary/direction/IsotropicDirection.h"
+
+using namespace siren::distributions;
+
+TEST(WeightableDistribution, OperatorLessSameType) {
+    Monoenergetic a(10.0);
+    Monoenergetic b(20.0);
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+    EXPECT_FALSE(a < a);
+}
+
+TEST(WeightableDistribution, StrictWeakOrderingSameType) {
+    Monoenergetic a(10.0);
+    Monoenergetic b(20.0);
+    Monoenergetic c(30.0);
+    // Irreflexivity
+    EXPECT_FALSE(a < a);
+    // Asymmetry
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+    // Transitivity
+    EXPECT_TRUE(a < b);
+    EXPECT_TRUE(b < c);
+    EXPECT_TRUE(a < c);
+}
+
+TEST(WeightableDistribution, OperatorEqualSameType) {
+    Monoenergetic a(10.0);
+    Monoenergetic b(10.0);
+    Monoenergetic c(20.0);
+    EXPECT_TRUE(a == b);
+    EXPECT_FALSE(a == c);
+}
+
+TEST(WeightableDistribution, OperatorEqualDifferentTypes) {
+    Monoenergetic mono(10.0);
+    PowerLaw power(2.0, 1.0, 100.0);
+    IsotropicDirection iso;
+    EXPECT_FALSE(mono == power);
+    EXPECT_FALSE(mono == iso);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/projects/distributions/private/test/WeightableDistribution_TEST.cxx
+++ b/projects/distributions/private/test/WeightableDistribution_TEST.cxx
@@ -15,19 +15,22 @@ TEST(WeightableDistribution, OperatorLessSameType) {
     EXPECT_FALSE(a < a);
 }
 
-TEST(WeightableDistribution, StrictWeakOrderingSameType) {
-    Monoenergetic a(10.0);
-    Monoenergetic b(20.0);
-    Monoenergetic c(30.0);
-    // Irreflexivity
-    EXPECT_FALSE(a < a);
-    // Asymmetry
-    EXPECT_TRUE(a < b);
-    EXPECT_FALSE(b < a);
-    // Transitivity
-    EXPECT_TRUE(a < b);
-    EXPECT_TRUE(b < c);
-    EXPECT_TRUE(a < c);
+TEST(WeightableDistribution, OperatorLessDifferentTypes) {
+    Monoenergetic mono(10.0);
+    PowerLaw power(2.0, 1.0, 100.0);
+
+    bool result1 = mono < power;
+    bool result2 = power < mono;
+    EXPECT_NE(result1, result2);
+}
+
+TEST(WeightableDistribution, OperatorLessDifferentFamilies) {
+    Monoenergetic mono(10.0);
+    IsotropicDirection iso;
+
+    bool result1 = mono < iso;
+    bool result2 = iso < mono;
+    EXPECT_NE(result1, result2);
 }
 
 TEST(WeightableDistribution, OperatorEqualSameType) {
@@ -44,6 +47,17 @@ TEST(WeightableDistribution, OperatorEqualDifferentTypes) {
     IsotropicDirection iso;
     EXPECT_FALSE(mono == power);
     EXPECT_FALSE(mono == iso);
+}
+
+TEST(WeightableDistribution, StrictWeakOrdering) {
+    Monoenergetic a(10.0);
+    Monoenergetic b(20.0);
+    Monoenergetic c(30.0);
+    EXPECT_FALSE(a < a);
+    EXPECT_TRUE(a < b);
+    EXPECT_FALSE(b < a);
+    EXPECT_TRUE(b < c);
+    EXPECT_TRUE(a < c);
 }
 
 int main(int argc, char** argv) {

--- a/projects/distributions/public/SIREN/distributions/Distributions.h
+++ b/projects/distributions/public/SIREN/distributions/Distributions.h
@@ -96,7 +96,7 @@ public:
         }
     }
     bool operator==(WeightableDistribution const & distribution) const;
-    bool operator<(WeightableDistribution const & distribution) const;
+    virtual bool operator<(WeightableDistribution const & distribution) const;
     virtual bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const;
 protected:
     virtual bool equal(WeightableDistribution const & distribution) const = 0;


### PR DESCRIPTION
The typeid check used in `WeightableDistribution::operator<` needs to take an object reference and not a pointer to work.
Additionally llvm compiler optimizations cause problems with child class methods that can be resolved by making `WeightableDistribution::operator<` a virtual method.