### PR TITLE
CI: harden cfitsio download and use native ARM runners

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -88,18 +88,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         py: [cp38, cp39, cp310, cp311, cp312]
         image: [manylinux, musllinux]
         arch: [x86_64, aarch64]
+        include:
+          # Native runners per arch - aarch64 emulated under qemu was 13x
+          # slower (~80min vs ~6min), and GitHub now offers free arm64
+          # Linux runners for public repos.
+          - arch: x86_64
+            os: ubuntu-latest
+          - arch: aarch64
+            os: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Restore cfitsio source tarball
         uses: actions/cache/restore@v4
@@ -111,7 +113,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_BUILD: ${{ matrix.py }}-${{ matrix.image }}_${{ matrix.arch }}
-          CIBW_ARCHS: all
+          CIBW_ARCHS: ${{ matrix.arch }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -3,8 +3,39 @@ name: Build
 on: [pull_request]
 
 jobs:
+  populate_cfitsio_cache:
+    name: Populate cfitsio cache
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.cfitsio.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read cfitsio version
+        id: cfitsio
+        shell: bash
+        run: |
+          ver=$(grep '^CFITSIO_VERSION=' tools/wheels/cibw_before_all.sh | cut -d'"' -f2)
+          echo "version=$ver" >> "$GITHUB_OUTPUT"
+
+      - name: Cache cfitsio source tarball
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: .cfitsio-cache
+          key: cfitsio-${{ steps.cfitsio.outputs.version }}-v1
+
+      - name: Download cfitsio if not cached
+        if: steps.cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          bash tools/wheels/fetch_cfitsio.sh \
+            "${{ steps.cfitsio.outputs.version }}" \
+            ".cfitsio-cache/cfitsio-${{ steps.cfitsio.outputs.version }}.tar.gz"
+
   build_wheels_macos:
     name: Build wheels on ${{ matrix.os }} (${{ matrix.arch }}) - ${{ matrix.py }}
+    needs: populate_cfitsio_cache
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -33,6 +64,12 @@ jobs:
         with:
           python-version: '3.8'
 
+      - name: Restore cfitsio source tarball
+        uses: actions/cache/restore@v4
+        with:
+          path: .cfitsio-cache
+          key: cfitsio-${{ needs.populate_cfitsio_cache.outputs.version }}-v1
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.1
         env:
@@ -46,6 +83,7 @@ jobs:
 
   build_wheels_linux:
     name: Build wheels on ${{ matrix.os }} - ${{ matrix.py }} - ${{ matrix.image }}_${{ matrix.arch }}
+    needs: populate_cfitsio_cache
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,6 +100,12 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: all
+
+      - name: Restore cfitsio source tarball
+        uses: actions/cache/restore@v4
+        with:
+          path: .cfitsio-cache
+          key: cfitsio-${{ needs.populate_cfitsio_cache.outputs.version }}-v1
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.18.1

--- a/tools/wheels/cibw_before_all.sh
+++ b/tools/wheels/cibw_before_all.sh
@@ -56,29 +56,50 @@ pip install scikit-build-core
 
 pip install tomli-w
 
+CFITSIO_TARBALL="cfitsio-$CFITSIO_VERSION.tar.gz"
+# Cache dir lives under the project tree so the workflow's populate_cache
+# job can populate it before this script runs and restore it for every
+# matrix job. The fetch is delegated to fetch_cfitsio.sh (also called
+# directly by the workflow) so the mirror list and retry logic live in
+# one place.
+CFITSIO_CACHE_DIR="$PROJECT_DIR/.cfitsio-cache"
+
+mkdir -p "$CFITSIO_CACHE_DIR"
+if [ -f "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL" ] && \
+   tar -tzf "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL" >/dev/null 2>&1; then
+    echo "Using cached $CFITSIO_CACHE_DIR/$CFITSIO_TARBALL"
+else
+    if [ -f "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL" ]; then
+        echo "Cached tarball is corrupt; re-downloading"
+        rm -f "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL"
+    else
+        echo "cfitsio tarball not in cache; downloading"
+    fi
+    bash "$PROJECT_DIR/tools/wheels/fetch_cfitsio.sh" \
+        "$CFITSIO_VERSION" "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL"
+fi
+
 if [[ $RUNNER_OS == "Linux" || $RUNNER_OS == "macOS" ]]; then
-    mkdir -p $CI_DOWNLOAD_PATH
-    cd $CI_DOWNLOAD_PATH
-    curl https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-$CFITSIO_VERSION.tar.gz --output cfitsio-$CFITSIO_VERSION.tar.gz
-    tar -xvf cfitsio-$CFITSIO_VERSION.tar.gz
-    cd cfitsio-$CFITSIO_VERSION
+    mkdir -p "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION"
+    tar -xzf "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL" \
+        -C "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION" --strip-components=1
+    cd "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION"
     mkdir -p build
     cd build
     cmake ../ -DCMAKE_INSTALL_PREFIX=$CI_INSTALL_PREFIX
     cmake --build . --config Release
     cmake --install .
 elif [[ $RUNNER_OS == "Windows" ]]; then
-    mkdir -p $CI_DOWNLOAD_PATH
-    cd $CI_DOWNLOAD_PATH
-    curl https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-$CFITSIO_VERSION.tar.gz --output cfitsio-$CFITSIO_VERSION.tar.gz
-    tar -xvf cfitsio-$CFITSIO_VERSION.tar.gz
-    mkdir -p cfitsio-$CFITSIO_VERSION.build
-    cd cfitsio-$CFITSIO_VERSION.build
-    cmake ../cfitsio-$CFITSIO_VERSION -DCMAKE_INSTALL_PREFIX=$CI_INSTALL_PREFIX
+    mkdir -p "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION"
+    tar -xzf "$CFITSIO_CACHE_DIR/$CFITSIO_TARBALL" \
+        -C "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION" --strip-components=1
+    mkdir -p "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION.build"
+    cd "$CI_DOWNLOAD_PATH/cfitsio-$CFITSIO_VERSION.build"
+    cmake "../cfitsio-$CFITSIO_VERSION" -DCMAKE_INSTALL_PREFIX=$CI_INSTALL_PREFIX
     cmake --build . --config Release
     cmake --install .
 else
-    echo "Unknown runner OS: $RUNNER OS" 1>&2
+    echo "Unknown runner OS: $RUNNER_OS" 1>&2
     exit 1
 fi
 

--- a/tools/wheels/fetch_cfitsio.sh
+++ b/tools/wheels/fetch_cfitsio.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Download the cfitsio source tarball with mirror fallback and integrity
+# validation. Used both by the GitHub Actions populate_cache job and as a
+# defensive backstop inside cibw_before_all.sh when the cache misses.
+#
+# Usage: fetch_cfitsio.sh <version> <output-path>
+#
+# The heasarc mirror is the official source. The github mirror serves the
+# same source tree (different wrapper directory and a few extra
+# .github/.gitignore files, normalized at extract time via tar
+# --strip-components=1 by the caller).
+#
+# Implemented as a portable bash retry loop because curl's --retry-all-errors
+# was added in 7.71 and the manylinux2014 base image still ships curl 7.29.
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <version> <output-path>" >&2
+    exit 2
+fi
+
+CFITSIO_VERSION="$1"
+OUT="$2"
+
+CFITSIO_TARBALL="cfitsio-${CFITSIO_VERSION}.tar.gz"
+CFITSIO_MIRRORS=(
+    "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/${CFITSIO_TARBALL}"
+    "https://github.com/HEASARC/cfitsio/archive/refs/tags/${CFITSIO_TARBALL}"
+)
+
+fetch_with_fallback() {
+    local out="$1"
+    shift
+    local max_attempts=3
+    local delay=10
+    local url attempt rc
+    for url in "$@"; do
+        echo "Trying $url" >&2
+        for attempt in $(seq 1 $max_attempts); do
+            rc=0
+            curl --fail --location --connect-timeout 30 "$url" --output "$out" || rc=$?
+            if [ "$rc" -eq 0 ] && tar -tzf "$out" >/dev/null 2>&1; then
+                return 0
+            fi
+            if [ "$rc" -eq 0 ]; then
+                echo "  downloaded file is not a valid gzip tarball" >&2
+            else
+                echo "  curl exited $rc on attempt $attempt/$max_attempts" >&2
+            fi
+            rm -f "$out"
+            if [ "$attempt" -lt "$max_attempts" ]; then
+                sleep "$delay"
+            fi
+        done
+    done
+    echo "All cfitsio mirrors exhausted" >&2
+    return 1
+}
+
+mkdir -p "$(dirname "$OUT")"
+fetch_with_fallback "$OUT" "${CFITSIO_MIRRORS[@]}"


### PR DESCRIPTION
## Summary

Two independent CI hardening changes for the cibuildwheel pipeline, split out of the crundec3 vendoring PR (#113) since they are not related to vendoring. Both are pure CI/build-infra changes; no functional code changes.

### 1. cfitsio download: mirror fallback + cross-run cache (df888f88)

The cfitsio source archive is fetched from heasarc.gsfc.nasa.gov, which has occasionally dropped connections during recent runs (curl exit 28). Three layers of defense:

- **Sequential pre-step job.** New `populate_cfitsio_cache` job runs first, downloads cfitsio once, saves it to the GitHub Actions cache. Both `build_wheels_macos` and `build_wheels_linux` declare `needs: populate_cfitsio_cache` and use `actions/cache/restore@v4` (read-only). One download per workflow run instead of 35.
- **Mirror fallback.** Tries `heasarc.gsfc.nasa.gov` first, then `github.com/HEASARC/cfitsio`. Both serve byte-identical source - the GitHub tarball wraps in `cfitsio-cfitsio-X.Y.Z/` instead of `cfitsio-X.Y.Z/` and includes a few `.github`/`.gitignore` files, all stripped at extract time via `tar --strip-components=1`.
- **Per-mirror retry loop.** Each mirror is tried up to 3 times with a 30s connect timeout and 10s sleep between attempts. Each download is validated with `tar -tzf` before being accepted.

Fetch logic lives in `tools/wheels/fetch_cfitsio.sh` so the workflow's pre-step and the in-script defensive fallback in `cibw_before_all.sh` share one implementation.

Implemented as a portable bash retry loop instead of curl's `--retry-all-errors` because that flag was added in curl 7.71 and the manylinux2014 base image still ships curl 7.29.

### 2. Native ARM runners for aarch64 wheels (e8346960)

`build_wheels_linux` aarch64 jobs were running ~1h 20min under QEMU emulation while the equivalent x86_64 jobs finished in ~6-7 min - a ~13x slowdown on compilation-heavy work. GitHub started offering free Linux arm64 runners for public repos in Jan 2025 (`ubuntu-24.04-arm`).

Matrix now uses native runners per arch via `include`:
- `x86_64`  -> `ubuntu-latest`
- `aarch64` -> `ubuntu-24.04-arm`

The QEMU setup step is dropped, and `CIBW_ARCHS` is narrowed to the matrix arch.

## Test plan

- [ ] `populate_cfitsio_cache` runs once and saves the tarball on first run
- [ ] All 35 wheel jobs see a cache hit (`Cache restored from key: cfitsio-4.6.3-v1`)
- [ ] No job invokes `fetch_cfitsio.sh` from inside `cibw_before_all.sh` (the in-script fallback should remain dormant)
- [ ] aarch64 wheel jobs complete in ~6-7 min instead of ~1h 20min
- [ ] All wheels still build successfully on every matrix entry
