### PR TITLE
Switch vendored libraries to static linking and fix CMake exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,12 +127,11 @@ include(cereal)
 if(TARGET cereal)
     apply_siren_compile_options(cereal)
 endif()
+set(DELABELLA_BUILD_STATIC ON CACHE BOOL "Build delabella static library" FORCE)
+set(DELABELLA_BUILD_SHARED OFF CACHE BOOL "Build delabella shared library" FORCE)
 include(delabella)
 if(TARGET delabella_static)
     apply_siren_compile_options(delabella_static)
-endif()
-if(TARGET delabella_shared)
-    apply_siren_compile_options(delabella_shared)
 endif()
 include(CFITSIO)
 if(TARGET CFITSIO::cfitsio)
@@ -190,7 +189,6 @@ endif()
 target_link_libraries(SIREN
     PRIVATE
     PUBLIC
-        delabella_shared
         photospline
         SIREN_utilities
         SIREN_serialization
@@ -207,7 +205,6 @@ target_link_libraries(SIREN
     PRIVATE
     PUBLIC
         photospline
-        delabella_shared
         SIREN_utilities
         SIREN_serialization
         SIREN_math
@@ -229,7 +226,6 @@ if(DEFINED SKBUILD_PLATLIB_DIR)
         message(STATUS "Setting SIREN install lib dir to: ${CI_INSTALL_PREFIX}/lib")
         message(STATUS "Setting SIREN install include dir to: ${CI_INSTALL_PREFIX}/include")
         install(TARGETS SIREN
-            delabella_shared
             SIREN_utilities
             SIREN_serialization
             SIREN_math
@@ -244,7 +240,6 @@ if(DEFINED SKBUILD_PLATLIB_DIR)
             PUBLIC_HEADER DESTINATION "${CI_INSTALL_PREFIX}/include")
     else()
         install(TARGETS SIREN
-            delabella_shared
             SIREN_utilities
             SIREN_serialization
             SIREN_math
@@ -260,7 +255,6 @@ if(DEFINED SKBUILD_PLATLIB_DIR)
     endif()
 else()
     install(TARGETS SIREN
-        delabella_shared
         SIREN_utilities
         SIREN_serialization
         SIREN_math

--- a/projects/math/CMakeLists.txt
+++ b/projects/math/CMakeLists.txt
@@ -19,7 +19,7 @@ if(${MACOSX})
 target_link_libraries(SIREN_math
     PUBLIC
         photospline
-        delabella_shared
+        delabella_static
     PRIVATE
         $<BUILD_INTERFACE:rk_static>
         SIREN_serialization
@@ -28,7 +28,7 @@ else()
 target_link_libraries(SIREN_math
     PUBLIC
         photospline
-        delabella_shared
+        delabella_static
     PRIVATE
         -Wl,--whole-archive
         $<BUILD_INTERFACE:rk_static>

--- a/vendor/crundec3/CMakeLists.txt
+++ b/vendor/crundec3/CMakeLists.txt
@@ -22,4 +22,32 @@ target_include_directories(crundec_static PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
+install(TARGETS crundec_static
+    EXPORT ${PROJECT_NAME}Config
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/CRunDec3.1/"
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.m"
+)
+
+### Export targets for use with the install tree
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion
+)
+export(EXPORT ${PROJECT_NAME}Config FILE ${PROJECT_NAME}Config.cmake)
+
+set(_config_dir share/${PROJECT_NAME}/cmake)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION ${_config_dir}
+)
+install(EXPORT ${PROJECT_NAME}Config
+  DESTINATION ${_config_dir}
+)
+
 message(STATUS "Added crundec3")


### PR DESCRIPTION
## Summary

Switches all vendored libraries to static linking and fixes CMake export errors.

- **delabella**: Build static only (`DELABELLA_BUILD_STATIC ON`, `DELABELLA_BUILD_SHARED OFF`). Use `delabella_static` in `SIREN_math`. Remove from top-level SIREN target since it propagates transitively through `SIREN_math`.
- **crundec3**: Add proper `install(EXPORT ...)` rules so it can participate in the CMake export set.
- **delabella submodule**: Updated to include the `DELABELLA_STATIC` -> `DELABELLA_BUILD_STATIC` variable name fix.

This resolves the CMake export error:
```
export called with target "SIREN_interactions" which requires target
"crundec_static" that is not in any export set.
```

## File list

| File | Change |
|---|---|
| `CMakeLists.txt` | Build delabella static-only, remove from top-level link/install |
| `projects/math/CMakeLists.txt` | `delabella_shared` -> `delabella_static` |
| `vendor/crundec3/CMakeLists.txt` | Add install/export rules |
| `vendor/delabella` | Updated submodule pointer |
