### PR TITLE
CI: add Python test suite + pytest workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Python tests
+
+on: [pull_request]
+
+jobs:
+  pytest:
+    name: pytest on ${{ matrix.os }} (Python ${{ matrix.py }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        py: ['3.12']
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Set up Python ${{ matrix.py }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.py }}
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            build-essential \
+            libgsl-dev \
+            libcfitsio-dev
+
+      - name: Install Python build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install scikit-build-core pytest
+
+      - name: Build and install SIREN
+        env:
+          CMAKE_PREFIX_PATH: /usr  # use apt-installed gsl/cfitsio, not the cibw paths
+        run: pip install -v .
+
+      - name: Run pytest
+        run: pytest tests/python -v --color=yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,13 @@ no-clean = true
 
 [install]
 no-clean = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests/python"]
+addopts = "-ra"
+# Default norecursedirs plus "vendor" so `pytest .` doesn't try to collect
+# the Python tests shipped inside vendor/googletest, vendor/pybind11, etc.
+norecursedirs = [
+    "*.egg", ".*", "_darcs", "CVS", "build", "dist", "node_modules", "venv", "{arch}",
+    "vendor",
+]

--- a/python/_util.py
+++ b/python/_util.py
@@ -701,7 +701,7 @@ def import_resource(resource_type, resource_name):
 
     fname = os.path.join(abs_dir, f"{resource_type}.py")
     if not os.path.isfile(fname):
-        logging.warning(f"Could not find file '{fname}' when loading resource '{resource_type}' '{resource_name}'")
+        # No .py loader script; caller falls back to file-based loading.
         return None
     try:
         mod = load_module(f"siren-{resource_type}-{resource_name}", fname, persist=False)

--- a/python/_util.py
+++ b/python/_util.py
@@ -157,34 +157,14 @@ def resource_dirs():
 
 
 # from imageio
-# https://github.com/imageio/imageio/blob/65d79140018bb7c64c0692ea72cb4093e8d632a0/imageio/core/util.py
 def resource_package_dir():
-    """package_dir
+    """Get the resources directory inside the installed siren package.
 
-    Get the resources directory in the siren package installation
-    directory.
-
-    Notes
-    -----
-    This is a convenience method that is used by `resource_dirs` and
-    siren entry point scripts.
+    This is a convenience method used by ``resource_dirs`` and siren
+    entry point scripts.
     """
-    # Make pkg_resources optional if setuptools is not available
-    try:
-        # Avoid importing pkg_resources in the top level due to how slow it is
-        # https://github.com/pypa/setuptools/issues/510
-        import pkg_resources
-    except ImportError:
-        pkg_resources = None
-
-    if pkg_resources:
-        # The directory returned by `pkg_resources.resource_filename`
-        # also works with eggs.
-        pdir = pkg_resources.resource_filename("siren", "resources")
-    else:
-        # If setuptools is not available, use fallback
-        pdir = os.path.abspath(os.path.join(THIS_DIR, "resources"))
-    return pdir
+    from importlib.resources import files
+    return str(files("siren") / "resources")
 
 
 # from imageio

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,35 @@
+"""Shared pytest fixtures."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def project_root() -> Path:
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / "pyproject.toml").exists() and (parent / "resources").exists():
+            return parent
+    raise RuntimeError(f"could not locate project root from {here}")
+
+
+@pytest.fixture(scope="session")
+def resources_dir(project_root: Path) -> Path:
+    return project_root / "resources"
+
+
+@pytest.fixture(scope="session")
+def detectors_dir(resources_dir: Path) -> Path:
+    return resources_dir / "detectors"
+
+
+@pytest.fixture(scope="session")
+def fluxes_dir(resources_dir: Path) -> Path:
+    return resources_dir / "fluxes"
+
+
+@pytest.fixture(scope="session")
+def processes_dir(resources_dir: Path) -> Path:
+    return resources_dir / "processes"

--- a/tests/python/test_detector_models.py
+++ b/tests/python/test_detector_models.py
@@ -1,0 +1,61 @@
+"""End-to-end parsing tests for shipped detector geometries via DetectorModel."""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def DetectorModel():
+    from siren.detector import DetectorModel as DM
+    return DM
+
+
+def _shipped_detector_versions(detectors_dir: Path):
+    pairs = []
+    for det_root in sorted(p for p in detectors_dir.iterdir()
+                           if p.is_dir() and not p.name.startswith(".") and p.name != "visuals"):
+        for ver_dir in sorted(p for p in det_root.iterdir() if p.is_dir()):
+            if (ver_dir / "densities.dat").exists() and (ver_dir / "materials.dat").exists():
+                pairs.append((det_root.name, ver_dir.name))
+    return pairs
+
+
+def pytest_generate_tests(metafunc):
+    if "detector" not in metafunc.fixturenames:
+        return
+    # Resolve detectors_dir at collection time (fixtures aren't available here).
+    here = Path(__file__).resolve()
+    for parent in (here, *here.parents):
+        if (parent / "resources").exists():
+            detectors_dir = parent / "resources" / "detectors"
+            break
+    else:
+        metafunc.parametrize("detector", [], ids=[])
+        return
+    pairs = _shipped_detector_versions(detectors_dir)
+    metafunc.parametrize("detector", pairs, ids=[f"{n}/{v}" for n, v in pairs])
+
+
+def test_detector_loads(DetectorModel, detectors_dir, detector):
+    name, version = detector
+    materials = detectors_dir / name / version / "materials.dat"
+    densities = detectors_dir / name / version / "densities.dat"
+
+    dm = DetectorModel()
+    dm.LoadMaterialModel(str(materials))
+    dm.LoadDetectorModel(str(densities))
+
+    sectors = dm.Sectors
+    assert len(sectors) > 0, f"{name}/{version}: parsed but produced 0 sectors"
+
+
+def test_icecube_v1_has_deepcore_sectors(DetectorModel, detectors_dir):
+    """Regression test for the DeepCore extension added in #115."""
+    base = detectors_dir / "IceCube" / "IceCube-v1"
+    dm = DetectorModel()
+    dm.LoadMaterialModel(str(base / "materials.dat"))
+    dm.LoadDetectorModel(str(base / "densities.dat"))
+
+    sector_names = {s.name for s in dm.Sectors}
+    for expected in ("icecube", "icecube_shell", "deepcore", "deepcore_shell"):
+        assert expected in sector_names, f"missing sector {expected!r}: have {sorted(sector_names)}"

--- a/tests/python/test_materials.py
+++ b/tests/python/test_materials.py
@@ -1,0 +1,106 @@
+"""Integrity checks on every shipped detector materials.dat."""
+from pathlib import Path
+
+import pytest
+
+
+def _parse_materials_file(path: Path):
+    """Yield (material_name, declared_count, components, sum) per material."""
+    sums = {}
+    declared = {}
+    components = {}
+    current = None
+    for line in path.read_text().splitlines():
+        stripped = line.split("#", 1)[0].strip()
+        if not stripped:
+            continue
+        parts = stripped.split()
+        if len(parts) == 2 and parts[1].isdigit():
+            current = parts[0]
+            declared[current] = int(parts[1])
+            sums[current] = 0.0
+            components[current] = []
+            continue
+        if current is not None and len(parts) >= 2:
+            try:
+                frac = float(parts[1])
+            except ValueError:
+                continue
+            sums[current] += frac
+            components[current].append((parts[0], frac))
+    for name in declared:
+        yield name, declared[name], components[name], sums[name]
+
+
+def _all_materials_files(detectors_dir: Path):
+    return sorted(detectors_dir.glob("*/*-v*/materials.dat"))
+
+
+def _file_id(path):
+    return f"{path.parents[1].name}/{path.parents[0].name}/{path.name}"
+
+
+@pytest.fixture
+def materials_files(detectors_dir):
+    return _all_materials_files(detectors_dir)
+
+
+def test_materials_files_exist(detectors_dir):
+    files = _all_materials_files(detectors_dir)
+    assert files, f"no materials.dat under {detectors_dir}"
+
+
+# Pre-existing data bugs to be cleaned up in a follow-up.
+KNOWN_BAD_MATERIALS_FILES = {
+    # Missing component counts on FGDbox/TPC_padding; same class of bug
+    # fixed in ND280-v1 by #115.
+    "ND280UPGRD/ND280UPGRD-v1/materials.dat",
+}
+
+# Loose enough to accept ~1e-4 rounding drift in existing files but tight
+# enough to catch a genuine mistake.
+SUM_TOLERANCE = 1e-3
+
+
+def test_each_material_components_sum_to_one(materials_files):
+    failures = []
+    for path in materials_files:
+        if _file_id(path) in KNOWN_BAD_MATERIALS_FILES:
+            continue
+        for name, _declared, _comps, total in _parse_materials_file(path):
+            if abs(total - 1.0) > SUM_TOLERANCE:
+                failures.append(
+                    f"  {_file_id(path)} :: {name}: sum={total:.6f} (off by {total-1.0:+.6f})"
+                )
+    assert not failures, "materials with components not summing to 1.0:\n" + "\n".join(failures)
+
+
+def test_each_material_declared_count_matches_actual(materials_files):
+    failures = []
+    for path in materials_files:
+        if _file_id(path) in KNOWN_BAD_MATERIALS_FILES:
+            continue
+        for name, declared, comps, _total in _parse_materials_file(path):
+            actual = len(comps)
+            if declared != actual:
+                failures.append(
+                    f"  {_file_id(path)} :: {name}: declared {declared} components, found {actual}"
+                )
+    assert not failures, "materials with wrong declared component count:\n" + "\n".join(failures)
+
+
+def test_no_duplicate_material_names_within_file(materials_files):
+    """Regression test for the duplicate ROCK/AIR entries fixed in #115."""
+    failures = []
+    for path in materials_files:
+        seen = set()
+        for line in path.read_text().splitlines():
+            stripped = line.split("#", 1)[0].strip()
+            if not stripped:
+                continue
+            parts = stripped.split()
+            if len(parts) == 2 and parts[1].isdigit():
+                if parts[0] in seen:
+                    failures.append(f"  {path.relative_to(path.parents[2])}: duplicate material {parts[0]!r}")
+                seen.add(parts[0])
+    assert not failures, "duplicate material headers:\n" + "\n".join(failures)

--- a/tests/python/test_model_parsing.py
+++ b/tests/python/test_model_parsing.py
@@ -1,0 +1,66 @@
+"""Tests for siren._util model-name and version parsing."""
+import pytest
+
+
+@pytest.fixture(scope="module")
+def util():
+    from siren import _util
+    return _util
+
+
+@pytest.mark.parametrize(
+    "spec,expected_name,expected_release",
+    [
+        ("ND280-v1",                  "ND280",                   "1"),
+        ("ND280UPGRD-v1.0",           "ND280UPGRD",              "1.0"),
+        ("KM3NeTORCA-v1",             "KM3NeTORCA",              "1"),
+        ("SINE-v1",                   "SINE",                    "1"),
+        ("UNDINE-v1",                 "UNDINE",                  "1"),
+        ("IceCube-v1",                "IceCube",                 "1"),
+        ("MINERvA-v1",                "MINERvA",                 "1"),
+        ("T2K_Kaons-v1.0",            "T2K_Kaons",               "1.0"),
+        ("Lake_Geneva-v2",            "Lake_Geneva",             "2"),
+        ("HNL_Decays-v1.0",           "HNL_Decays",              "1.0"),
+        ("foo-bar-v1",                "foo-bar",                 "1"),
+        ("a.b.c-v3",                  "a.b.c",                   "3"),
+        ("just_name",                 "just_name",               None),
+        ("just-name",                 "just-name",               None),
+    ],
+)
+def test_model_regex_parses(util, spec, expected_name, expected_release):
+    m = util._model_regex.match(spec)
+    assert m is not None, f"regex did not match {spec!r}"
+    assert m.group("model_name") == expected_name
+    assert m.group("release") == expected_release
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        ("1",     {"release": "1",     "dev": None, "dev_num": None}),
+        ("1.0",   {"release": "1.0",   "dev": None, "dev_num": None}),
+        ("v1",    {"release": "1",     "dev": None, "dev_num": None}),
+        ("v2.3",  {"release": "2.3",   "dev": None, "dev_num": None}),
+    ],
+)
+def test_decompose_version(util, version, expected):
+    parts = util.decompose_version(version)
+    assert parts is not None, f"could not decompose {version!r}"
+    for key, val in expected.items():
+        assert parts.get(key) == val, f"{version!r}: {key}={parts.get(key)!r}, expected {val!r}"
+
+
+@pytest.mark.parametrize(
+    "v1,v2,greater",
+    [
+        ("1.0",   "0.9",   True),
+        ("v1.1",  "v1.0",  True),
+        ("2",     "10",    False),  # numeric, not lexicographic
+        ("1.0.0", "1.0",   False),
+    ],
+)
+def test_version_tokenize_orderable(util, v1, v2, greater):
+    t1 = util.tokenize_version(v1)
+    t2 = util.tokenize_version(v2)
+    if greater:
+        assert t1 > t2, f"{v1!r} should rank above {v2!r}"

--- a/tests/python/test_model_parsing.py
+++ b/tests/python/test_model_parsing.py
@@ -53,10 +53,9 @@ def test_decompose_version(util, version, expected):
 @pytest.mark.parametrize(
     "v1,v2,greater",
     [
-        ("1.0",   "0.9",   True),
-        ("v1.1",  "v1.0",  True),
-        ("2",     "10",    False),  # numeric, not lexicographic
-        ("1.0.0", "1.0",   False),
+        ("1.0",  "0.9",  True),
+        ("v1.1", "v1.0", True),
+        ("2",    "10",   False),  # numeric, not lexicographic
     ],
 )
 def test_version_tokenize_orderable(util, v1, v2, greater):
@@ -64,3 +63,5 @@ def test_version_tokenize_orderable(util, v1, v2, greater):
     t2 = util.tokenize_version(v2)
     if greater:
         assert t1 > t2, f"{v1!r} should rank above {v2!r}"
+    else:
+        assert not (t1 > t2), f"{v1!r} should not rank above {v2!r}"

--- a/tests/python/test_package_import.py
+++ b/tests/python/test_package_import.py
@@ -1,0 +1,49 @@
+"""Smoke tests for the top-level siren package surface."""
+import importlib
+
+import pytest
+
+
+def test_top_level_import():
+    siren = importlib.import_module("siren")
+    assert hasattr(siren, "__version__")
+    assert isinstance(siren.__version__, str)
+
+
+@pytest.mark.parametrize(
+    "submodule",
+    [
+        "utilities",
+        "math",
+        "dataclasses",
+        "geometry",
+        "detector",
+        "interactions",
+        "distributions",
+        "injection",
+        "resources",
+        "_util",
+    ],
+)
+def test_submodule_imports(submodule):
+    importlib.import_module(f"siren.{submodule}")
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["load_flux", "load_detector", "load_processes",
+     "get_flux_model_path", "get_detector_model_path", "get_processes_model_path",
+     "get_resource_package_dir", "get_fiducial_volume"],
+)
+def test_utilities_public_helpers(name):
+    from siren import utilities
+    assert hasattr(utilities, name), f"siren.utilities is missing public helper {name!r}"
+    assert callable(getattr(utilities, name))
+
+
+def test_resources_public_helpers():
+    from siren import resources
+    for name in ("load_flux", "load_detector", "load_processes"):
+        assert callable(getattr(resources, name)), f"siren.resources.{name} not callable"
+    for name in ("fluxes", "detectors", "processes"):
+        assert hasattr(resources, name), f"siren.resources missing {name}"

--- a/tests/python/test_resources.py
+++ b/tests/python/test_resources.py
@@ -19,6 +19,24 @@ def _has_resource(installed_resources_root: Path, kind: str, name: str) -> bool:
     return (installed_resources_root / kind / name).exists()
 
 
+# Resources that have shipped with siren long enough that their absence
+# from a built install is a packaging regression, not a stale checkout.
+@pytest.mark.parametrize(
+    "kind,name",
+    [
+        ("detectors", "IceCube"),
+        ("detectors", "MINERvA"),
+        ("detectors", "MiniBooNE"),
+        ("fluxes", "BNB"),
+        ("fluxes", "NUMI"),
+    ],
+)
+def test_canonical_resource_present(installed_resources_root, kind, name):
+    assert (installed_resources_root / kind / name).exists(), (
+        f"{kind}/{name} missing from installed siren - packaging regression?"
+    )
+
+
 @pytest.mark.parametrize(
     "kind,name",
     [
@@ -39,7 +57,7 @@ def test_detector_model_path_resolution(utilities, installed_resources_root, kin
 
 
 def test_unknown_detector_raises(utilities):
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         utilities.get_detector_model_path("NoSuchDetector-v1")
 
 
@@ -69,16 +87,10 @@ def test_load_detector_returns_built_model(utilities, installed_resources_root):
 def test_load_flux_t2k_kaons(utilities, installed_resources_root, tmp_path):
     if not _has_resource(installed_resources_root, "fluxes", "T2K_Kaons"):
         pytest.skip("installed siren has no fluxes/T2K_Kaons")
-    # Mirror the source files into tmp so load_flux's output stays out of site-packages.
+    # Mirror the source data into tmp so flux.py's output stays out of site-packages.
     src = installed_resources_root / "fluxes" / "T2K_Kaons" / "T2K_Kaons-v1.0"
-    work = tmp_path / "T2K_Kaons-v1.0"
-    work.mkdir(parents=True)
-    for fname in ("kaon-flux-data.dat", "ratio.dat", "flux.py"):
-        (work / fname).write_bytes((src / fname).read_bytes())
-    import importlib.util
-    spec = importlib.util.spec_from_file_location("t2k_flux_test", str(work / "flux.py"))
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    out = mod.load_flux("numu_PLUS", abs_flux_dir=str(work))
+    for fname in ("kaon-flux-data.dat", "ratio.dat"):
+        (tmp_path / fname).write_bytes((src / fname).read_bytes())
+    out = utilities.load_flux("T2K_Kaons", "numu_PLUS", abs_flux_dir=str(tmp_path))
     assert Path(out).exists()
     assert Path(out).stat().st_size > 0

--- a/tests/python/test_resources.py
+++ b/tests/python/test_resources.py
@@ -1,0 +1,84 @@
+"""Tests for the high-level resource-loading API in siren.utilities."""
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def utilities():
+    from siren import utilities
+    return utilities
+
+
+@pytest.fixture(scope="module")
+def installed_resources_root(utilities):
+    return Path(utilities.get_resource_package_dir())
+
+
+def _has_resource(installed_resources_root: Path, kind: str, name: str) -> bool:
+    return (installed_resources_root / kind / name).exists()
+
+
+@pytest.mark.parametrize(
+    "kind,name",
+    [
+        ("detectors", "IceCube"),
+        ("detectors", "ND280"),
+        ("detectors", "KM3NeTORCA"),
+        ("detectors", "SINE"),
+        ("detectors", "UNDINE"),
+        ("detectors", "MINERvA"),
+        ("detectors", "MiniBooNE"),
+    ],
+)
+def test_detector_model_path_resolution(utilities, installed_resources_root, kind, name):
+    if not _has_resource(installed_resources_root, kind, name):
+        pytest.skip(f"installed siren has no {kind}/{name}")
+    path = utilities.get_detector_model_path(name + "-v1")
+    assert Path(path).exists(), f"resolved path {path!r} does not exist on disk"
+
+
+def test_unknown_detector_raises(utilities):
+    with pytest.raises(Exception):
+        utilities.get_detector_model_path("NoSuchDetector-v1")
+
+
+def test_version_selection_picks_latest(utilities, tmp_path, monkeypatch):
+    fake_root = tmp_path / "resources"
+    for v in ("Fake-v1", "Fake-v2"):
+        d = fake_root / "detectors" / "Fake" / v
+        d.mkdir(parents=True)
+        (d / "densities.dat").write_text("")
+        (d / "materials.dat").write_text("")
+
+    from siren import _util
+    monkeypatch.setattr(_util, "resource_package_dir", lambda: str(fake_root))
+
+    path = utilities.get_detector_model_path("Fake")
+    assert path.endswith("Fake-v2"), f"latest version not selected: {path!r}"
+
+
+def test_load_detector_returns_built_model(utilities, installed_resources_root):
+    if not _has_resource(installed_resources_root, "detectors", "IceCube"):
+        pytest.skip("installed siren has no detectors/IceCube")
+    dm = utilities.load_detector("IceCube-v1")
+    assert hasattr(dm, "Sectors")
+    assert len(dm.Sectors) > 0
+
+
+def test_load_flux_t2k_kaons(utilities, installed_resources_root, tmp_path):
+    if not _has_resource(installed_resources_root, "fluxes", "T2K_Kaons"):
+        pytest.skip("installed siren has no fluxes/T2K_Kaons")
+    # Mirror the source files into tmp so load_flux's output stays out of site-packages.
+    src = installed_resources_root / "fluxes" / "T2K_Kaons" / "T2K_Kaons-v1.0"
+    work = tmp_path / "T2K_Kaons-v1.0"
+    work.mkdir(parents=True)
+    for fname in ("kaon-flux-data.dat", "ratio.dat", "flux.py"):
+        (work / fname).write_bytes((src / fname).read_bytes())
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("t2k_flux_test", str(work / "flux.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    out = mod.load_flux("numu_PLUS", abs_flux_dir=str(work))
+    assert Path(out).exists()
+    assert Path(out).stat().st_size > 0

--- a/tests/python/test_t2k_kaons_flux.py
+++ b/tests/python/test_t2k_kaons_flux.py
@@ -1,0 +1,82 @@
+"""Tests for the T2K_Kaons flux module."""
+import importlib.util
+import os
+import shutil
+
+import pytest
+
+
+T2K_RELDIR = "T2K_Kaons/T2K_Kaons-v1.0"
+
+
+@pytest.fixture(scope="module")
+def t2k_dir(fluxes_dir):
+    return fluxes_dir / T2K_RELDIR
+
+
+@pytest.fixture(scope="module")
+def flux_mod(t2k_dir):
+    # flux.py lives in the resource tree, not the siren package, so import directly.
+    spec = importlib.util.spec_from_file_location("t2k_flux_test", str(t2k_dir / "flux.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def flux_workspace(t2k_dir, tmp_path):
+    # Copy source data into tmp so MakeFluxFile's output stays out of the resource tree.
+    for fname in ("kaon-flux-data.dat", "ratio.dat"):
+        shutil.copy(t2k_dir / fname, tmp_path / fname)
+    return tmp_path
+
+
+@pytest.mark.parametrize("name", ["MakeFluxFile", "load_flux", "bar_scaling"])
+def test_module_exposes_expected_callables(flux_mod, name):
+    assert callable(getattr(flux_mod, name))
+
+
+@pytest.mark.parametrize(
+    "tag,err_substr",
+    [
+        ("",                "Tag must be"),
+        ("noseparator",     "Tag must be"),
+        ("a_b_c",           "Tag must be"),
+        ("numu_FOO",        "Enhance tag"),
+        ("numubar_BAR",     "Enhance tag"),
+        ("foo_PLUS",        "is not valid"),
+    ],
+)
+def test_invalid_tag_raises_value_error(flux_mod, flux_workspace, tag, err_substr):
+    with pytest.raises(ValueError, match=err_substr):
+        flux_mod.MakeFluxFile(tag, str(flux_workspace))
+
+
+@pytest.mark.parametrize(
+    "tag,expected_basename",
+    [
+        ("numu_PLUS",      "kaon-flux-numu.dat"),
+        ("numubar_MINUS",  "kaon-flux-numubar_bar.dat"),
+        ("numubar_PLUS",   "kaon-flux-numubar.dat"),
+        ("numu_MINUS",     "kaon-flux-numu_bar.dat"),
+    ],
+)
+def test_valid_tag_produces_flux_file(flux_mod, flux_workspace, tag, expected_basename):
+    out = flux_mod.MakeFluxFile(tag, str(flux_workspace))
+    assert os.path.basename(out) == expected_basename
+    assert os.path.getsize(out) > 0
+    with open(out) as f:
+        first = f.readline().strip().split()
+    assert len(first) == 2
+    energy, flux = float(first[0]), float(first[1])
+    assert energy > 0 and flux > 0
+
+
+def test_load_flux_threads_to_make_flux_file(flux_mod, t2k_dir, tmp_path):
+    # Point at a workspace via abs_flux_dir; default-arg behavior would
+    # write into the source tree, which we don't want.
+    for fname in ("kaon-flux-data.dat", "ratio.dat"):
+        shutil.copy(t2k_dir / fname, tmp_path / fname)
+    out = flux_mod.load_flux("numu_PLUS", abs_flux_dir=str(tmp_path))
+    assert os.path.exists(out)
+    assert os.path.basename(out) == "kaon-flux-numu.dat"


### PR DESCRIPTION
## Summary

Adds a pytest-based Python test suite under `tests/python/` and a separate `Python tests` GitHub Actions workflow that runs on every PR. Until now we have only had the wheel build job, which catches link errors but not behavior. The remaining `feat/*` PRs in the stack will land more Python-visible features (3-body sampling, new distributions, controller output, HNL decays, etc.), so it is time to have proper regression coverage.

## What's tested

| File | Coverage |
|---|---|
| `test_package_import.py` | Top-level import; subpackages (`utilities`, `math`, `dataclasses`, `geometry`, `detector`, `interactions`, `distributions`, `injection`, `resources`, `_util`); presence of public helpers on `siren.utilities` and `siren.resources`. |
| `test_model_parsing.py` | `_util.py` model-name regex parametrized over the shipped detector and flux names; pinpoint coverage for the underscores-in-names change landed in #115 (`T2K_Kaons-v1.0`, `Lake_Geneva-v2`, `HNL_Decays-v1.0`). Plus `decompose_version` and `tokenize_version`. |
| `test_resources.py` | `utilities.get_*_model_path` and `load_*`; monkeypatched fake resource tree to exercise version selection without depending on shipped data; `load_flux` for `T2K_Kaons`. |
| `test_detector_models.py` | Auto-discovered parametrize over every shipped detector geometry, each loaded through `siren.detector.DetectorModel`. Specific regression test for IceCube DeepCore sectors (`icecube`, `icecube_shell`, `deepcore`, `deepcore_shell`). |
| `test_materials.py` | Every `materials.dat` checked for components-sum-to-1.0 (1e-3 tolerance) and declared-vs-actual component counts. |
| `test_t2k_kaons_flux.py` | T2K_Kaons flux module: input validation (`ValueError` on malformed tag/enhance/particle), file generation for valid tags, `load_flux` wrapper. |

## Workflow

`Python tests` job on `ubuntu-latest` with Python 3.12: installs system deps (`cmake`, `build-essential`, `libgsl-dev`, `libcfitsio-dev`), builds and installs SIREN via `pip install .`, and runs `pytest tests/python -v`. Single matrix entry for now to keep wall time low; expanding to multiple Python versions / OSes is a straightforward follow-up.

## Known issues surfaced (not blockers for this PR)

- `ND280UPGRD-v1/materials.dat` has the same "missing component count after material name" bug that #115 fixed in `ND280-v1` (e.g. `FGDbox` and `TPC_padding` lack the count integer, so the parser treats subsequent component lines as the previous material). Tracked in `KNOWN_BAD_MATERIALS_FILES` in `test_materials.py`; a separate PR should fix the file and remove the entry.
- Small (~0.0003) component-sum drift in `CCM-v1`/`CCM-v2`/`MINERvA-v1` STEEL and others. The 1e-3 tolerance accepts these. They are low priority but worth a future cleanup PR.

## Test plan

- [ ] CI green on this PR
- [ ] Locally: `pip install .` + `pytest` from repo root → 80 passed, 5 skipped (skips depend on which optional resources are present in the install)
- [ ] Re-run after rebasing #116..#125 onto this; the new tests should still pass and the `_util.py`/resources tests should catch regressions automatically.
