### PR TITLE
GDML Compatibility: Part B (Path refactor + GDML parser modules)

### DIFF
--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -28,6 +28,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLPreprocess.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLMaterialParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLSolidParser.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLStructureParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -23,6 +23,8 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/DetectorModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLExpression.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLUnits.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLReadUtils.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLDefineParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -21,6 +21,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/RadialAxisPolynomialDensityDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/RadialAxisExponentialDensityDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/DetectorModel.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/GDMLParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLExpression.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLUnits.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLReadUtils.cxx

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -21,6 +21,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/RadialAxisPolynomialDensityDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/RadialAxisExponentialDensityDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/DetectorModel.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLExpression.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -26,6 +26,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLReadUtils.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLDefineParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLPreprocess.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLMaterialParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -22,6 +22,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/RadialAxisExponentialDensityDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/DetectorModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLExpression.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLUnits.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -27,6 +27,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLDefineParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLPreprocess.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLMaterialParser.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLSolidParser.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/CMakeLists.txt
+++ b/projects/detector/CMakeLists.txt
@@ -25,6 +25,7 @@ LIST (APPEND detector_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLUnits.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLReadUtils.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLDefineParser.cxx
+    ${PROJECT_SOURCE_DIR}/projects/detector/private/gdml/GDMLPreprocess.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/MaterialModel.cxx
     ${PROJECT_SOURCE_DIR}/projects/detector/private/Path.cxx
 )

--- a/projects/detector/private/GDMLParser.cxx
+++ b/projects/detector/private/GDMLParser.cxx
@@ -1,0 +1,255 @@
+#include "SIREN/detector/GDMLParser.h"
+
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <cereal/external/rapidxml/rapidxml.hpp>
+
+#include "gdml/GDMLParserPrivate.h"
+
+namespace rapidxml = cereal::rapidxml;
+
+namespace siren {
+namespace detector {
+
+void GDMLData::ThrowIfErrors() {
+    if(errors.empty()) return;
+    std::string msg = "GDML parse errors (" + std::to_string(errors.size()) + "):";
+    for(auto const & e : errors) {
+        msg += "\n  - " + e;
+    }
+    errors.clear();
+    throw std::runtime_error(msg);
+}
+
+std::unordered_map<std::string, std::string> GDMLData::MergeFrom(GDMLData & other) {
+    std::unordered_map<std::string, std::string> renames;
+
+    // Find a name that doesn't collide with the parent, the sub-file,
+    // or any already-chosen rename target.
+    auto inAny = [](std::string const & c, GDMLData const & d) {
+        return d.materials.count(c) || d.elements.count(c)
+            || d.isotopes.count(c) || d.solids.count(c)
+            || d.volumes.count(c) || d.positions.count(c)
+            || d.rotations.count(c) || d.constants.count(c);
+    };
+    auto findUnique = [&](std::string const & name) -> std::string {
+        std::string candidate;
+        int suffix = 2;
+        for(;;) {
+            candidate = name + "_" + std::to_string(suffix++);
+            if(inAny(candidate, *this)) continue;
+            if(inAny(candidate, other)) continue;
+            bool rename_hit = false;
+            for(auto const & r : renames)
+                if(r.second == candidate) { rename_hit = true; break; }
+            if(rename_hit) continue;
+            return candidate;
+        }
+    };
+
+    // Detect collisions across typed maps. Identical definitions are
+    // silently reused (no rename). Differing definitions get a rename.
+    auto checkMaterials = [&](auto const & sub_map, auto const & parent_map) {
+        for(auto const & p : sub_map) {
+            auto it = parent_map.find(p.first);
+            if(it != parent_map.end() && !(it->second == p.second))
+                renames[p.first] = findUnique(p.first);
+        }
+    };
+    checkMaterials(other.isotopes, isotopes);
+    checkMaterials(other.elements, elements);
+    checkMaterials(other.materials, materials);
+
+    for(auto const & p : other.solids) {
+        auto it = solids.find(p.first);
+        if(it != solids.end() && !(*it->second == *p.second))
+            renames[p.first] = findUnique(p.first);
+    }
+
+    for(auto const & p : other.volumes) {
+        auto it = volumes.find(p.first);
+        if(it != volumes.end()) {
+            auto const & a = it->second;
+            auto const & b = p.second;
+            bool differ = (a.solid_ref != b.solid_ref
+                || a.material_ref != b.material_ref
+                || a.children.size() != b.children.size()
+                || a.is_assembly != b.is_assembly);
+            if(!differ) {
+                for(size_t i = 0; i < a.children.size(); ++i) {
+                    if(a.children[i].volume_ref != b.children[i].volume_ref
+                       || !(a.children[i].position == b.children[i].position)
+                       || !(a.children[i].rotation == b.children[i].rotation)) {
+                        differ = true;
+                        break;
+                    }
+                }
+            }
+            if(differ) renames[p.first] = findUnique(p.first);
+        }
+    }
+
+    // Apply renames to the other's internal references
+    auto r = [&](std::string const & name) -> std::string const & {
+        auto it = renames.find(name);
+        return (it != renames.end()) ? it->second : name;
+    };
+
+    if(!renames.empty()) {
+        other.world_volume = r(other.world_volume);
+
+        for(auto & vp : other.volumes) {
+            vp.second.name = r(vp.second.name);
+            vp.second.solid_ref = r(vp.second.solid_ref);
+            vp.second.material_ref = r(vp.second.material_ref);
+            for(auto & child : vp.second.children)
+                child.volume_ref = r(child.volume_ref);
+        }
+
+        for(auto * map_ptr : {&other.materials, &other.elements, &other.isotopes}) {
+            for(auto & mp : *map_ptr) {
+                mp.second.name = r(mp.second.name);
+                std::map<std::string, double> new_comp;
+                for(auto & cp : mp.second.composition)
+                    new_comp[r(cp.first)] = cp.second;
+                mp.second.composition = std::move(new_comp);
+            }
+        }
+    }
+
+    // Merge with renamed keys. For identical definitions that weren't
+    // renamed, emplace is a no-op (parent's version is kept).
+    auto merge = [&](auto & sub_map, auto & dst_map) {
+        using Map = std::remove_reference_t<decltype(dst_map)>;
+        Map staged;
+        for(auto & p : sub_map)
+            staged.emplace(r(p.first), std::move(p.second));
+        for(auto & p : staged)
+            dst_map.emplace(std::move(p.first), std::move(p.second));
+    };
+    merge(other.solids, solids);
+    merge(other.isotopes, isotopes);
+    merge(other.elements, elements);
+    merge(other.materials, materials);
+    merge(other.volumes, volumes);
+    merge(other.positions, positions);
+    merge(other.rotations, rotations);
+    merge(other.constants, constants);
+
+    // Propagate sub-file warnings so the caller sees diagnostics from
+    // all included files, not just the top-level parse.
+    warnings.insert(warnings.end(), other.warnings.begin(), other.warnings.end());
+
+    return renames;
+}
+
+
+GDMLData ParseGDML(std::string const & filename, GDMLParseOptions const & options) {
+    // Read the file into a mutable buffer (rapidxml modifies in-place)
+    std::ifstream file(filename.c_str(), std::ios::binary);
+    if(!file.is_open()) {
+        throw std::runtime_error("Cannot open GDML file: " + filename);
+    }
+
+    // Read entire file into string
+    std::string content((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+    file.close();
+
+    // Determine base directory for entity resolution
+    std::string base_dir;
+    {
+        size_t last_slash = filename.rfind('/');
+        if(last_slash != std::string::npos) {
+            base_dir = filename.substr(0, last_slash);
+        } else {
+            base_dir = ".";
+        }
+    }
+
+    // Expand ENTITY references before XML parsing
+    if(content.find("<!ENTITY") != std::string::npos || content.find("<!entity") != std::string::npos) {
+        content = gdml::ExpandEntities(content, base_dir);
+    }
+
+    // Handle xi:include (XInclude) before XML parsing.
+    if(content.find("xi:include") != std::string::npos) {
+        content = gdml::ExpandXIncludes(content, base_dir);
+    }
+
+    // rapidxml requires a mutable, null-terminated buffer
+    std::vector<char> buffer(content.begin(), content.end());
+    buffer.push_back('\0');
+
+    // Parse the XML
+    rapidxml::xml_document<> doc;
+    try {
+        doc.parse<0>(buffer.data());
+    } catch(rapidxml::parse_error & e) {
+        throw std::runtime_error(std::string("GDML XML parse error: ") + e.what());
+    }
+
+    GDMLData data;
+    data.base_dir = base_dir;
+
+    gdml::SeedBuiltInConstants(data);
+
+    // Find root node: accept <gdml> or any root element
+    auto* gdml_node = doc.first_node("gdml");
+    if(!gdml_node) {
+        gdml_node = doc.first_node();
+        if(!gdml_node) {
+            throw std::runtime_error("GDML error: empty document: " + filename);
+        }
+        std::string root_tag(gdml_node->name());
+        gdml::EmitWarning(data, options, "non-standard root element <" + root_tag + "> in " + filename + ", treating as <gdml>");
+    }
+
+    // Resolve all <define> sections in document order (handles loops inline).
+    gdml::ResolveDefineInOrder(gdml_node, data, options);
+
+    // Expand <loop> elements in non-define sections (structure, solids) where
+    // downstream parsers need to see the expanded DOM nodes.
+    gdml::ExpandLoops(doc, gdml_node, data.constants, data);
+    data.ThrowIfErrors();
+    // Remove loops from <define> sections (already resolved, but the DOM nodes
+    // are still present; remove them so ParseDefine is not confused if called again)
+    for(auto* def = gdml_node->first_node("define"); def; def = def->next_sibling("define")) {
+        auto* child = def->first_node();
+        while(child) {
+            auto* next = child->next_sibling();
+            if(std::strcmp(child->name(), "loop") == 0) {
+                def->remove_node(child);
+            }
+            child = next;
+        }
+    }
+
+    // Parse all <materials> sections (with instance-scoped name resolution)
+    gdml::ParseAllMaterials(gdml_node, data, options);
+    // Parse all <solids> sections (with instance-scoped boolean resolution)
+    gdml::ParseAllSolids(gdml_node, data, options);
+    // Parse all <structure> sections
+    for(auto* node = gdml_node->first_node("structure"); node; node = node->next_sibling("structure")) {
+        gdml::ParseStructure(node, data, options);
+    }
+    // Parse all <setup> sections (last wins)
+    for(auto* node = gdml_node->first_node("setup"); node; node = node->next_sibling("setup")) {
+        gdml::ParseSetup(node, data, options);
+    }
+
+    // Warn if no <setup> section was found (world volume undefined)
+    if(data.world_volume.empty()) {
+        gdml::EmitWarning(data, options, "No <setup> section found in GDML; world volume is undefined");
+    }
+
+    return data;
+}
+
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/Path.cxx
+++ b/projects/detector/private/Path.cxx
@@ -92,9 +92,6 @@ bool Path::HasIntersections() {
     return set_intersections_;
 }
 
-bool Path::HasColumnDepth() {
-    return set_column_depth_;
-}
 
 std::shared_ptr<const DetectorModel> Path::GetDetectorModel() {
     return detector_model_;
@@ -162,7 +159,6 @@ void Path::SetPoints(GeometryPosition first_point, GeometryPosition last_point) 
     set_points_ = true;
     set_det_points_ = false;
     set_intersections_ = false;
-    set_column_depth_ = false;
     first_inf_ = IsInfinite(first_point);
     last_inf_ = IsInfinite(last_point);
     RequireBothFinite();
@@ -178,7 +174,6 @@ void Path::SetPoints(DetectorPosition first_point, DetectorPosition last_point) 
     set_points_ = false;
     set_det_points_ = true;
     set_intersections_ = false;
-    set_column_depth_ = false;
     first_inf_ = IsInfinite(first_point);
     last_inf_ = IsInfinite(last_point);
     RequireBothFinite();
@@ -186,17 +181,33 @@ void Path::SetPoints(DetectorPosition first_point, DetectorPosition last_point) 
 }
 
 void Path::SetPointsWithRay(GeometryPosition first_point, GeometryDirection direction, double distance) {
+    // Check if the new ray is collinear with the cached intersections.
+    // Intersections along the same line are reusable: SectorLoop compensates
+    // for origin shifts via the offset calculation.
+    bool can_reuse_intersections = false;
+    if(set_intersections_) {
+        math::Vector3D new_dir = direction;
+        new_dir.normalize();
+        double dot = std::abs(new_dir * intersections_.direction);
+        if(dot > 1.0 - 1e-9) {
+            math::Vector3D offset = math::Vector3D(first_point) - intersections_.position;
+            math::Vector3D perp = math::cross_product(offset, intersections_.direction);
+            if(perp.magnitude() < 1e-6 * (1.0 + offset.magnitude())) {
+                can_reuse_intersections = true;
+            }
+        }
+    }
+
     first_point_ = first_point;
     direction_ = direction;
     direction_->normalize();
-    //double dif = std::abs(direction_.magnitude() - direction.magnitude()) / std::max(direction_.magnitude(), direction.magnitude());
-    //if(not std::isnan(dif)) assert(dif < 1e-12);
     distance_ = distance;
-    last_point_ = first_point + GeometryPosition(direction * distance);
+    last_point_ = first_point + GeometryPosition(direction_ * distance);
     set_points_ = true;
     set_det_points_ = false;
-    set_intersections_ = false;
-    set_column_depth_ = false;
+    if(!can_reuse_intersections) {
+        set_intersections_ = false;
+    }
     first_inf_ = IsInfinite(first_point_); // Set using GeometryPosition
     last_inf_ = IsInfinite(last_point_); // Set using GeometryPosition
     RequireFirstFinite();
@@ -204,17 +215,35 @@ void Path::SetPointsWithRay(GeometryPosition first_point, GeometryDirection dire
 }
 
 void Path::SetPointsWithRay(DetectorPosition first_point, DetectorDirection direction, double distance) {
+    // Check if the new ray is collinear with the cached intersections.
+    // intersections_ are stored in geometry frame, so we must convert the
+    // detector-frame arguments before comparing.
+    bool can_reuse_intersections = false;
+    if(set_intersections_ && set_detector_model_) {
+        GeometryDirection geo_dir = detector_model_->ToGeo(direction);
+        GeometryPosition geo_pos = detector_model_->ToGeo(first_point);
+        math::Vector3D new_dir = geo_dir;
+        new_dir.normalize();
+        double dot = std::abs(new_dir * intersections_.direction);
+        if(dot > 1.0 - 1e-9) {
+            math::Vector3D offset = math::Vector3D(geo_pos) - intersections_.position;
+            math::Vector3D perp = math::cross_product(offset, intersections_.direction);
+            if(perp.magnitude() < 1e-6 * (1.0 + offset.magnitude())) {
+                can_reuse_intersections = true;
+            }
+        }
+    }
+
     first_point_det_ = first_point;
     direction_det_ = direction;
     direction_det_->normalize();
-    //double dif = std::abs(direction_.magnitude() - direction.magnitude()) / std::max(direction_.magnitude(), direction.magnitude());
-    //if(not std::isnan(dif)) assert(dif < 1e-12);
     distance_ = distance;
-    last_point_det_ = first_point + DetectorPosition(direction * distance);
+    last_point_det_ = first_point + DetectorPosition(direction_det_ * distance);
     set_points_ = false;
     set_det_points_ = true;
-    set_intersections_ = false;
-    set_column_depth_ = false;
+    if(!can_reuse_intersections) {
+        set_intersections_ = false;
+    }
     first_inf_ = IsInfinite(first_point_det_); // Set using DetectorPosition
     last_inf_ = IsInfinite(last_point_det_); // Set using DetectorPosition
     RequireFirstFinite();
@@ -274,7 +303,6 @@ void Path::ClipToOuterBounds() {
         }
         if(clip) {
             distance_ = (last_point_ - first_point_)->magnitude();
-            set_column_depth_ = false;
         }
         set_det_points_ = false;
     } else {
@@ -303,7 +331,6 @@ void Path::ExtendFromEndByDistance(double distance) {
         distance_ = 0;
         last_point_ = first_point_;
     }
-    set_column_depth_ = false;
     set_det_points_ = false;
 }
 
@@ -316,7 +343,6 @@ void Path::ExtendFromStartByDistance(double distance) {
         distance_ = 0;
         first_point_ = last_point_;
     }
-    set_column_depth_ = false;
     set_det_points_ = false;
 }
 
@@ -504,13 +530,7 @@ double Path::GetColumnDepthInBounds() {
     EnsureIntersections();
     EnsurePoints();
     RequireBothFinite();
-    if(HasColumnDepth()) {
-        return column_depth_cached_;
-    } else {
-        double column_depth = detector_model_->GetColumnDepthInCGS(intersections_, first_point_, last_point_);
-        column_depth_cached_ = column_depth;
-        return column_depth;
-    }
+    return detector_model_->GetColumnDepthInCGS(intersections_, first_point_, last_point_);
 }
 
 

--- a/projects/detector/private/Path.cxx
+++ b/projects/detector/private/Path.cxx
@@ -139,6 +139,10 @@ void Path::SetDetectorModel(std::shared_ptr<const DetectorModel> detector_model)
     if(set_detector_model_ and set_det_points_) {
         set_points_ = false;
     }
+    // Cached intersections are stale if the model changes.
+    if(set_intersections_ and detector_model_ != detector_model) {
+        set_intersections_ = false;
+    }
     detector_model_ = detector_model;
     set_detector_model_ = true;
     UpdatePoints();

--- a/projects/detector/private/gdml/GDMLDefineParser.cxx
+++ b/projects/detector/private/gdml/GDMLDefineParser.cxx
@@ -1,0 +1,224 @@
+#include "GDMLParserPrivate.h"
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+using namespace siren::math;
+
+namespace siren {
+namespace detector {
+namespace gdml {
+// Resolve all <define> sections in document order with inline loop handling.
+// Uses an explicit stack to iterate loop bodies without recursion or DOM
+// modification. Constants/variables are evaluated immediately when encountered,
+// giving document-order semantics (a constant before a loop sees the pre-loop
+// variable value; a constant after sees the post-loop value).
+//
+// Precondition: data.constants has been seeded with the built-in constants
+// (pi, mm, MeV, etc.) by the caller. ParseGDML does this on every entry,
+// including the recursive entry for <file> sub-modules, so the phase parsers
+// (materials, solids, structure, this) can all assume the seed is present.
+void ResolveDefineInOrder(rapidxml::xml_node<>* gdml_node,
+                                 GDMLData & data,
+                                 GDMLParseOptions const & options) {
+    // Evaluate bracket expressions [expr] in an attribute string using current
+    // constants. Transforms "sum_[i+1]" into "sum_4" (if i=3 in constants).
+    // Used for both name and value attributes within loop bodies.
+    auto resolveBrackets = [&](const char* raw) -> std::string {
+        std::string s(raw);
+        size_t pos = 0;
+        while((pos = s.find('[', pos)) != std::string::npos) {
+            size_t end = s.find(']', pos + 1);
+            if(end == std::string::npos) break;
+            std::string expr = s.substr(pos + 1, end - pos - 1);
+            try {
+                double v = EvalExpression(expr, data.constants, data.matrices);
+                long long iv = static_cast<long long>(v);
+                s.replace(pos, end - pos + 1, std::to_string(iv));
+            } catch(...) {
+                pos = end + 1;
+            }
+        }
+        return s;
+    };
+
+    // Stack frame: either a sequence of sibling nodes, or a loop iteration context.
+    struct Frame {
+        rapidxml::xml_node<>* current; // next node to process
+        bool is_loop = false;
+        std::string var_name;
+        double to_val = 0;
+        double step_val = 0;
+        rapidxml::xml_node<>* body_first = nullptr; // first child of loop (for restart)
+    };
+
+    std::vector<Frame> stack;
+    int loop_depth = 0;
+    // Collect define sections in document order, then push in reverse so the
+    // stack (LIFO) processes the first section first.
+    std::vector<rapidxml::xml_node<>*> defines;
+    for(auto* def = gdml_node->first_node("define"); def; def = def->next_sibling("define")) {
+        defines.push_back(def);
+    }
+    for(auto it = defines.rbegin(); it != defines.rend(); ++it) {
+        stack.push_back({(*it)->first_node(), false, {}, 0, 0, nullptr});
+    }
+
+    static constexpr int MAX_DEPTH = 64;
+
+    while(!stack.empty()) {
+        Frame & top = stack.back();
+
+        if(!top.current) {
+            // End of this scope
+            if(top.is_loop) {
+                // Advance loop iteration
+                double next_val = data.constants[top.var_name] + top.step_val;
+                bool in_range = (top.step_val > 0)
+                    ? (next_val <= top.to_val + 1e-9)
+                    : (next_val >= top.to_val - 1e-9);
+                if(in_range) {
+                    data.constants[top.var_name] = next_val;
+                    top.current = top.body_first;
+                    continue;
+                }
+                --loop_depth;
+            }
+            stack.pop_back();
+            continue;
+        }
+
+        auto* node = top.current;
+        top.current = node->next_sibling();
+        std::string tag(node->name());
+
+        if(tag == "loop") {
+            if((int)stack.size() >= MAX_DEPTH) continue;
+            std::string var_name = SafeAttrVal(node, "for");
+            if(IsBuiltInConstant(var_name)) {
+                EmitWarning(data, options, "loop variable '" + var_name + "' shadows a built-in constant, skipping loop");
+                continue;
+            }
+            const char* from_attr = SafeAttrVal(node, "from");
+            double from_val;
+            if(from_attr[0] != '\0') {
+                from_val = SafeParseDouble(from_attr, data.constants, data.matrices);
+            } else {
+                auto it = data.constants.find(var_name);
+                from_val = (it != data.constants.end()) ? it->second : 0.0;
+            }
+            double to_val = SafeParseDouble(SafeAttrVal(node, "to"), data.constants, data.matrices);
+            double step_val = SafeParseDouble(SafeAttrVal(node, "step"), data.constants, data.matrices);
+            if(step_val == 0) step_val = 1.0;
+
+            // Check if the loop will execute at all
+            bool will_run = (step_val > 0) ? (from_val <= to_val + 1e-9) : (from_val >= to_val - 1e-9);
+            if(!will_run || !node->first_node()) continue;
+
+            data.constants[var_name] = from_val;
+            ++loop_depth;
+            stack.push_back({node->first_node(), true, var_name, to_val, step_val, node->first_node()});
+        }
+        else if(tag == "constant" || tag == "variable") {
+            std::string name = resolveBrackets(SafeAttrVal(node, "name"));
+            if(name.empty()) continue;
+            if(IsBuiltInConstant(name)) {
+                EmitWarning(data, options, "cannot redefine built-in constant '" + name + "', ignoring");
+                continue;
+            }
+            bool in_loop = loop_depth > 0;
+            double value;
+            if(in_loop) {
+                std::string val_str = resolveBrackets(SafeAttrVal(node, "value"));
+                value = SafeParseDouble(val_str.c_str(), data.constants, data.matrices);
+            } else {
+                value = SafeParseDouble(SafeAttrVal(node, "value"), data.constants, data.matrices);
+            }
+            data.constants[name] = value;
+        }
+        else if(tag == "quantity") {
+            std::string name = resolveBrackets(SafeAttrVal(node, "name"));
+            if(name.empty()) continue;
+            if(IsBuiltInConstant(name)) {
+                EmitWarning(data, options, "cannot redefine built-in constant '" + name + "', ignoring");
+                continue;
+            }
+            bool in_loop = loop_depth > 0;
+            double value;
+            if(in_loop) {
+                std::string val_str = resolveBrackets(SafeAttrVal(node, "value"));
+                value = SafeParseDouble(val_str.c_str(), data.constants, data.matrices);
+            } else {
+                value = SafeParseDouble(SafeAttrVal(node, "value"), data.constants, data.matrices);
+            }
+            const char* unit = SafeAttrVal(node, "unit");
+            const char* type_attr = SafeAttrVal(node, "type");
+            GDMLQuantityType resolved_type = ResolveQuantityType(type_attr, unit, name, data, options);
+            value *= QuantityUnitScale(unit, resolved_type);
+            data.constants[name] = value;
+            if(resolved_type != GDMLQuantityType::NONE) {
+                data.quantity_types[name] = resolved_type;
+            }
+        }
+        else if(tag == "position") {
+            std::string name = resolveBrackets(SafeAttrVal(node, "name"));
+            if(name.empty()) continue;
+            bool in_loop = loop_depth > 0;
+            const char* unit = SafeAttrVal(node, "unit");
+            double x, y, z;
+            if(in_loop) {
+                x = ParseLength(resolveBrackets(SafeAttrVal(node, "x")).c_str(), unit, data.constants);
+                y = ParseLength(resolveBrackets(SafeAttrVal(node, "y")).c_str(), unit, data.constants);
+                z = ParseLength(resolveBrackets(SafeAttrVal(node, "z")).c_str(), unit, data.constants);
+            } else {
+                x = ParseLength(SafeAttrVal(node, "x"), unit, data.constants);
+                y = ParseLength(SafeAttrVal(node, "y"), unit, data.constants);
+                z = ParseLength(SafeAttrVal(node, "z"), unit, data.constants);
+            }
+            data.positions[name] = Vector3D(x, y, z);
+        }
+        else if(tag == "rotation") {
+            std::string name = resolveBrackets(SafeAttrVal(node, "name"));
+            if(name.empty()) continue;
+            bool in_loop = loop_depth > 0;
+            const char* unit = SafeAttrVal(node, "unit");
+            double rx, ry, rz;
+            if(in_loop) {
+                rx = ParseAngle(resolveBrackets(SafeAttrVal(node, "x")).c_str(), unit, data.constants);
+                ry = ParseAngle(resolveBrackets(SafeAttrVal(node, "y")).c_str(), unit, data.constants);
+                rz = ParseAngle(resolveBrackets(SafeAttrVal(node, "z")).c_str(), unit, data.constants);
+            } else {
+                rx = ParseAngle(SafeAttrVal(node, "x"), unit, data.constants);
+                ry = ParseAngle(SafeAttrVal(node, "y"), unit, data.constants);
+                rz = ParseAngle(SafeAttrVal(node, "z"), unit, data.constants);
+            }
+            data.rotations[name] = QuatFromGDMLRotation(rx, ry, rz);
+        }
+        else if(tag == "matrix") {
+            std::string name = resolveBrackets(SafeAttrVal(node, "name"));
+            if(name.empty()) continue;
+            int coldim = 1;
+            const char* cd = SafeAttrVal(node, "coldim");
+            if(cd[0] != '\0') { try { coldim = std::stoi(std::string(cd)); } catch(...) { coldim = 1; } }
+            if(coldim < 1) coldim = 1;
+            std::string values_str = SafeAttrVal(node, "values");
+            std::vector<double> values;
+            std::istringstream iss(values_str);
+            std::string tok;
+            while(iss >> tok) {
+                values.push_back(EvalExpression(tok, data.constants, data.matrices));
+            }
+            if(!values.empty()) data.matrices[name] = {coldim, values};
+        }
+        else if(tag == "scale") {
+            std::string sname = SafeAttrVal(node, "name");
+            EmitWarning(data, options, "GDML <scale> element '" + sname + "' is not supported and will be ignored");
+        }
+    }
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLExpression.cxx
+++ b/projects/detector/private/gdml/GDMLExpression.cxx
@@ -1,0 +1,390 @@
+#include "GDMLParserPrivate.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <stdexcept>
+
+namespace siren {
+namespace detector {
+namespace gdml {
+// Safe attribute value accessor: returns empty string if attribute is missing
+const char* SafeAttrVal(rapidxml::xml_node<>* node, const char* attr_name) {
+    if(!node) return "";
+    rapidxml::xml_attribute<>* attr = node->first_attribute(attr_name);
+    if(!attr) return "";
+    return attr->value();
+}
+
+// Trim leading and trailing whitespace from a string
+std::string TrimWhitespace(std::string const & s) {
+    size_t start = s.find_first_not_of(" \t\n\r");
+    if(start == std::string::npos) return "";
+    size_t end = s.find_last_not_of(" \t\n\r");
+    return s.substr(start, end - start + 1);
+}
+
+
+// Iterative expression evaluator using the shunting-yard algorithm.
+// Tokenizes the input, converts infix to postfix (RPN), and evaluates
+// the RPN with an explicit value stack. No recursion, O(1) call-stack depth.
+
+enum class TokenKind { NUMBER, OP, LPAREN, RPAREN, COMMA, FUNC, UNARY_NEG };
+
+struct Token {
+    TokenKind kind;
+    double value;
+    char op;
+    std::string name;
+    int argc;
+};
+
+static int OpPrecedence(char op) {
+    if(op == '+' || op == '-') return 1;
+    if(op == '*' || op == '/') return 2;
+    if(op == '^') return 3;
+    return 0;
+}
+
+static bool IsRightAssociative(char op) {
+    return op == '^';
+}
+
+// IsIdentStart and IsIdentChar are in GDMLParserPrivate.h
+
+static double ApplyFunc(std::string const & name, double const * args, int argc, std::string const & expr) {
+    if(argc == 1) {
+        double a = args[0];
+        if(name == "sin") return std::sin(a);
+        if(name == "cos") return std::cos(a);
+        if(name == "tan") return std::tan(a);
+        if(name == "asin") return std::asin(a);
+        if(name == "acos") return std::acos(a);
+        if(name == "atan") return std::atan(a);
+        if(name == "exp") return std::exp(a);
+        if(name == "log") return std::log(a);
+        if(name == "sqrt") return std::sqrt(a);
+        if(name == "abs") return std::fabs(a);
+    } else if(argc == 2) {
+        double a = args[0], b = args[1];
+        if(name == "pow") return std::pow(a, b);
+        if(name == "atan2") return std::atan2(a, b);
+        if(name == "min") return std::min(a, b);
+        if(name == "max") return std::max(a, b);
+    }
+    throw std::runtime_error("GDML expression error: unknown function '" + name + "' in '" + expr + "'");
+}
+
+double EvalExpression(std::string const & expr, std::unordered_map<std::string, double> const & constants,
+                      std::unordered_map<std::string, std::pair<int, std::vector<double>>> const & matrices,
+                      int depth);
+
+static std::vector<Token> Tokenize(std::string const & s, std::unordered_map<std::string, double> const & constants, std::string const & expr,
+                                   std::unordered_map<std::string, std::pair<int, std::vector<double>>> const & matrices = {},
+                                   int depth = 0) {
+    std::vector<Token> tokens;
+    size_t i = 0;
+    while(i < s.size()) {
+        char c = s[i];
+        if(c == ' ' || c == '\t' || c == '\n' || c == '\r') { ++i; continue; }
+
+        if(c == '(') { tokens.push_back({TokenKind::LPAREN}); ++i; continue; }
+        if(c == ')') { tokens.push_back({TokenKind::RPAREN}); ++i; continue; }
+        if(c == ',') { tokens.push_back({TokenKind::COMMA}); ++i; continue; }
+
+        if(c == '+' || c == '-' || c == '*' || c == '/' || c == '^') {
+            bool is_unary = (c == '-' || c == '+') &&
+                (tokens.empty() || tokens.back().kind == TokenKind::LPAREN ||
+                 tokens.back().kind == TokenKind::OP || tokens.back().kind == TokenKind::COMMA ||
+                 tokens.back().kind == TokenKind::UNARY_NEG);
+            if(is_unary && c == '-') {
+                tokens.push_back({TokenKind::UNARY_NEG});
+            } else if(is_unary && c == '+') {
+                // unary plus: skip
+            } else {
+                Token t; t.kind = TokenKind::OP; t.op = c;
+                tokens.push_back(t);
+            }
+            ++i; continue;
+        }
+
+        if(std::isdigit(static_cast<unsigned char>(c)) || c == '.') {
+            char* end = nullptr;
+            double val = std::strtod(s.c_str() + i, &end);
+            Token t; t.kind = TokenKind::NUMBER; t.value = val;
+            tokens.push_back(t);
+            i += (end - (s.c_str() + i)); continue;
+        }
+
+        if(IsIdentStart(c)) {
+            size_t start = i;
+            while(i < s.size() && IsIdentChar(s[i])) ++i;
+            std::string name = s.substr(start, i - start);
+            size_t j = i;
+            while(j < s.size() && (s[j] == ' ' || s[j] == '\t')) ++j;
+            if(j < s.size() && s[j] == '(') {
+                Token t; t.kind = TokenKind::FUNC; t.name = name; t.argc = 1;
+                tokens.push_back(t);
+            } else if(j < s.size() && s[j] == '[') {
+                // Matrix/vector element access: name[idx] or name[row,col]
+                auto mit = matrices.find(name);
+                if(mit == matrices.end()) {
+                    throw std::runtime_error("GDML expression error: unknown matrix '" + name + "' in '" + expr + "'");
+                }
+                i = j + 1; // skip '['
+                // Parse first index expression (up to ',' or ']')
+                int bracket_depth = 1;
+                size_t idx_start = i;
+                size_t comma_pos = std::string::npos;
+                while(i < s.size() && bracket_depth > 0) {
+                    if(s[i] == '[') ++bracket_depth;
+                    else if(s[i] == ']') --bracket_depth;
+                    else if(s[i] == ',' && bracket_depth == 1) comma_pos = i;
+                    if(bracket_depth > 0) ++i;
+                }
+                if(bracket_depth != 0) {
+                    throw std::runtime_error("GDML expression error: unmatched '[' in '" + expr + "'");
+                }
+                size_t bracket_end = i;
+                ++i; // skip ']'
+
+                int coldim = mit->second.first;
+                auto const & vals = mit->second.second;
+                double result;
+
+                if(comma_pos != std::string::npos) {
+                    // Two indices: name[row, col] (1-based)
+                    std::string row_expr = s.substr(idx_start, comma_pos - idx_start);
+                    std::string col_expr = s.substr(comma_pos + 1, bracket_end - comma_pos - 1);
+                    // Recursively evaluate the index expressions
+                    double row_val = EvalExpression(row_expr, constants, {}, depth + 1);
+                    double col_val = EvalExpression(col_expr, constants, {}, depth + 1);
+                    int row = static_cast<int>(row_val + 0.5);
+                    int col = static_cast<int>(col_val + 0.5);
+                    int flat_idx = (row - 1) * coldim + (col - 1);
+                    if(flat_idx < 0 || flat_idx >= static_cast<int>(vals.size())) {
+                        throw std::runtime_error("GDML expression error: matrix index out of range for '" + name + "[" + std::to_string(row) + "," + std::to_string(col) + "]' in '" + expr + "'");
+                    }
+                    result = vals[flat_idx];
+                } else {
+                    // Single index: name[idx] (1-based)
+                    std::string idx_expr = s.substr(idx_start, bracket_end - idx_start);
+                    double idx_val = EvalExpression(idx_expr, constants, {}, depth + 1);
+                    int idx = static_cast<int>(idx_val + 0.5);
+                    int flat_idx = idx - 1;
+                    if(flat_idx < 0 || flat_idx >= static_cast<int>(vals.size())) {
+                        throw std::runtime_error("GDML expression error: matrix index out of range for '" + name + "[" + std::to_string(idx) + "]' in '" + expr + "'");
+                    }
+                    result = vals[flat_idx];
+                }
+                Token t; t.kind = TokenKind::NUMBER; t.value = result;
+                tokens.push_back(t);
+            } else {
+                auto it = constants.find(name);
+                if(it == constants.end()) {
+                    throw std::runtime_error("GDML expression error: unknown constant '" + name + "' in '" + expr + "'");
+                }
+                Token t; t.kind = TokenKind::NUMBER; t.value = it->second;
+                tokens.push_back(t);
+            }
+            continue;
+        }
+
+        throw std::runtime_error("GDML expression error: unexpected character '" + std::string(1, c) + "' in '" + expr + "'");
+    }
+    return tokens;
+}
+
+double EvalExpression(std::string const & expr, std::unordered_map<std::string, double> const & constants,
+                      std::unordered_map<std::string, std::pair<int, std::vector<double>>> const & matrices,
+                      int depth) {
+    if(depth > 64) {
+        throw std::runtime_error("GDML expression error: recursion depth exceeded in '" + expr + "'");
+    }
+    std::string s = TrimWhitespace(expr);
+    if(s.empty()) return 0.0;
+
+    // Fast path: bare number
+    {
+        char* end = nullptr;
+        errno = 0;
+        double val = std::strtod(s.c_str(), &end);
+        if(end != s.c_str() && end == s.c_str() + s.size()) {
+            if(errno == ERANGE)
+                throw std::runtime_error("GDML expression error: numeric value out of range in '" + expr + "'");
+            return val;
+        }
+    }
+
+    // Fast path: bare constant name (only if no bracket follows)
+    {
+        bool bare = true;
+        for(size_t i = 0; i < s.size(); ++i) {
+            if(!IsIdentChar(s[i])) { bare = false; break; }
+        }
+        if(bare && IsIdentStart(s[0])) {
+            auto it = constants.find(s);
+            if(it != constants.end()) return it->second;
+            if(matrices.find(s) == matrices.end()) {
+                throw std::runtime_error("GDML expression error: unknown constant '" + s + "'");
+            }
+        }
+    }
+
+    std::vector<Token> tokens = Tokenize(s, constants, expr, matrices, depth);
+
+    // Shunting-yard: convert to RPN
+    std::vector<Token> output;
+    std::vector<Token> op_stack;
+    output.reserve(tokens.size());
+    op_stack.reserve(tokens.size());
+
+    for(size_t i = 0; i < tokens.size(); ++i) {
+        Token const & tok = tokens[i];
+        switch(tok.kind) {
+        case TokenKind::NUMBER:
+            output.push_back(tok);
+            break;
+        case TokenKind::FUNC:
+            op_stack.push_back(tok);
+            break;
+        case TokenKind::COMMA:
+            while(!op_stack.empty() && op_stack.back().kind != TokenKind::LPAREN) {
+                output.push_back(op_stack.back());
+                op_stack.pop_back();
+            }
+            if(!op_stack.empty() && op_stack.size() >= 2) {
+                Token & func_below = op_stack[op_stack.size() - 2];
+                if(func_below.kind == TokenKind::FUNC) func_below.argc++;
+            }
+            break;
+        case TokenKind::UNARY_NEG:
+        case TokenKind::OP: {
+            // Unary minus is right-associative at the same precedence as ^
+            // so -2+3 = (-2)+3 = 1, -2*3 = (-2)*3 = -6, but -2^2 = -(2^2) = -4
+            // (matching standard math and Geant4/CLHEP convention).
+            int cur_prec = (tok.kind == TokenKind::UNARY_NEG) ? 3 : OpPrecedence(tok.op);
+            bool cur_right = (tok.kind == TokenKind::UNARY_NEG) || IsRightAssociative(tok.op);
+            while(!op_stack.empty()
+                  && (op_stack.back().kind == TokenKind::OP || op_stack.back().kind == TokenKind::UNARY_NEG)) {
+                int stack_prec = (op_stack.back().kind == TokenKind::UNARY_NEG) ? 3 : OpPrecedence(op_stack.back().op);
+                if(cur_right ? (stack_prec > cur_prec) : (stack_prec >= cur_prec)) {
+                    output.push_back(op_stack.back());
+                    op_stack.pop_back();
+                } else {
+                    break;
+                }
+            }
+            op_stack.push_back(tok);
+            break;
+        }
+        case TokenKind::LPAREN:
+            op_stack.push_back(tok);
+            break;
+        case TokenKind::RPAREN:
+            while(!op_stack.empty() && op_stack.back().kind != TokenKind::LPAREN) {
+                output.push_back(op_stack.back());
+                op_stack.pop_back();
+            }
+            if(op_stack.empty()) {
+                throw std::runtime_error("GDML expression error: mismatched parentheses in '" + expr + "'");
+            }
+            op_stack.pop_back(); // pop LPAREN
+            if(!op_stack.empty() && op_stack.back().kind == TokenKind::FUNC) {
+                output.push_back(op_stack.back());
+                op_stack.pop_back();
+            }
+            break;
+        }
+    }
+    while(!op_stack.empty()) {
+        if(op_stack.back().kind == TokenKind::LPAREN) {
+            throw std::runtime_error("GDML expression error: mismatched parentheses in '" + expr + "'");
+        }
+        output.push_back(op_stack.back());
+        op_stack.pop_back();
+    }
+
+    // Evaluate RPN
+    std::vector<double> val_stack;
+    val_stack.reserve(output.size());
+    for(auto const & tok : output) {
+        switch(tok.kind) {
+        case TokenKind::NUMBER:
+            val_stack.push_back(tok.value);
+            break;
+        case TokenKind::OP: {
+            if(val_stack.size() < 2) {
+                throw std::runtime_error("GDML expression error: malformed expression '" + expr + "'");
+            }
+            double b = val_stack.back(); val_stack.pop_back();
+            double a = val_stack.back(); val_stack.pop_back();
+            switch(tok.op) {
+            case '+': val_stack.push_back(a + b); break;
+            case '-': val_stack.push_back(a - b); break;
+            case '*': val_stack.push_back(a * b); break;
+            case '/':
+                if(b == 0.0) throw std::runtime_error("GDML expression error: division by zero in '" + expr + "'");
+                val_stack.push_back(a / b);
+                break;
+            case '^':
+                val_stack.push_back(std::pow(a, b));
+                break;
+            }
+            break;
+        }
+        case TokenKind::UNARY_NEG: {
+            if(val_stack.empty()) {
+                throw std::runtime_error("GDML expression error: malformed expression '" + expr + "'");
+            }
+            val_stack.back() = -val_stack.back();
+            break;
+        }
+        case TokenKind::FUNC: {
+            int argc = tok.argc;
+            if(argc > 2) {
+                throw std::runtime_error("GDML expression error: function '" + tok.name + "' called with " + std::to_string(argc) + " arguments (max 2) in '" + expr + "'");
+            }
+            if(static_cast<int>(val_stack.size()) < argc) {
+                throw std::runtime_error("GDML expression error: not enough arguments for '" + tok.name + "' in '" + expr + "'");
+            }
+            double args[2];
+            for(int j = argc - 1; j >= 0; --j) {
+                args[j] = val_stack.back();
+                val_stack.pop_back();
+            }
+            val_stack.push_back(ApplyFunc(tok.name, args, argc, expr));
+            break;
+        }
+        default:
+            throw std::runtime_error("GDML expression error: unexpected token in RPN for '" + expr + "'");
+        }
+    }
+    if(val_stack.size() != 1) {
+        throw std::runtime_error("GDML expression error: malformed expression '" + expr + "'");
+    }
+    return val_stack[0];
+}
+
+// Parse a double from a string, returning 0 if empty.
+// Optionally evaluates expressions using the provided constants map.
+double SafeParseDouble(const char* val, std::unordered_map<std::string, double> const & constants,
+                       std::unordered_map<std::string, std::pair<int, std::vector<double>>> const & matrices) {
+    if(!val || val[0] == '\0') return 0.0;
+    char* end = nullptr;
+    errno = 0;
+    double result = std::strtod(val, &end);
+    if(end != val && *end == '\0') {
+        if(errno == ERANGE)
+            throw std::runtime_error("GDML expression error: numeric value out of range in '" + std::string(val) + "'");
+        return result;
+    }
+    return EvalExpression(std::string(val), constants, matrices);
+}
+
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLMaterialParser.cxx
+++ b/projects/detector/private/gdml/GDMLMaterialParser.cxx
@@ -1,0 +1,281 @@
+#include "GDMLParserPrivate.h"
+
+#include <cctype>
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace siren {
+namespace detector {
+namespace gdml {
+// Parse all <materials> sections with instance-scoped name resolution.
+// Each name can have multiple definitions (instances). Composition references
+// resolve to the current instance of the referenced name at definition time.
+// After parsing, multi-instance names are flattened to unique names.
+void ParseAllMaterials(rapidxml::xml_node<>* root_node, GDMLData & data, GDMLParseOptions const & options) {
+    if(!root_node) return;
+
+    // Collect all <materials> section nodes
+    std::vector<rapidxml::xml_node<>*> mat_sections;
+    for(auto* node = root_node->first_node("materials"); node; node = node->next_sibling("materials")) {
+        mat_sections.push_back(node);
+    }
+    if(mat_sections.empty()) return;
+
+    // Instance trackers for the three GDML material namespaces.
+    auto mat_eq = [](GDMLMaterial const & a, GDMLMaterial const & b) { return a == b; };
+    InstanceTracker<GDMLMaterial> isotope_tracker(data, options.strip_pointer_suffixes);
+    InstanceTracker<GDMLMaterial> element_tracker(data, options.strip_pointer_suffixes);
+    InstanceTracker<GDMLMaterial> material_tracker(data, options.strip_pointer_suffixes);
+
+    auto storeInStack = [&](InstanceTracker<GDMLMaterial> & tracker, GDMLMaterial const & mat) {
+        GDMLMaterial stored = mat;
+        std::string stripped = StripPointerSuffix(mat.name, options.strip_pointer_suffixes);
+        stored.name = stripped;
+        tracker.Store(mat.name, stored, mat_eq);
+    };
+
+    // Resolve a composition reference across all three namespaces.
+    // Isotopes first (most specific), then elements, then materials.
+    auto resolveCompRef = [&](std::string const & ref_name) -> std::string {
+        std::string resolved = isotope_tracker.Resolve(ref_name);
+        if(resolved != StripPointerSuffix(ref_name, options.strip_pointer_suffixes)) return resolved;
+        resolved = element_tracker.Resolve(ref_name);
+        if(resolved != StripPointerSuffix(ref_name, options.strip_pointer_suffixes)) return resolved;
+        return material_tracker.Resolve(ref_name);
+    };
+
+    // Process all sections in order
+    for(auto* mat_node : mat_sections) {
+        for(auto* node = mat_node->first_node(); node; node = node->next_sibling()) {
+            std::string tag(node->name());
+
+            if(tag == "isotope") {
+                GDMLMaterial mat;
+                mat.name = SafeAttrVal(node, "name");
+                mat.Z = SafeParseDouble(SafeAttrVal(node, "Z"), data.constants);
+                mat.A = SafeParseDouble(SafeAttrVal(node, "N"), data.constants);
+                mat.density = 0.0;
+
+                auto* atom_node = node->first_node("atom");
+                if(atom_node) {
+                    mat.A = SafeParseDouble(SafeAttrVal(atom_node, "value"), data.constants);
+                }
+
+                if(!mat.name.empty()) {
+                    storeInStack(isotope_tracker, mat);
+                }
+            }
+            else if(tag == "element") {
+                GDMLMaterial mat;
+                mat.name = SafeAttrVal(node, "name");
+                mat.Z = SafeParseDouble(SafeAttrVal(node, "Z"), data.constants);
+                mat.density = 0.0;
+                mat.A = 0.0;
+
+                auto* atom_node = node->first_node("atom");
+                if(atom_node) {
+                    const char* a_val = SafeAttrVal(atom_node, "value");
+                    mat.A = SafeParseDouble(a_val, data.constants);
+                }
+
+                // Fraction children (element defined as isotope mix)
+                // Resolve each ref to the current instance
+                for(auto* frac = node->first_node("fraction"); frac; frac = frac->next_sibling("fraction")) {
+                    std::string ref = SafeAttrVal(frac, "ref");
+                    double n = SafeParseDouble(SafeAttrVal(frac, "n"), data.constants);
+                    if(!ref.empty()) {
+                        mat.composition[resolveCompRef(ref)] = n;
+                    }
+                }
+
+                if(!mat.name.empty()) {
+                    storeInStack(element_tracker, mat);
+                }
+            }
+            else if(tag == "material") {
+                GDMLMaterial mat;
+                mat.name = SafeAttrVal(node, "name");
+                mat.Z = SafeParseDouble(SafeAttrVal(node, "Z"), data.constants);
+                mat.density = 0.0;
+                mat.A = 0.0;
+
+                auto* d_node = node->first_node("D");
+                if(d_node) {
+                    const char* d_val_str = SafeAttrVal(d_node, "value");
+                    std::string d_val_trimmed = TrimWhitespace(d_val_str);
+                    auto qty_it = data.quantity_types.find(d_val_trimmed);
+                    bool is_density_qty = (qty_it != data.quantity_types.end()
+                                           && qty_it->second == GDMLQuantityType::DENSITY);
+
+                    // Guard against inline-unit density expressions
+                    // (e.g. value="1*gram"). SafeParseDouble would resolve
+                    // 'gram' to the CLHEP-internal scale 6.24e21, and no
+                    // subsequent unit-attribute conversion can undo it,
+                    // so the stored density would be wrong by 20+ orders
+                    // of magnitude. Typed <quantity type="density"> refs
+                    // route through QuantityUnitScale and are safe.
+                    if(!is_density_qty) {
+                        std::string found_unit;
+                        if(ExpressionContainsUnitBuiltIn(d_val_trimmed, found_unit)) {
+                            throw std::runtime_error(
+                                "Material '" + mat.name + "' has <D value=\"" +
+                                d_val_trimmed + "\"> which embeds the unit "
+                                "identifier '" + found_unit + "'. Inline-unit "
+                                "expressions are not supported in density values "
+                                "because SafeParseDouble would resolve the unit "
+                                "to its CLHEP-internal scale. Use "
+                                "<D value=\"<number>\" unit=\"g/cm3\"/> (or a "
+                                "<quantity type=\"density\"> definition) instead.");
+                        }
+                    }
+
+                    mat.density = SafeParseDouble(d_val_str, data.constants);
+
+                    if(!is_density_qty) {
+                        const char* d_unit = SafeAttrVal(d_node, "unit");
+                        if(d_unit && d_unit[0] != '\0') {
+                            std::string du(d_unit);
+                            if(du == "kg/m3") {
+                                mat.density /= 1000.0;
+                            } else if(du == "mg/cm3") {
+                                mat.density /= 1000.0;
+                            } else if(du == "g/cm3") {
+                                // No conversion needed
+                            } else {
+                                EmitWarning(data, options, "unrecognized density unit '" + du + "' for material '" + mat.name + "', assuming g/cm3");
+                            }
+                        }
+                    }
+                }
+                if(mat.density < 0.0) {
+                    throw std::runtime_error("Material '" + mat.name + "' has negative density: " + std::to_string(mat.density));
+                }
+                if(mat.density == 0.0) {
+                    EmitWarning(data, options, "material '" + mat.name + "' has zero density, treating as vacuum (1e-25 g/cm3)");
+                    mat.density = 1e-25;
+                }
+
+                auto* atom_node = node->first_node("atom");
+                if(atom_node) {
+                    mat.A = SafeParseDouble(SafeAttrVal(atom_node, "value"), data.constants);
+                    // Z can appear on the <material> element or on <atom>.
+                    // Some GDML generators put it on <atom Z="..."/>.
+                    if(mat.Z == 0) {
+                        mat.Z = SafeParseDouble(SafeAttrVal(atom_node, "Z"), data.constants);
+                    }
+                }
+
+                // Fraction children: resolve each ref to the current instance
+                for(auto* frac = node->first_node("fraction"); frac; frac = frac->next_sibling("fraction")) {
+                    std::string ref = SafeAttrVal(frac, "ref");
+                    double n = SafeParseDouble(SafeAttrVal(frac, "n"), data.constants);
+                    if(!ref.empty()) {
+                        mat.composition[resolveCompRef(ref)] = n;
+                    }
+                }
+
+                // Composite children: atom counts -> mass fractions.
+                // Collect (resolved_name, atom_count) pairs, then convert
+                // to mass fractions using the referenced element's atomic mass:
+                //   mass_fraction_i = n_i * A_i / sum(n_j * A_j)
+                std::vector<std::pair<std::string, double>> composite_entries;
+                for(auto* comp = node->first_node("composite"); comp; comp = comp->next_sibling("composite")) {
+                    std::string ref = SafeAttrVal(comp, "ref");
+                    double n = SafeParseDouble(SafeAttrVal(comp, "n"), data.constants);
+                    if(!ref.empty()) {
+                        composite_entries.push_back({resolveCompRef(ref), n});
+                    }
+                }
+                if(!composite_entries.empty()) {
+                    // Extract original name from a flattened name like "Iron__2".
+                    // The flattened format is "OriginalName__N" (double underscore + instance number).
+                    // Instance 0 keeps the original name unchanged.
+                    // Parse a flattened name "Base__N" into (base, index).
+                    // FlatName uses 1-based suffixes, so "Iron__2" → index 1.
+                    // Returns (name, 0) for bare names without a suffix.
+                    auto parseFlatIdx = [](std::string const & flat) -> std::pair<std::string, int> {
+                        size_t pos = flat.rfind("__");
+                        if(pos == std::string::npos || pos == 0 || pos + 2 >= flat.size())
+                            return {flat, 0};
+                        for(size_t i = pos + 2; i < flat.size(); ++i)
+                            if(!std::isdigit(static_cast<unsigned char>(flat[i])))
+                                return {flat, 0};
+                        int idx = std::stoi(flat.substr(pos + 2)) - 1;
+                        return {flat.substr(0, pos), (idx >= 0) ? idx : 0};
+                    };
+                    auto lookupA = [&](std::string const & resolved_name) -> double {
+                        auto [base, idx] = parseFlatIdx(resolved_name);
+                        auto const & iso_inst = isotope_tracker.Instances();
+                        auto iso_it = iso_inst.find(base);
+                        if(iso_it != iso_inst.end() && idx < (int)iso_it->second.size())
+                            return iso_it->second[idx].A;
+                        auto const & elem_inst = element_tracker.Instances();
+                        auto elem_it = elem_inst.find(base);
+                        if(elem_it != elem_inst.end() && idx < (int)elem_it->second.size())
+                            return elem_it->second[idx].A;
+                        auto const & mat_inst = material_tracker.Instances();
+                        auto mat_it = mat_inst.find(base);
+                        if(mat_it != mat_inst.end() && idx < (int)mat_it->second.size())
+                            return mat_it->second[idx].A;
+                        return 0.0;
+                    };
+                    double total_mass = 0.0;
+                    std::vector<double> masses(composite_entries.size());
+                    for(size_t ci = 0; ci < composite_entries.size(); ++ci) {
+                        double A = lookupA(composite_entries[ci].first);
+                        masses[ci] = composite_entries[ci].second * A;
+                        total_mass += masses[ci];
+                    }
+                    if(total_mass > 0) {
+                        for(size_t ci = 0; ci < composite_entries.size(); ++ci) {
+                            mat.composition[composite_entries[ci].first] = masses[ci] / total_mass;
+                        }
+                    } else {
+                        for(auto const & ce : composite_entries) {
+                            mat.composition[ce.first] = ce.second;
+                        }
+                    }
+                }
+
+                if(!mat.name.empty()) {
+                    storeInStack(material_tracker, mat);
+                }
+            }
+        }
+    }
+
+    // Flatten all three trackers into GDMLData maps.
+    // Flatten handles suffix-then-strip naming and alias rewriting.
+    auto mat_set_name = [](GDMLMaterial & m, std::string const & n) { m.name = n; };
+    auto renames_iso = isotope_tracker.Flatten(data.isotopes, nullptr, mat_set_name);
+    auto renames_elem = element_tracker.Flatten(data.elements, nullptr, mat_set_name);
+    auto renames_mat = material_tracker.Flatten(data.materials, &data.material_instance_counts, mat_set_name);
+
+    // Merge all renames and rewrite composition references across all maps.
+    std::unordered_map<std::string, std::string> all_renames;
+    all_renames.insert(renames_iso.begin(), renames_iso.end());
+    all_renames.insert(renames_elem.begin(), renames_elem.end());
+    all_renames.insert(renames_mat.begin(), renames_mat.end());
+    if(!all_renames.empty()) {
+        auto rewriteComposition = [&](std::unordered_map<std::string, GDMLMaterial> & dest) {
+            for(auto & pair : dest) {
+                std::map<std::string, double> new_comp;
+                for(auto const & comp : pair.second.composition) {
+                    auto rit = all_renames.find(comp.first);
+                    new_comp[rit != all_renames.end() ? rit->second : comp.first] = comp.second;
+                }
+                pair.second.composition = std::move(new_comp);
+            }
+        };
+        rewriteComposition(data.isotopes);
+        rewriteComposition(data.elements);
+        rewriteComposition(data.materials);
+    }
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLParserPrivate.h
+++ b/projects/detector/private/gdml/GDMLParserPrivate.h
@@ -1,0 +1,321 @@
+#pragma once
+
+#include <cctype>
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "SIREN/detector/GDMLParser.h"
+
+#include <cereal/external/rapidxml/rapidxml.hpp>
+
+#include "SIREN/math/Quaternion.h"
+#include "SIREN/math/Vector3D.h"
+
+namespace rapidxml = cereal::rapidxml;
+
+namespace siren {
+namespace detector {
+namespace gdml {
+
+struct GDMLPlacement {
+    math::Vector3D position = math::Vector3D(0, 0, 0);
+    math::Quaternion rotation = math::Quaternion();
+    bool specified = false;
+};
+
+struct GDMLPhiRange {
+    double start = 0.0;
+    double delta = 0.0;
+};
+
+struct GDMLZPlanes {
+    std::vector<double> z;
+    std::vector<double> rmin;
+    std::vector<double> rmax;
+};
+
+const char* SafeAttrVal(rapidxml::xml_node<>* node, const char* attr_name);
+std::string TrimWhitespace(std::string const & s);
+
+// Strip trailing Geant4 pointer-address suffix (e.g. "Si0x7f3a4c002a" -> "Si").
+// Requires at least 7 hex digits after "0x" to avoid false positives on
+// intentional hex names (real pointer addresses are 9-12 hex digits).
+// Returns the name unchanged if no valid suffix is found or if disabled.
+inline std::string StripPointerSuffix(std::string const & name, bool enabled = true) {
+    if(!enabled) return name;
+    size_t pos = name.rfind("0x");
+    if(pos == std::string::npos || pos == 0) return name;
+    size_t hex_len = name.size() - (pos + 2);
+    if(hex_len < 7) return name;
+    for(size_t i = pos + 2; i < name.size(); ++i) {
+        char c = name[i];
+        bool is_hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+        if(!is_hex) return name;
+    }
+    return name.substr(0, pos);
+}
+
+// Resolve a name through the alias map, returning the canonical name.
+// If the name is not in the alias map, returns it unchanged.
+inline std::string ResolveAlias(std::string const & name, GDMLData const & data) {
+    auto it = data.name_aliases.find(name);
+    return (it != data.name_aliases.end()) ? it->second : name;
+}
+
+inline bool IsIdentStart(char c) {
+    return std::isalpha(static_cast<unsigned char>(c)) || c == '_';
+}
+
+inline bool IsIdentChar(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
+
+bool IsBuiltInConstant(std::string const & name);
+void SeedBuiltInConstants(GDMLData & data);
+
+// Returns true if expr contains any built-in identifier that carries a
+// dimensional scale (gram, cm, eV, ...). Math-only built-ins (pi, e, ...)
+// are allowed. On a hit, found_name is set to the offending identifier.
+// Used by the materials parser to reject <D value="N*gram"/> and similar
+// inline-unit density expressions that would silently misparse.
+bool ExpressionContainsUnitBuiltIn(std::string const & expr, std::string & found_name);
+
+double EvalExpression(std::string const & expr,
+                      std::unordered_map<std::string, double> const & constants,
+                      std::unordered_map<std::string, std::pair<int, std::vector<double>>> const & matrices = {},
+                      int depth = 0);
+double SafeParseDouble(const char* val,
+                       std::unordered_map<std::string, double> const & constants = {},
+                       std::unordered_map<std::string, std::pair<int, std::vector<double>>> const & matrices = {});
+
+double LengthScale(const char* unit);
+double ParseLength(const char* value, const char* unit,
+                   std::unordered_map<std::string, double> const & constants = {});
+double AngleScale(const char* unit);
+double ParseAngle(const char* value, const char* unit,
+                  std::unordered_map<std::string, double> const & constants = {});
+math::Quaternion QuatFromGDMLRotation(double rx, double ry, double rz);
+
+GDMLQuantityType ResolveQuantityType(const char* type_attr, const char* unit,
+                                     std::string const & name,
+                                     GDMLData & data,
+                                     GDMLParseOptions const & options);
+double QuantityUnitScale(const char* unit, GDMLQuantityType resolved_type);
+
+double ReadDoubleAttr(rapidxml::xml_node<>* node, const char* attr,
+                      std::unordered_map<std::string, double> const & constants,
+                      double scale = 1.0);
+double ReadLengthAttr(rapidxml::xml_node<>* node, const char* attr,
+                      double lscale,
+                      std::unordered_map<std::string, double> const & constants);
+double ReadAngleAttr(rapidxml::xml_node<>* node, const char* attr,
+                     double ascale,
+                     std::unordered_map<std::string, double> const & constants);
+GDMLPhiRange ReadPhiRange(rapidxml::xml_node<>* node,
+                          double ascale,
+                          std::unordered_map<std::string, double> const & constants);
+math::Vector3D ReadPositionXYZ(rapidxml::xml_node<>* node, GDMLData const & data);
+math::Quaternion ReadRotationXYZ(rapidxml::xml_node<>* node, GDMLData const & data);
+math::Vector3D ReadPositionReferenceAttr(rapidxml::xml_node<>* node,
+                                         const char* attr,
+                                         GDMLData const & data);
+GDMLPlacement ReadPlacement(rapidxml::xml_node<>* node,
+                            const char* position_tag,
+                            const char* position_ref_tag,
+                            const char* rotation_tag,
+                            const char* rotation_ref_tag,
+                            GDMLData const & data);
+GDMLZPlanes ReadZPlanes(rapidxml::xml_node<>* node,
+                        double lscale,
+                        GDMLData const & data);
+bool ValidateZPlaneMonotonicity(GDMLZPlanes const & planes);
+
+std::string ExpandEntities(std::string const & content, std::string const & base_dir);
+std::string ExpandXIncludes(std::string const & content, std::string const & base_dir);
+void ExpandLoops(rapidxml::xml_document<> & doc,
+                 rapidxml::xml_node<>* root,
+                 std::unordered_map<std::string, double> & constants,
+                 GDMLData & data);
+
+void EmitWarning(GDMLData & data, GDMLParseOptions const & options, std::string const & msg);
+
+// =========================================================================
+// InstanceTracker: reusable instance-tracking with pointer-suffix stripping,
+// dedup, alias recording, and suffix-then-strip flatten.
+//
+// Used by materials (GDMLMaterial), solids (shared_ptr<Geometry>), and
+// volumes (GDMLVolume) to handle Geant4 exports with pointer-suffixed names
+// and hand-written GDML with duplicate definitions.
+// =========================================================================
+template<typename T>
+class InstanceTracker {
+public:
+    using EqualFn = std::function<bool(T const &, T const &)>;
+
+    InstanceTracker(GDMLData & data, bool strip_suffixes)
+        : data_(data), strip_(strip_suffixes) {}
+
+    // Store an item under original_name. Strips pointer suffix, dedups
+    // against the most recent instance (using eq), records alias if the
+    // original name had a pointer suffix.
+    void Store(std::string const & original_name, T const & item, EqualFn const & eq) {
+        std::string stripped = StripPointerSuffix(original_name, strip_);
+        bool had_suffix = (stripped != original_name);
+        auto & vec = instances_[stripped];
+        if(!vec.empty() && eq(vec.back(), item)) {
+            if(had_suffix) {
+                data_.name_aliases[original_name] = FlatName(stripped, (int)vec.size() - 1);
+            }
+            return;
+        }
+        vec.push_back(item);
+        counts_[stripped] = (int)vec.size();
+        if(had_suffix) {
+            data_.name_aliases[original_name] = FlatName(stripped, (int)vec.size() - 1);
+        }
+    }
+
+    // Resolve a reference name to its flattened name for the most recent
+    // instance. Strips pointer suffix first.
+    std::string Resolve(std::string const & ref_name) const {
+        std::string name = StripPointerSuffix(ref_name, strip_);
+        auto it = counts_.find(name);
+        if(it != counts_.end()) {
+            return FlatName(name, it->second - 1);
+        }
+        return name;
+    }
+
+    // Look up the most recent instance by name. Checks alias map first,
+    // then falls back to stripped name.
+    T const * Lookup(std::string const & original_name) const {
+        auto ait = data_.name_aliases.find(original_name);
+        if(ait != data_.name_aliases.end()) {
+            auto parsed = ParseFlatName(ait->second);
+            if(parsed.second >= 0) {
+                auto sit = instances_.find(parsed.first);
+                if(sit != instances_.end() && parsed.second < (int)sit->second.size()) {
+                    return &sit->second[parsed.second];
+                }
+            }
+        }
+        std::string name = StripPointerSuffix(original_name, strip_);
+        auto it = counts_.find(name);
+        if(it != counts_.end()) {
+            return &instances_.at(name)[it->second - 1];
+        }
+        return nullptr;
+    }
+
+    // Instance count for a stripped name.
+    int Count(std::string const & name) const {
+        auto it = counts_.find(name);
+        return (it != counts_.end()) ? it->second : 0;
+    }
+
+    // Access raw instances map.
+    std::unordered_map<std::string, std::vector<T>> const & Instances() const { return instances_; }
+
+    using NameSetter = std::function<void(T &, std::string const &)>;
+
+    // Flatten into dest map with suffix-then-strip naming. Populates
+    // instance_counts and returns the rename map (suffixed -> bare) for
+    // sole instances so callers can rewrite cross-map references.
+    // If set_name is provided, it is called on each item with its final
+    // map key (handles types like GDMLMaterial/GDMLVolume that have a
+    // name field that must match the map key).
+    std::unordered_map<std::string, std::string> Flatten(
+            std::unordered_map<std::string, T> & dest,
+            std::unordered_map<std::string, int> * instance_counts = nullptr,
+            NameSetter set_name = nullptr) {
+        for(auto const & pair : instances_) {
+            std::string const & name = pair.first;
+            auto const & vec = pair.second;
+            if(instance_counts) {
+                (*instance_counts)[name] = (int)vec.size();
+            }
+            for(int i = 0; i < (int)vec.size(); ++i) {
+                std::string flat = FlatName(name, i);
+                dest[flat] = vec[i];
+                if(set_name) set_name(dest[flat], flat);
+            }
+        }
+        // Build rename map and apply strip for sole instances
+        std::unordered_map<std::string, std::string> renames;
+        for(auto const & pair : instances_) {
+            if(pair.second.size() == 1) {
+                renames[FlatName(pair.first, 0)] = pair.first;
+            }
+        }
+        for(auto const & r : renames) {
+            auto it = dest.find(r.first);
+            if(it != dest.end()) {
+                T val = std::move(it->second);
+                dest.erase(it);
+                if(set_name) set_name(val, r.second);
+                dest[r.second] = std::move(val);
+            }
+        }
+        // Update aliases that point to renamed keys
+        for(auto & alias : data_.name_aliases) {
+            auto rit = renames.find(alias.second);
+            if(rit != renames.end()) {
+                alias.second = rit->second;
+            }
+        }
+        return renames;
+    }
+
+    std::string FlatName(std::string const & name, int idx) const {
+        return name + "__" + std::to_string(idx + 1);
+    }
+
+private:
+    // Parse "name__N" into (name, N-1). Returns ("", -1) on failure.
+    static std::pair<std::string, int> ParseFlatName(std::string const & flat) {
+        size_t sep = flat.rfind("__");
+        if(sep == std::string::npos || sep == 0 || sep + 2 >= flat.size()) {
+            return {"", -1};
+        }
+        bool all_digits = true;
+        for(size_t i = sep + 2; i < flat.size(); ++i) {
+            if(!std::isdigit(static_cast<unsigned char>(flat[i]))) {
+                all_digits = false;
+                break;
+            }
+        }
+        if(!all_digits) return {"", -1};
+        int idx = std::stoi(flat.substr(sep + 2)) - 1;
+        return {flat.substr(0, sep), idx};
+    }
+
+    GDMLData & data_;
+    bool strip_;
+    std::unordered_map<std::string, std::vector<T>> instances_;
+    std::unordered_map<std::string, int> counts_;
+};
+
+void ResolveDefineInOrder(rapidxml::xml_node<>* gdml_node,
+                          GDMLData & data,
+                          GDMLParseOptions const & options);
+void ParseAllMaterials(rapidxml::xml_node<>* root_node,
+                       GDMLData & data,
+                       GDMLParseOptions const & options);
+void ParseAllSolids(rapidxml::xml_node<>* root_node,
+                    GDMLData & data,
+                    GDMLParseOptions const & options);
+void ParseStructure(rapidxml::xml_node<>* structure_node,
+                    GDMLData & data,
+                    GDMLParseOptions const & options);
+void ParseSetup(rapidxml::xml_node<>* setup_node,
+                GDMLData & data,
+                GDMLParseOptions const & options);
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLPreprocess.cxx
+++ b/projects/detector/private/gdml/GDMLPreprocess.cxx
@@ -1,0 +1,485 @@
+#include "GDMLParserPrivate.h"
+
+#include <cmath>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+namespace siren {
+namespace detector {
+namespace gdml {
+static std::vector<std::pair<std::string, std::string>> ParseEntityDeclarations(
+        std::string const & content, std::string const & base_dir) {
+    std::vector<std::pair<std::string, std::string>> decls;
+
+    size_t doctype_start = content.find("<!DOCTYPE");
+    if(doctype_start == std::string::npos)
+        doctype_start = content.find("<!doctype");
+    if(doctype_start == std::string::npos) return decls;
+
+    size_t bracket_open = content.find('[', doctype_start);
+    if(bracket_open == std::string::npos) return decls;
+    size_t bracket_close = content.find(']', bracket_open);
+    if(bracket_close == std::string::npos) return decls;
+
+    std::string dtd = content.substr(bracket_open + 1, bracket_close - bracket_open - 1);
+    size_t pos = 0;
+    while((pos = dtd.find("<!ENTITY", pos)) != std::string::npos) {
+        pos += 8;
+        while(pos < dtd.size() && std::isspace(static_cast<unsigned char>(dtd[pos]))) ++pos;
+
+        size_t name_start = pos;
+        while(pos < dtd.size() && !std::isspace(static_cast<unsigned char>(dtd[pos]))) ++pos;
+        std::string ent_name = dtd.substr(name_start, pos - name_start);
+
+        while(pos < dtd.size() && std::isspace(static_cast<unsigned char>(dtd[pos]))) ++pos;
+
+        if(dtd.substr(pos, 6) != "SYSTEM") continue;
+        pos += 6;
+        while(pos < dtd.size() && std::isspace(static_cast<unsigned char>(dtd[pos]))) ++pos;
+
+        if(pos >= dtd.size()) break;
+        char quote = dtd[pos];
+        if(quote != '"' && quote != '\'') continue;
+        ++pos;
+        size_t path_start = pos;
+        while(pos < dtd.size() && dtd[pos] != quote) ++pos;
+        std::string filepath = dtd.substr(path_start, pos - path_start);
+
+        std::string full_path;
+        if(!filepath.empty() && filepath[0] == '/') {
+            full_path = filepath;
+        } else {
+            full_path = base_dir + "/" + filepath;
+        }
+        decls.push_back({ent_name, full_path});
+    }
+    return decls;
+}
+
+// Strip the DOCTYPE declaration from content (RapidXML cannot parse it).
+static std::string StripDoctype(std::string const & content) {
+    size_t doctype_start = content.find("<!DOCTYPE");
+    if(doctype_start == std::string::npos)
+        doctype_start = content.find("<!doctype");
+    if(doctype_start == std::string::npos) return content;
+
+    size_t bracket_close = content.find(']', doctype_start);
+    if(bracket_close == std::string::npos) return content;
+    size_t doctype_end = content.find('>', bracket_close);
+    if(doctype_end == std::string::npos) return content;
+
+    std::string result = content;
+    result.erase(doctype_start, doctype_end - doctype_start + 1);
+    return result;
+}
+
+// Substitute entity references (&name;) in content using the given entity map.
+static std::string SubstituteEntities(std::string const & content,
+        std::map<std::string, std::string> const & entities) {
+    if(entities.empty()) return content;
+    std::string result;
+    result.reserve(content.size());
+    size_t pos = 0;
+    while(pos < content.size()) {
+        size_t amp = content.find('&', pos);
+        if(amp == std::string::npos) {
+            result.append(content, pos, content.size() - pos);
+            break;
+        }
+        result.append(content, pos, amp - pos);
+        size_t semi = content.find(';', amp + 1);
+        if(semi == std::string::npos) {
+            result.append(content, amp, content.size() - amp);
+            break;
+        }
+        std::string ent_name = content.substr(amp + 1, semi - amp - 1);
+        auto it = entities.find(ent_name);
+        if(it != entities.end()) {
+            result.append(it->second);
+        } else {
+            result.append(content, amp, semi - amp + 1);
+        }
+        pos = semi + 1;
+    }
+    return result;
+}
+
+// Preprocess XML content to expand ENTITY references.
+// Reads the DOCTYPE for ENTITY SYSTEM declarations, loads the referenced files,
+// and substitutes all &name; references with file contents.
+// Uses an iterative stack to handle nested entity files without recursion.
+// Each stack frame owns its own scope: entities declared in a file's DOCTYPE
+// are only visible for substitution within that file's content.
+std::string ExpandEntities(std::string const & content, std::string const & base_dir) {
+    struct Frame {
+        std::string content;
+        std::string base_dir;
+        std::vector<std::pair<std::string, std::string>> decls; // name, file_path
+        std::map<std::string, std::string> resolved;            // name -> expanded content
+        int next_decl = 0;
+    };
+
+    std::vector<Frame> stack;
+    stack.push_back({content, base_dir, ParseEntityDeclarations(content, base_dir), {}, 0});
+
+    static constexpr int MAX_DEPTH = 16;
+
+    while(!stack.empty()) {
+        Frame & top = stack.back();
+
+        if(top.next_decl < (int)top.decls.size() && (int)stack.size() <= MAX_DEPTH) {
+            auto & [ent_name, ent_path] = top.decls[top.next_decl];
+            top.next_decl++;
+
+            std::ifstream ent_file(ent_path.c_str(), std::ios::binary);
+            if(!ent_file.is_open()) continue;
+
+            std::string file_content((std::istreambuf_iterator<char>(ent_file)),
+                                      std::istreambuf_iterator<char>());
+            ent_file.close();
+
+            size_t last_slash = ent_path.rfind('/');
+            std::string ent_dir = (last_slash != std::string::npos) ?
+                ent_path.substr(0, last_slash) : top.base_dir;
+
+            auto child_decls = ParseEntityDeclarations(file_content, ent_dir);
+            if(child_decls.empty()) {
+                top.resolved[ent_name] = file_content;
+            } else {
+                stack.push_back({file_content, ent_dir, std::move(child_decls), {}, 0});
+                // Tag the child frame so we know which entity it resolves
+                // Store the entity name in the parent's next slot (already incremented)
+                // We'll retrieve it when the child pops
+            }
+        } else {
+            // All declarations resolved (or depth limit reached) - substitute and pop
+            std::string expanded = StripDoctype(top.content);
+            if(!top.resolved.empty()) {
+                expanded = SubstituteEntities(expanded, top.resolved);
+            }
+
+            if(stack.size() == 1) {
+                return expanded;
+            }
+
+            // Pop this frame and store result in parent as the resolved entity
+            std::string result = std::move(expanded);
+            stack.pop_back();
+
+            Frame & parent = stack.back();
+            // The entity name is from the declaration we just finished processing
+            // (parent.next_decl - 1, since we incremented before pushing)
+            std::string const & ent_name = parent.decls[parent.next_decl - 1].first;
+            parent.resolved[ent_name] = std::move(result);
+        }
+    }
+
+    return content;
+}
+
+
+static size_t FindXIncludeEnd(std::string const & content, size_t inc_start) {
+    size_t self_close = content.find("/>", inc_start);
+    size_t explicit_close = content.find("</xi:include>", inc_start);
+
+    if(self_close == std::string::npos && explicit_close == std::string::npos) {
+        return std::string::npos;
+    }
+    if(self_close != std::string::npos
+       && (explicit_close == std::string::npos || self_close < explicit_close)) {
+        return self_close + 2;
+    }
+    return explicit_close + std::string("</xi:include>").size();
+}
+
+static std::string ExtractQuotedAttribute(std::string const & tag, std::string const & attr) {
+    size_t pos = 0;
+    while((pos = tag.find(attr, pos)) != std::string::npos) {
+        bool left_ok = (pos == 0 || !IsIdentChar(tag[pos - 1]));
+        size_t after = pos + attr.size();
+        bool right_ok = (after < tag.size() && tag[after] == '=');
+        if(left_ok && right_ok) break;
+        pos = after;
+    }
+    if(pos == std::string::npos) return "";
+
+    pos += attr.size() + 1;
+    if(pos >= tag.size()) return "";
+
+    char quote = tag[pos];
+    if(quote != '"' && quote != '\'') return "";
+
+    ++pos;
+    size_t end = tag.find(quote, pos);
+    if(end == std::string::npos) return "";
+    return tag.substr(pos, end - pos);
+}
+
+static std::string DirectoryName(std::string const & path, std::string const & fallback) {
+    size_t slash = path.rfind('/');
+    if(slash == std::string::npos) return fallback;
+    return path.substr(0, slash);
+}
+
+static std::string ResolvePath(std::string const & href, std::string const & base_dir) {
+    if(href.empty()) return "";
+    if(href[0] == '/') return href;
+    return base_dir + "/" + href;
+}
+
+static bool ContainsPath(std::vector<std::string> const & stack, std::string const & path) {
+    for(auto const & entry : stack) {
+        if(entry == path) return true;
+    }
+    return false;
+}
+
+static std::string ExpandXIncludesImpl(std::string const & content,
+                                        std::string const & base_dir,
+                                        std::vector<std::string> & include_stack,
+                                        int depth) {
+    static constexpr int MAX_XINCLUDE_DEPTH = 16;
+
+    std::string result;
+    size_t pos = 0;
+    while(pos < content.size()) {
+        size_t inc_start = content.find("<xi:include", pos);
+        if(inc_start == std::string::npos) {
+            result.append(content, pos, content.size() - pos);
+            break;
+        }
+        result.append(content, pos, inc_start - pos);
+        size_t inc_end = FindXIncludeEnd(content, inc_start);
+        if(inc_end == std::string::npos) {
+            result.append(content, inc_start, content.size() - inc_start);
+            break;
+        }
+
+        std::string inc_tag = content.substr(inc_start, inc_end - inc_start);
+        std::string href = ExtractQuotedAttribute(inc_tag, "href");
+        std::string inc_path = ResolvePath(href, base_dir);
+        if(!inc_path.empty() && depth < MAX_XINCLUDE_DEPTH && !ContainsPath(include_stack, inc_path)) {
+            std::ifstream inc_file(inc_path.c_str(), std::ios::binary);
+            if(inc_file.is_open()) {
+                std::string inc_content((std::istreambuf_iterator<char>(inc_file)),
+                                        std::istreambuf_iterator<char>());
+                inc_file.close();
+
+                std::string inc_dir = DirectoryName(inc_path, base_dir);
+                inc_content = ExpandEntities(inc_content, inc_dir);
+                if(inc_content.find("xi:include") != std::string::npos) {
+                    include_stack.push_back(inc_path);
+                    inc_content = ExpandXIncludesImpl(inc_content, inc_dir, include_stack, depth + 1);
+                    include_stack.pop_back();
+                }
+                result.append(inc_content);
+            }
+        }
+        pos = inc_end;
+    }
+    return result;
+}
+
+// Expand simple xi:include tags by replacing them with the referenced file content.
+// Included files are ENTITY-expanded relative to their own directory before insertion.
+std::string ExpandXIncludes(std::string const & content, std::string const & base_dir) {
+    std::vector<std::string> include_stack;
+    return ExpandXIncludesImpl(content, base_dir, include_stack, 0);
+}
+
+// Record a warning. In strict mode, throws instead of continuing.
+void EmitWarning(GDMLData & data, GDMLParseOptions const & options, std::string const & msg) {
+    if(options.strict) {
+        throw std::runtime_error("GDML error (strict mode): " + msg);
+    }
+    data.warnings.push_back(msg);
+}
+
+// Substitute loop variable references in an attribute value string.
+// Two substitution modes following Geant4 convention:
+//   1. Bracket notation: [expr] is evaluated and replaced with the integer
+//      result. Used in name attributes to construct unique identifiers
+//      (e.g. "layer_[i]" -> "layer_0"). The expression inside brackets
+//      can be any evaluable expression using the loop variable.
+//   2. Word-boundary replacement: bare occurrences of the variable name
+//      that form a complete identifier token are replaced with the numeric
+//      value. Used in numeric expressions (e.g. "i*10" -> "0*10").
+//      Does NOT replace the variable inside longer identifiers
+//      (e.g. "ChildVol" is untouched when the variable is "i").
+static std::string SubstLoopVar(
+    std::string const & val,
+    std::string const & var_name,
+    std::string const & var_value_str,
+    std::unordered_map<std::string, double> const & constants,
+    GDMLData & data) {
+    std::string result = val;
+
+    // Pass 1: bracket substitution [expr] -> evaluated integer
+    size_t pos = 0;
+    while((pos = result.find('[', pos)) != std::string::npos) {
+        size_t end = result.find(']', pos + 1);
+        if(end == std::string::npos) break;
+        std::string expr = result.substr(pos + 1, end - pos - 1);
+        try {
+            double v = EvalExpression(expr, constants);
+            long long iv = static_cast<long long>(v);
+            result.replace(pos, end - pos + 1, std::to_string(iv));
+        } catch(std::exception const & e) {
+            data.errors.push_back("bracket evaluation failed for '[" + expr + "]': " + e.what());
+            pos = end + 1;
+        } catch(...) {
+            data.errors.push_back("bracket evaluation failed for '[" + expr + "]'");
+            pos = end + 1;
+        }
+    }
+
+    // Pass 2: word-boundary replacement of the bare variable name
+    pos = 0;
+    while((pos = result.find(var_name, pos)) != std::string::npos) {
+        bool left_ok = (pos == 0 || !IsIdentChar(result[pos - 1]));
+        bool right_ok = (pos + var_name.size() >= result.size() || !IsIdentChar(result[pos + var_name.size()]));
+        if(left_ok && right_ok) {
+            result.replace(pos, var_name.size(), var_value_str);
+            pos += var_value_str.size();
+        } else {
+            pos += var_name.size();
+        }
+    }
+
+    return result;
+}
+
+// Deep-clone an XML node and all its children/attributes into a document.
+// Performs loop variable substitution in all attribute values.
+static rapidxml::xml_node<>* CloneNodeWithSubst(
+    rapidxml::xml_document<> & doc,
+    rapidxml::xml_node<>* src,
+    std::string const & var_name,
+    std::string const & var_value_str,
+    std::unordered_map<std::string, double> const & constants,
+    GDMLData & data) {
+
+    auto* node = doc.allocate_node(src->type());
+    node->name(src->name(), src->name_size());
+
+    for(auto* attr = src->first_attribute(); attr; attr = attr->next_attribute()) {
+        std::string val(attr->value(), attr->value_size());
+        val = SubstLoopVar(val, var_name, var_value_str, constants, data);
+        char* aname = doc.allocate_string(attr->name(), attr->name_size() + 1);
+        char* aval = doc.allocate_string(val.c_str(), val.size() + 1);
+        node->append_attribute(doc.allocate_attribute(aname, aval));
+    }
+
+    for(auto* child = src->first_node(); child; child = child->next_sibling()) {
+        node->append_node(CloneNodeWithSubst(doc, child, var_name, var_value_str, constants, data));
+    }
+    return node;
+}
+
+// Expand all <loop> elements in a DOM subtree (iterative, stack-based).
+// Clones loop body nodes for each iteration with text substitution, inserts
+// them into the parent, and removes the loop node. Used for non-define
+// sections (structure, solids) where the DOM must be modified for downstream
+// parsers that iterate over it.
+void ExpandLoops(rapidxml::xml_document<> & doc,
+                        rapidxml::xml_node<>* root,
+                        std::unordered_map<std::string, double> & constants,
+                        GDMLData & data) {
+    if(!root) return;
+
+    struct Frame {
+        rapidxml::xml_node<>* parent;
+        rapidxml::xml_node<>* current; // next child to process
+    };
+
+    std::vector<Frame> stack;
+    stack.push_back({root, root->first_node()});
+
+    static constexpr int MAX_DEPTH = 64;
+
+    while(!stack.empty()) {
+        if((int)stack.size() > MAX_DEPTH) {
+            stack.pop_back();
+            continue;
+        }
+
+        Frame & top = stack.back();
+        if(!top.current) {
+            stack.pop_back();
+            continue;
+        }
+
+        auto* child = top.current;
+        top.current = child->next_sibling();
+
+        if(std::strcmp(child->name(), "loop") != 0) {
+            // Descend into non-loop nodes to find nested loops
+            if(child->first_node()) {
+                stack.push_back({child, child->first_node()});
+            }
+            continue;
+        }
+
+        // Process the loop: expand inline
+        std::string var_name = SafeAttrVal(child, "for");
+        if(IsBuiltInConstant(var_name)) {
+            top.parent->remove_node(child);
+            continue;
+        }
+        const char* from_attr = SafeAttrVal(child, "from");
+        double from_val;
+        if(from_attr[0] != '\0') {
+            from_val = SafeParseDouble(from_attr, constants);
+        } else {
+            auto it = constants.find(var_name);
+            from_val = (it != constants.end()) ? it->second : 0.0;
+        }
+        double to_val = SafeParseDouble(SafeAttrVal(child, "to"), constants);
+        double step_val = SafeParseDouble(SafeAttrVal(child, "step"), constants);
+        if(step_val == 0) step_val = 1.0;
+
+        // Track the first cloned node so we can resume processing from there
+        // (cloned nodes may contain nested loops)
+        rapidxml::xml_node<>* first_cloned = nullptr;
+        int count = 0;
+        for(double v = from_val;
+            (step_val > 0) ? (v <= to_val + 1e-9) : (v >= to_val - 1e-9);
+            v += step_val) {
+            if(++count > 10000) {
+                throw std::runtime_error("GDML loop exceeded 10000 iterations");
+            }
+            constants[var_name] = v;
+
+            std::string v_str;
+            if(v == std::floor(v) && std::fabs(v) < 1e15) {
+                v_str = std::to_string(static_cast<long long>(v));
+            } else {
+                std::ostringstream oss;
+                oss << v;
+                v_str = oss.str();
+            }
+
+            for(auto* body = child->first_node(); body; body = body->next_sibling()) {
+                auto* cloned = CloneNodeWithSubst(doc, body, var_name, v_str, constants, data);
+                top.parent->insert_node(child, cloned);
+                if(!first_cloned) first_cloned = cloned;
+            }
+        }
+
+        top.parent->remove_node(child);
+
+        // Resume processing from the first cloned node (to catch nested loops)
+        if(first_cloned) {
+            top.current = first_cloned;
+        }
+    }
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLReadUtils.cxx
+++ b/projects/detector/private/gdml/GDMLReadUtils.cxx
@@ -1,0 +1,162 @@
+#include "GDMLParserPrivate.h"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace siren::math;
+
+namespace siren {
+namespace detector {
+namespace gdml {
+
+double ReadDoubleAttr(rapidxml::xml_node<>* node, const char* attr,
+                      std::unordered_map<std::string, double> const & constants,
+                      double scale) {
+    return SafeParseDouble(SafeAttrVal(node, attr), constants) * scale;
+}
+
+double ReadLengthAttr(rapidxml::xml_node<>* node, const char* attr,
+                      double lscale,
+                      std::unordered_map<std::string, double> const & constants) {
+    return ReadDoubleAttr(node, attr, constants, lscale);
+}
+
+double ReadAngleAttr(rapidxml::xml_node<>* node, const char* attr,
+                     double ascale,
+                     std::unordered_map<std::string, double> const & constants) {
+    return ReadDoubleAttr(node, attr, constants, ascale);
+}
+
+GDMLPhiRange ReadPhiRange(rapidxml::xml_node<>* node,
+                          double ascale,
+                          std::unordered_map<std::string, double> const & constants) {
+    GDMLPhiRange range;
+    range.start = 0.0;
+    range.delta = 2.0 * M_PI;
+
+    const char* start = SafeAttrVal(node, "startphi");
+    if(start[0] != '\0') {
+        range.start = SafeParseDouble(start, constants) * ascale;
+    }
+
+    const char* delta = SafeAttrVal(node, "deltaphi");
+    if(delta[0] != '\0') {
+        range.delta = SafeParseDouble(delta, constants) * ascale;
+    }
+
+    return range;
+}
+
+Vector3D ReadPositionXYZ(rapidxml::xml_node<>* node, GDMLData const & data) {
+    if(!node) return Vector3D(0, 0, 0);
+
+    const char* unit = SafeAttrVal(node, "unit");
+    double x = ParseLength(SafeAttrVal(node, "x"), unit, data.constants);
+    double y = ParseLength(SafeAttrVal(node, "y"), unit, data.constants);
+    double z = ParseLength(SafeAttrVal(node, "z"), unit, data.constants);
+    return Vector3D(x, y, z);
+}
+
+Quaternion ReadRotationXYZ(rapidxml::xml_node<>* node, GDMLData const & data) {
+    if(!node) return Quaternion();
+
+    const char* unit = SafeAttrVal(node, "unit");
+    double x = ParseAngle(SafeAttrVal(node, "x"), unit, data.constants);
+    double y = ParseAngle(SafeAttrVal(node, "y"), unit, data.constants);
+    double z = ParseAngle(SafeAttrVal(node, "z"), unit, data.constants);
+    return QuatFromGDMLRotation(x, y, z);
+}
+
+Vector3D ReadPositionReferenceAttr(rapidxml::xml_node<>* node,
+                                  const char* attr,
+                                  GDMLData const & data) {
+    std::string ref = SafeAttrVal(node, attr);
+    if(ref.empty()) {
+        return Vector3D(0, 0, 0);
+    }
+    auto it = data.positions.find(ref);
+    if(it != data.positions.end()) {
+        return it->second;
+    }
+    throw std::runtime_error("GDML error: missing position reference '" + ref + "'");
+}
+
+GDMLPlacement ReadPlacement(rapidxml::xml_node<>* node,
+                            const char* position_tag,
+                            const char* position_ref_tag,
+                            const char* rotation_tag,
+                            const char* rotation_ref_tag,
+                            GDMLData const & data) {
+    GDMLPlacement placement;
+
+    auto* pos_node = node->first_node(position_tag);
+    if(pos_node) {
+        placement.position = ReadPositionXYZ(pos_node, data);
+        placement.specified = true;
+    }
+
+    auto* posref_node = node->first_node(position_ref_tag);
+    if(posref_node) {
+        std::string ref = SafeAttrVal(posref_node, "ref");
+        auto it = data.positions.find(ref);
+        if(it == data.positions.end()) {
+            throw std::runtime_error("GDML error: unresolved position reference '" + ref + "'");
+        }
+        placement.position = it->second;
+        placement.specified = true;
+    }
+
+    auto* rot_node = node->first_node(rotation_tag);
+    if(rot_node) {
+        placement.rotation = ReadRotationXYZ(rot_node, data);
+        placement.specified = true;
+    }
+
+    auto* rotref_node = node->first_node(rotation_ref_tag);
+    if(rotref_node) {
+        std::string ref = SafeAttrVal(rotref_node, "ref");
+        auto it = data.rotations.find(ref);
+        if(it == data.rotations.end()) {
+            throw std::runtime_error("GDML error: unresolved rotation reference '" + ref + "'");
+        }
+        placement.rotation = it->second;
+        placement.specified = true;
+    }
+
+    return placement;
+}
+
+GDMLZPlanes ReadZPlanes(rapidxml::xml_node<>* node,
+                        double lscale,
+                        GDMLData const & data) {
+    GDMLZPlanes planes;
+
+    for(auto* zp = node->first_node("zplane"); zp; zp = zp->next_sibling("zplane")) {
+        planes.z.push_back(ReadLengthAttr(zp, "z", lscale, data.constants));
+        planes.rmin.push_back(ReadLengthAttr(zp, "rmin", lscale, data.constants));
+        planes.rmax.push_back(ReadLengthAttr(zp, "rmax", lscale, data.constants));
+    }
+
+    return planes;
+}
+
+bool ValidateZPlaneMonotonicity(GDMLZPlanes const & planes) {
+    if(planes.z.size() < 2) return false;
+    // Z-planes must be monotonic (ascending or descending, duplicates allowed).
+    // The geometry constructors handle reversal to ascending order internally.
+    bool ascending = true, descending = true;
+    for(size_t i = 1; i < planes.z.size(); ++i) {
+        if(planes.z[i] < planes.z[i - 1]) ascending = false;
+        if(planes.z[i] > planes.z[i - 1]) descending = false;
+    }
+    return ascending || descending;
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLSolidParser.cxx
+++ b/projects/detector/private/gdml/GDMLSolidParser.cxx
@@ -1,0 +1,564 @@
+#include "GDMLParserPrivate.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "SIREN/geometry/Placement.h"
+#include "SIREN/geometry/Box.h"
+#include "SIREN/geometry/Sphere.h"
+#include "SIREN/geometry/Cylinder.h"
+#include "SIREN/geometry/Cone.h"
+#include "SIREN/geometry/Trd.h"
+#include "SIREN/geometry/ExtrPoly.h"
+#include "SIREN/geometry/Polycone.h"
+#include "SIREN/geometry/Polyhedra.h"
+#include "SIREN/geometry/Torus.h"
+#include "SIREN/geometry/BooleanGeometry.h"
+#include "SIREN/geometry/EllipticalTube.h"
+#include "SIREN/geometry/CutTube.h"
+#include "SIREN/geometry/Trap.h"
+#include "SIREN/geometry/Ellipsoid.h"
+#include "SIREN/geometry/Para.h"
+#include "SIREN/geometry/GenericPolycone.h"
+#include "SIREN/geometry/GeometryMesh.h"
+
+using namespace siren::math;
+using namespace siren::geometry;
+
+namespace siren {
+namespace detector {
+namespace gdml {
+
+namespace {
+
+static constexpr double ANG_TOL = 1e-6;
+
+struct SolidContext {
+    rapidxml::xml_node<>* node;
+    GDMLData & data;
+    GDMLParseOptions const & options;
+    std::string tag;
+    std::string name;
+    double lscale;
+    double ascale;
+};
+
+SolidContext MakeSolidContext(rapidxml::xml_node<>* node,
+                              GDMLData & data,
+                              GDMLParseOptions const & options) {
+    return SolidContext{
+        node,
+        data,
+        options,
+        std::string(node->name()),
+        std::string(SafeAttrVal(node, "name")),
+        LengthScale(SafeAttrVal(node, "lunit")),
+        AngleScale(SafeAttrVal(node, "aunit"))
+    };
+}
+
+double L(SolidContext const & ctx, const char* attr) {
+    return ReadLengthAttr(ctx.node, attr, ctx.lscale, ctx.data.constants);
+}
+
+double A(SolidContext const & ctx, const char* attr) {
+    return ReadAngleAttr(ctx.node, attr, ctx.ascale, ctx.data.constants);
+}
+
+double D(SolidContext const & ctx, const char* attr) {
+    return ReadDoubleAttr(ctx.node, attr, ctx.data.constants);
+}
+
+bool HasPhiCut(GDMLPhiRange const & phi) {
+    return std::fabs(phi.start) > ANG_TOL || std::fabs(phi.delta - 2.0 * M_PI) > ANG_TOL;
+}
+
+BooleanOperation BooleanOperationFromTag(std::string const & tag) {
+    if(tag == "subtraction") return BooleanOperation::SUBTRACTION;
+    if(tag == "union") return BooleanOperation::UNION;
+    return BooleanOperation::INTERSECTION;
+}
+
+std::shared_ptr<Geometry> BuildBooleanGeometry(BooleanOperation op,
+                                               std::shared_ptr<Geometry> const & left,
+                                               std::shared_ptr<Geometry> const & right_base,
+                                               GDMLPlacement const & first,
+                                               GDMLPlacement const & second) {
+    std::shared_ptr<Geometry> left_placed;
+    if(first.specified) {
+        left_placed = left->create();
+        left_placed->SetPlacement(Placement(first.position, first.rotation));
+    }
+
+    auto right = right_base->create();
+    right->SetPlacement(Placement(second.position, second.rotation));
+
+    auto left_final = first.specified
+        ? std::const_pointer_cast<const Geometry>(left_placed)
+        : std::const_pointer_cast<const Geometry>(left);
+
+    return std::make_shared<BooleanGeometry>(op, left_final,
+        std::const_pointer_cast<const Geometry>(right));
+}
+
+std::shared_ptr<Geometry> ParseBox(SolidContext const & ctx) {
+    // GDML <box> x,y,z are half-widths; SIREN Box takes full widths.
+    return Box(L(ctx, "x") * 2.0, L(ctx, "y") * 2.0, L(ctx, "z") * 2.0).create();
+}
+
+std::shared_ptr<Geometry> ParseSphere(SolidContext const & ctx) {
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+    double starttheta = A(ctx, "starttheta");
+    double deltatheta = M_PI;
+    const char* dt_val = SafeAttrVal(ctx.node, "deltatheta");
+    if(dt_val[0] != '\0') {
+        deltatheta = SafeParseDouble(dt_val, ctx.data.constants) * ctx.ascale;
+    }
+
+    return Sphere(L(ctx, "rmax"), L(ctx, "rmin"),
+                  phi.start, phi.delta, starttheta, deltatheta).create();
+}
+
+std::shared_ptr<Geometry> ParseOrb(SolidContext const & ctx) {
+    return Sphere(L(ctx, "r"), 0).create();
+}
+
+std::shared_ptr<Geometry> ParseTube(SolidContext const & ctx) {
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+    // GDML <tube> z is half-height; SIREN Cylinder takes full height.
+    return Cylinder(L(ctx, "rmax"), L(ctx, "rmin"), L(ctx, "z") * 2.0,
+                    phi.start, phi.delta).create();
+}
+
+std::shared_ptr<Geometry> ParseCone(SolidContext const & ctx) {
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+    // GDML <cone> z is half-height; SIREN Cone takes full height.
+    return Cone(L(ctx, "rmin1"), L(ctx, "rmax1"),
+                L(ctx, "rmin2"), L(ctx, "rmax2"),
+                L(ctx, "z") * 2.0, phi.start, phi.delta).create();
+}
+
+std::shared_ptr<Geometry> ParseTrd(SolidContext const & ctx) {
+    // GDML <trd> uses half-widths; SIREN Trd also uses half-widths.
+    return Trd(L(ctx, "x1"), L(ctx, "x2"), L(ctx, "y1"), L(ctx, "y2"), L(ctx, "z")).create();
+}
+
+std::shared_ptr<Geometry> ParsePolycone(SolidContext const & ctx) {
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+    GDMLZPlanes planes = ReadZPlanes(ctx.node, ctx.lscale, ctx.data);
+    if(planes.z.size() < 2) return nullptr;
+
+    if(!ValidateZPlaneMonotonicity(planes)) {
+        throw std::runtime_error("polycone '" + ctx.name + "' has non-monotonic z-planes");
+    }
+
+    return Polycone(planes.z, planes.rmin, planes.rmax, phi.start, phi.delta).create();
+}
+
+std::shared_ptr<Geometry> ParsePolyhedra(SolidContext const & ctx) {
+    int numSide = 0;
+    std::string ns_str(SafeAttrVal(ctx.node, "numsides"));
+    if(!ns_str.empty()) {
+        try {
+            numSide = std::stoi(ns_str);
+        } catch(std::invalid_argument &) {
+            numSide = 0;
+        } catch(std::out_of_range &) {
+            numSide = 0;
+        }
+    }
+    if(numSide <= 0) return nullptr;
+
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+    GDMLZPlanes planes = ReadZPlanes(ctx.node, ctx.lscale, ctx.data);
+    if(planes.z.size() < 2 || numSide < 3) return nullptr;
+
+    if(!ValidateZPlaneMonotonicity(planes)) {
+        throw std::runtime_error("polyhedra '" + ctx.name + "' has non-monotonic z-planes");
+    }
+
+    return Polyhedra(numSide, phi.start, planes.z, planes.rmin, planes.rmax, phi.delta).create();
+}
+
+std::shared_ptr<Geometry> ParseXtru(SolidContext const & ctx) {
+    std::vector<std::vector<double>> polygon;
+    std::vector<ExtrPoly::ZSection> zsections;
+
+    for(auto* vtx = ctx.node->first_node("twoDimVertex"); vtx; vtx = vtx->next_sibling("twoDimVertex")) {
+        polygon.push_back({
+            ReadLengthAttr(vtx, "x", ctx.lscale, ctx.data.constants),
+            ReadLengthAttr(vtx, "y", ctx.lscale, ctx.data.constants)
+        });
+    }
+
+    for(auto* sec = ctx.node->first_node("section"); sec; sec = sec->next_sibling("section")) {
+        double zpos = ReadLengthAttr(sec, "zPosition", ctx.lscale, ctx.data.constants);
+        double xoff = ReadLengthAttr(sec, "xOffset", ctx.lscale, ctx.data.constants);
+        double yoff = ReadLengthAttr(sec, "yOffset", ctx.lscale, ctx.data.constants);
+        double scale = ReadDoubleAttr(sec, "scalingFactor", ctx.data.constants);
+        if(scale == 0.0) scale = 1.0;
+        double offset[2] = {xoff, yoff};
+        zsections.push_back(ExtrPoly::ZSection(zpos, offset, scale));
+    }
+
+    if(polygon.empty() || zsections.empty()) return nullptr;
+    return ExtrPoly(polygon, zsections).create();
+}
+
+std::shared_ptr<Geometry> ParseTorus(SolidContext const & ctx) {
+    double rmin_t = L(ctx, "rmin");
+    double rmax_t = L(ctx, "rmax");
+    double rtor = L(ctx, "rtor");
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+
+    if(rtor <= 0 || rmax_t <= 0) return nullptr;
+    return Torus(rtor, rmax_t, rmin_t, phi.start, phi.delta).create();
+}
+
+std::shared_ptr<Geometry> ParseEllipticalTube(SolidContext const & ctx) {
+    double dx = L(ctx, "dx");
+    double dy = L(ctx, "dy");
+    double dz = L(ctx, "dz");
+    if(dx <= 0 || dy <= 0 || dz <= 0) return nullptr;
+    return EllipticalTube(dx, dy, dz).create();
+}
+
+std::shared_ptr<Geometry> ParseCutTube(SolidContext const & ctx) {
+    double rmin = L(ctx, "rmin");
+    double rmax = L(ctx, "rmax");
+    double hz = L(ctx, "z");
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+
+    if(rmax <= 0 || hz <= 0) return nullptr;
+
+    Vector3D low_norm(D(ctx, "lowX"), D(ctx, "lowY"), D(ctx, "lowZ"));
+    Vector3D high_norm(D(ctx, "highX"), D(ctx, "highY"), D(ctx, "highZ"));
+    return CutTube(rmin, rmax, hz, low_norm, high_norm, phi.start, phi.delta).create();
+}
+
+std::shared_ptr<Geometry> ParseTrap(SolidContext const & ctx) {
+    return Trap(L(ctx, "z"), A(ctx, "theta"), A(ctx, "phi"),
+                L(ctx, "y1"), L(ctx, "x1"), L(ctx, "x2"), A(ctx, "alpha1"),
+                L(ctx, "y2"), L(ctx, "x3"), L(ctx, "x4"), A(ctx, "alpha2")).create();
+}
+
+std::shared_ptr<Geometry> ParseEllipsoid(SolidContext const & ctx) {
+    double ax = L(ctx, "ax");
+    double by = L(ctx, "by");
+    double cz = L(ctx, "cz");
+    if(ax <= 0 || by <= 0 || cz <= 0) return nullptr;
+
+    double zcut1 = -cz;
+    double zcut2 = cz;
+    const char* z1_val = SafeAttrVal(ctx.node, "zcut1");
+    if(z1_val[0] != '\0') zcut1 = SafeParseDouble(z1_val, ctx.data.constants) * ctx.lscale;
+    const char* z2_val = SafeAttrVal(ctx.node, "zcut2");
+    if(z2_val[0] != '\0') zcut2 = SafeParseDouble(z2_val, ctx.data.constants) * ctx.lscale;
+
+    return Ellipsoid(ax, by, cz, zcut1, zcut2).create();
+}
+
+std::shared_ptr<Geometry> ParsePara(SolidContext const & ctx) {
+    double dx = L(ctx, "x");
+    double dy = L(ctx, "y");
+    double dz = L(ctx, "z");
+    if(dx <= 0 || dy <= 0 || dz <= 0) return nullptr;
+
+    return Para(dx, dy, dz, A(ctx, "alpha"), A(ctx, "theta"), A(ctx, "phi")).create();
+}
+
+std::shared_ptr<Geometry> ParseGenericPolycone(SolidContext const & ctx) {
+    GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
+    std::vector<double> r_vec;
+    std::vector<double> z_vec;
+
+    for(auto* rz = ctx.node->first_node("rzpoint"); rz; rz = rz->next_sibling("rzpoint")) {
+        r_vec.push_back(ReadLengthAttr(rz, "r", ctx.lscale, ctx.data.constants));
+        z_vec.push_back(ReadLengthAttr(rz, "z", ctx.lscale, ctx.data.constants));
+    }
+
+    if(r_vec.size() < 3) return nullptr;
+    if(HasPhiCut(phi)) return GenericPolycone(r_vec, z_vec, phi.start, phi.delta).create();
+    return GenericPolycone(r_vec, z_vec).create();
+}
+
+std::shared_ptr<Geometry> ParseTessellated(SolidContext const & ctx) {
+    std::vector<std::array<math::Vector3D, 3>> triangles;
+
+    for(auto* facet = ctx.node->first_node(); facet; facet = facet->next_sibling()) {
+        std::string ftag(facet->name());
+        if(ftag == "triangular") {
+            math::Vector3D v1 = ReadPositionReferenceAttr(facet, "vertex1", ctx.data);
+            math::Vector3D v2 = ReadPositionReferenceAttr(facet, "vertex2", ctx.data);
+            math::Vector3D v3 = ReadPositionReferenceAttr(facet, "vertex3", ctx.data);
+            triangles.push_back({{v1, v2, v3}});
+        } else if(ftag == "quadrangular") {
+            math::Vector3D v1 = ReadPositionReferenceAttr(facet, "vertex1", ctx.data);
+            math::Vector3D v2 = ReadPositionReferenceAttr(facet, "vertex2", ctx.data);
+            math::Vector3D v3 = ReadPositionReferenceAttr(facet, "vertex3", ctx.data);
+            math::Vector3D v4 = ReadPositionReferenceAttr(facet, "vertex4", ctx.data);
+            triangles.push_back({{v1, v2, v3}});
+            triangles.push_back({{v1, v3, v4}});
+        }
+    }
+
+    if(triangles.empty()) return nullptr;
+    return TriangularMesh(triangles).create();
+}
+
+std::shared_ptr<Geometry> ParseArb8(SolidContext const & ctx) {
+    double dz = L(ctx, "dz");
+    if(dz <= 0) return nullptr;
+
+    static const char* x_attrs[8] = {"v1x", "v2x", "v3x", "v4x", "v5x", "v6x", "v7x", "v8x"};
+    static const char* y_attrs[8] = {"v1y", "v2y", "v3y", "v4y", "v5y", "v6y", "v7y", "v8y"};
+
+    math::Vector3D verts[8];
+    for(int i = 0; i < 8; ++i) {
+        double z = (i < 4) ? -dz : dz;
+        verts[i] = math::Vector3D(
+            ReadLengthAttr(ctx.node, x_attrs[i], ctx.lscale, ctx.data.constants),
+            ReadLengthAttr(ctx.node, y_attrs[i], ctx.lscale, ctx.data.constants),
+            z);
+    }
+
+    std::vector<std::array<math::Vector3D, 3>> triangles;
+    triangles.reserve(12);
+
+    auto addQuad = [&](math::Vector3D const & a, math::Vector3D const & b,
+                       math::Vector3D const & c, math::Vector3D const & d) {
+        triangles.push_back({{a, b, c}});
+        triangles.push_back({{a, c, d}});
+    };
+
+    // Bottom face (outward normal in -z): v4, v3, v2, v1.
+    addQuad(verts[3], verts[2], verts[1], verts[0]);
+    // Top face (outward normal in +z): v5, v6, v7, v8.
+    addQuad(verts[4], verts[5], verts[6], verts[7]);
+    addQuad(verts[0], verts[1], verts[5], verts[4]);
+    addQuad(verts[1], verts[2], verts[6], verts[5]);
+    addQuad(verts[2], verts[3], verts[7], verts[6]);
+    addQuad(verts[3], verts[0], verts[4], verts[7]);
+
+    return TriangularMesh(triangles).create();
+}
+
+std::shared_ptr<Geometry> ParsePrimitiveSolid(SolidContext const & ctx) {
+    if(ctx.tag == "box") return ParseBox(ctx);
+    if(ctx.tag == "sphere") return ParseSphere(ctx);
+    if(ctx.tag == "orb") return ParseOrb(ctx);
+    if(ctx.tag == "tube" || ctx.tag == "tubs") return ParseTube(ctx);
+    if(ctx.tag == "cone") return ParseCone(ctx);
+    if(ctx.tag == "trd") return ParseTrd(ctx);
+    if(ctx.tag == "polycone") return ParsePolycone(ctx);
+    if(ctx.tag == "polyhedra") return ParsePolyhedra(ctx);
+    if(ctx.tag == "xtru") return ParseXtru(ctx);
+    if(ctx.tag == "torus") return ParseTorus(ctx);
+    if(ctx.tag == "eltube") return ParseEllipticalTube(ctx);
+    if(ctx.tag == "cutTube") return ParseCutTube(ctx);
+    if(ctx.tag == "trap") return ParseTrap(ctx);
+    if(ctx.tag == "ellipsoid") return ParseEllipsoid(ctx);
+    if(ctx.tag == "para") return ParsePara(ctx);
+    if(ctx.tag == "genericPolycone") return ParseGenericPolycone(ctx);
+    if(ctx.tag == "tessellated") return ParseTessellated(ctx);
+    if(ctx.tag == "arb8") return ParseArb8(ctx);
+
+    if(!ctx.tag.empty()) {
+        EmitWarning(ctx.data, ctx.options,
+            "unsupported solid type '" + ctx.tag + "' (name='" + ctx.name + "'), skipping");
+    }
+    return nullptr;
+}
+
+} // namespace
+
+// Parse all <solids> sections: convert GDML solids to SIREN Geometry objects.
+// Iterates all <solids> children of root_node, running the primitive parse pass
+// for each section first, then performing iterative boolean resolution across
+// all sections.
+void ParseAllSolids(rapidxml::xml_node<>* root_node, GDMLData & data, GDMLParseOptions const & options) {
+    if(!root_node) return;
+
+    std::vector<rapidxml::xml_node<>*> solids_sections;
+    for(auto* node = root_node->first_node("solids"); node; node = node->next_sibling("solids")) {
+        solids_sections.push_back(node);
+    }
+    if(solids_sections.empty()) return;
+
+    // Instance-aware storage: each name can have multiple definitions.
+    using GeoPtr = std::shared_ptr<Geometry>;
+    auto geo_eq = [](GeoPtr const & a, GeoPtr const & b) { return *a == *b; };
+    InstanceTracker<GeoPtr> solid_tracker(data, options.strip_pointer_suffixes);
+
+    auto storeSolid = [&](std::string const & name, GeoPtr geo) {
+        solid_tracker.Store(name, geo, geo_eq);
+    };
+
+    auto lookupSolid = [&](std::string const & name) -> GeoPtr {
+        auto const * p = solid_tracker.Lookup(name);
+        return p ? *p : nullptr;
+    };
+
+    auto parseBooleanInstanced = [&](rapidxml::xml_node<>* node) -> std::shared_ptr<Geometry> {
+        BooleanOperation op = BooleanOperationFromTag(std::string(node->name()));
+
+        auto* first_node = node->first_node("first");
+        auto* second_node = node->first_node("second");
+        if(!first_node || !second_node) return nullptr;
+
+        auto left = lookupSolid(SafeAttrVal(first_node, "ref"));
+        auto right_base = lookupSolid(SafeAttrVal(second_node, "ref"));
+        if(!left || !right_base) return nullptr;
+
+        GDMLPlacement first = ReadPlacement(
+            node, "firstposition", "firstpositionref", "firstrotation", "firstrotationref", data);
+        GDMLPlacement second = ReadPlacement(
+            node, "position", "positionref", "rotation", "rotationref", data);
+        return BuildBooleanGeometry(op, left, right_base, first, second);
+    };
+
+    struct DeferredBoolean {
+        rapidxml::xml_node<>* node;
+        std::string name;
+        std::string first_ref;
+        std::string second_ref;
+        int first_instance;
+        int second_instance;
+    };
+
+    std::vector<DeferredBoolean> deferred;
+
+    for(auto* solids_node : solids_sections) {
+        for(auto* node = solids_node->first_node(); node; node = node->next_sibling()) {
+            std::string tag(node->name());
+            std::string name = SafeAttrVal(node, "name");
+            if(name.empty()) continue;
+
+            bool is_boolean = (tag == "subtraction" || tag == "union" || tag == "intersection");
+
+            if(!is_boolean) {
+                auto geo = ParsePrimitiveSolid(MakeSolidContext(node, data, options));
+                if(geo) {
+                    storeSolid(name, geo);
+                }
+                continue;
+            }
+
+            auto* first_child = node->first_node("first");
+            auto* second_child = node->first_node("second");
+            if(!first_child || !second_child) continue;
+
+            std::string first_ref = SafeAttrVal(first_child, "ref");
+            std::string second_ref = SafeAttrVal(second_child, "ref");
+
+            auto left = lookupSolid(first_ref);
+            auto right = lookupSolid(second_ref);
+
+            if(left && right) {
+                auto geo = parseBooleanInstanced(node);
+                if(geo) {
+                    storeSolid(name, geo);
+                }
+                continue;
+            }
+
+            // Canonicalize operand refs at storage time. The deferred-resolution
+            // loop below queries InstanceTracker::Instances() directly (rather
+            // than through Lookup), whose keys are stripped names. Storing the
+            // raw pointer-suffixed ref here would silently break resolution
+            // for Geant4 exports that forward-reference a not-yet-defined
+            // operand.
+            std::string first_key  = StripPointerSuffix(first_ref,  options.strip_pointer_suffixes);
+            std::string second_key = StripPointerSuffix(second_ref, options.strip_pointer_suffixes);
+            DeferredBoolean db;
+            db.node = node;
+            db.name = name;
+            db.first_ref = first_key;
+            db.second_ref = second_key;
+            db.first_instance = left ? (solid_tracker.Count(first_key) - 1) : 0;
+            db.second_instance = right ? (solid_tracker.Count(second_key) - 1) : 0;
+            deferred.push_back(db);
+        }
+    }
+
+    auto const & solid_instances = solid_tracker.Instances();
+
+    // Build reverse dependency map: ref name -> indices of deferred booleans that need it
+    std::unordered_map<std::string, std::vector<size_t>> dependents;
+    std::vector<size_t> ready;
+
+    auto isAvailable = [&](std::string const & ref, int instance) -> bool {
+        auto it = solid_instances.find(ref);
+        return it != solid_instances.end() && instance < (int)it->second.size();
+    };
+
+    for(size_t i = 0; i < deferred.size(); ++i) {
+        auto & db = deferred[i];
+        bool have_first = isAvailable(db.first_ref, db.first_instance);
+        bool have_second = isAvailable(db.second_ref, db.second_instance);
+        if(have_first && have_second) {
+            ready.push_back(i);
+        } else {
+            if(!have_first) dependents[db.first_ref].push_back(i);
+            if(!have_second) dependents[db.second_ref].push_back(i);
+        }
+    }
+
+    while(!ready.empty()) {
+        size_t idx = ready.back();
+        ready.pop_back();
+        auto & db = deferred[idx];
+        if(db.node == nullptr) continue;
+
+        auto f_it = solid_instances.find(db.first_ref);
+        auto s_it = solid_instances.find(db.second_ref);
+        if(f_it == solid_instances.end() || s_it == solid_instances.end()) continue;
+        if(db.first_instance >= (int)f_it->second.size()) continue;
+        if(db.second_instance >= (int)s_it->second.size()) continue;
+
+        auto left = f_it->second[db.first_instance];
+        auto right_base = s_it->second[db.second_instance];
+        if(!left || !right_base) continue;
+
+        BooleanOperation op = BooleanOperationFromTag(std::string(db.node->name()));
+        GDMLPlacement first = ReadPlacement(
+            db.node, "firstposition", "firstpositionref", "firstrotation", "firstrotationref", data);
+        GDMLPlacement second = ReadPlacement(
+            db.node, "position", "positionref", "rotation", "rotationref", data);
+        auto geo = BuildBooleanGeometry(op, left, right_base, first, second);
+
+        storeSolid(db.name, geo);
+        db.node = nullptr;
+
+        std::string stored_name = StripPointerSuffix(db.name, options.strip_pointer_suffixes);
+        auto dep_it = dependents.find(stored_name);
+        if(dep_it != dependents.end()) {
+            for(size_t di : dep_it->second) {
+                if(deferred[di].node == nullptr) continue;
+                auto & ddb = deferred[di];
+                if(isAvailable(ddb.first_ref, ddb.first_instance)
+                   && isAvailable(ddb.second_ref, ddb.second_instance)) {
+                    ready.push_back(di);
+                }
+            }
+        }
+    }
+
+    for(auto const & db : deferred) {
+        if(db.node != nullptr) {
+            EmitWarning(data, options, "boolean solid '" + db.name + "' has unresolved operand references; skipping");
+        }
+    }
+
+    solid_tracker.Flatten(data.solids, &data.solid_instance_counts);
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLStructureParser.cxx
+++ b/projects/detector/private/gdml/GDMLStructureParser.cxx
@@ -1,0 +1,322 @@
+#include "GDMLParserPrivate.h"
+
+#include <cmath>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+
+using namespace siren::math;
+
+namespace siren {
+namespace detector {
+namespace gdml {
+// Parse the <structure> section: volumes, assemblies, and physical volumes.
+// Checks for ambiguous solid/material references (names with multiple instances).
+void ParseStructure(rapidxml::xml_node<>* structure_node, GDMLData & data, GDMLParseOptions const & options) {
+    if(!structure_node) return;
+
+    auto vol_eq = [](GDMLVolume const & a, GDMLVolume const & b) {
+        if(a.solid_ref != b.solid_ref || a.material_ref != b.material_ref
+           || a.children.size() != b.children.size()
+           || a.is_assembly != b.is_assembly)
+            return false;
+        for(size_t i = 0; i < a.children.size(); ++i) {
+            if(a.children[i].volume_ref != b.children[i].volume_ref
+               || !(a.children[i].position == b.children[i].position)
+               || !(a.children[i].rotation == b.children[i].rotation))
+                return false;
+        }
+        return true;
+    };
+    InstanceTracker<GDMLVolume> volume_tracker(data, options.strip_pointer_suffixes);
+
+    // Scope isolation for <file> sub-modules: track which volume names
+    // came from sub-files so parent volumes cannot reference them.
+    std::unordered_set<std::string> file_volumes;
+    std::unordered_set<std::string> file_internal_volumes;
+
+    // Shared physvol child parser used by both <volume> and <assembly>
+    auto parsePhysVols = [&](rapidxml::xml_node<>* parent_node, GDMLVolume & vol) {
+        for(auto* pv = parent_node->first_node("physvol"); pv; pv = pv->next_sibling("physvol")) {
+            GDMLPhysVol physvol;
+            physvol.position = Vector3D(0, 0, 0);
+            physvol.rotation = Quaternion(); // identity
+
+            auto* volref = pv->first_node("volumeref");
+            if(volref) {
+                // Store the raw ref; alias resolution happens later in
+                // BuildVolume after the volume flatten/strip pass.
+                physvol.volume_ref = SafeAttrVal(volref, "ref");
+            }
+
+            // Handle <file> references: parse the external GDML as a
+            // fully independent file, then merge into the parent scope
+            // using GDMLData::MergeFrom (handles name collisions).
+            //
+            // SIREN extension attribute (not in GDML schema):
+            //   as_assembly="true" -- treat the referenced volume as an
+            //                         assembly (skip its own sector, place
+            //                         children directly).
+            auto* file_node = pv->first_node("file");
+            if(file_node) {
+                std::string fname = SafeAttrVal(file_node, "name");
+                std::string volname = SafeAttrVal(file_node, "volname");
+                std::string as_asm_str = SafeAttrVal(file_node, "as_assembly");
+                bool as_assembly = (as_asm_str == "true" || as_asm_str == "1");
+                if(!fname.empty()) {
+                    bool is_absolute = (!fname.empty() && fname[0] == '/');
+                    std::string path = (is_absolute || data.base_dir.empty()) ? fname : data.base_dir + "/" + fname;
+                    GDMLData sub = ParseGDML(path, options);
+
+                    // Collect sub-file volume names before merge (maps
+                    // are partially moved-from after MergeFrom).
+                    std::vector<std::string> sub_vol_keys;
+                    sub_vol_keys.reserve(sub.volumes.size());
+                    for(auto const & p : sub.volumes)
+                        sub_vol_keys.push_back(p.first);
+
+                    auto renames = data.MergeFrom(sub);
+
+                    auto r = [&](std::string const & name) -> std::string const & {
+                        auto it = renames.find(name);
+                        return (it != renames.end()) ? it->second : name;
+                    };
+
+                    for(auto const & n : sub_vol_keys) {
+                        std::string const & merged = r(n);
+                        file_volumes.insert(merged);
+                        file_internal_volumes.insert(merged);
+                    }
+
+                    if(!volname.empty()) {
+                        physvol.volume_ref = r(volname);
+                    } else if(!sub.world_volume.empty()) {
+                        physvol.volume_ref = sub.world_volume;
+                    }
+
+                    // The exposed world volume is the sole gateway into
+                    // the sub-file; remove it from the internal set.
+                    if(!physvol.volume_ref.empty())
+                        file_internal_volumes.erase(physvol.volume_ref);
+
+                    if(as_assembly && !physvol.volume_ref.empty()) {
+                        auto vit = data.volumes.find(physvol.volume_ref);
+                        if(vit != data.volumes.end()) {
+                            vit->second.is_assembly = true;
+                        }
+                    }
+                }
+            }
+
+            // Validate child elements: reject unrecognized tags that almost
+            // certainly indicate typos (e.g. <positoinref> instead of <positionref>).
+            for(auto* child = pv->first_node(); child; child = child->next_sibling()) {
+                std::string tag(child->name(), child->name_size());
+                if(tag.empty() || tag == "auxiliary" || tag == "file") {
+                    continue;
+                } else if(tag != "volumeref" && tag != "position" && tag != "positionref"
+                          && tag != "rotation" && tag != "rotationref"
+                          && tag != "scale" && tag != "scaleref") {
+                    throw std::runtime_error(
+                        "GDML error: physvol contains unrecognized child element <" + tag + ">");
+                }
+            }
+
+            GDMLPlacement placement = ReadPlacement(
+                pv, "position", "positionref", "rotation", "rotationref", data);
+            physvol.position = placement.position;
+            physvol.rotation = placement.rotation;
+
+            vol.children.push_back(physvol);
+        }
+    };
+
+    for(auto* vol_node = structure_node->first_node(); vol_node;
+        vol_node = vol_node->next_sibling()) {
+
+        std::string tag(vol_node->name());
+        if(tag != "volume" && tag != "assembly") continue;
+
+        GDMLVolume vol;
+        vol.name = StripPointerSuffix(SafeAttrVal(vol_node, "name"), options.strip_pointer_suffixes);
+        vol.is_assembly = (tag == "assembly");
+
+        if(!vol.is_assembly) {
+            // Get <materialref> — resolve through alias map for pointer-suffixed names.
+            // Only check for ambiguity when the raw ref name was not resolved through
+            // the alias map (i.e., it was a bare name that matches multiple instances).
+            auto* matref = vol_node->first_node("materialref");
+            if(matref) {
+                std::string raw_ref = SafeAttrVal(matref, "ref");
+                vol.material_ref = ResolveAlias(raw_ref, data);
+                bool was_aliased = (vol.material_ref != raw_ref);
+                if(!was_aliased && !vol.material_ref.empty()) {
+                    auto it = data.material_instance_counts.find(vol.material_ref);
+                    if(it != data.material_instance_counts.end() && it->second > 1) {
+                        throw std::runtime_error(
+                            "GDML error: volume '" + vol.name
+                            + "' references ambiguous material '" + vol.material_ref
+                            + "' which has " + std::to_string(it->second) + " instances");
+                    }
+                }
+            }
+
+            // Get <solidref> — same alias + ambiguity logic
+            auto* solidref = vol_node->first_node("solidref");
+            if(solidref) {
+                std::string raw_ref = SafeAttrVal(solidref, "ref");
+                vol.solid_ref = ResolveAlias(raw_ref, data);
+                bool was_aliased = (vol.solid_ref != raw_ref);
+                if(!was_aliased && !vol.solid_ref.empty()) {
+                    auto it = data.solid_instance_counts.find(vol.solid_ref);
+                    if(it != data.solid_instance_counts.end() && it->second > 1) {
+                        throw std::runtime_error(
+                            "GDML error: volume '" + vol.name
+                            + "' references ambiguous solid '" + vol.solid_ref
+                            + "' which has " + std::to_string(it->second) + " instances");
+                    }
+                }
+            }
+        }
+
+        parsePhysVols(vol_node, vol);
+
+        for(auto* rv = vol_node->first_node("replicavol"); rv; rv = rv->next_sibling("replicavol")) {
+            int ncopies = 0;
+            {
+                std::string ns(SafeAttrVal(rv, "number"));
+                if(!ns.empty()) {
+                    try { ncopies = std::stoi(ns); } catch(...) { ncopies = 0; }
+                }
+            }
+            if(ncopies <= 0) continue;
+
+            std::string child_vol_ref;
+            auto* vref = rv->first_node("volumeref");
+            if(vref) child_vol_ref = SafeAttrVal(vref, "ref");
+            if(child_vol_ref.empty()) continue;
+
+            auto* raa = rv->first_node("replicate_along_axis");
+            if(!raa) continue;
+
+            double dir_x = 0, dir_y = 0, dir_z = 0;
+            auto* dir = raa->first_node("direction");
+            if(dir) {
+                dir_x = SafeParseDouble(SafeAttrVal(dir, "x"), data.constants);
+                dir_y = SafeParseDouble(SafeAttrVal(dir, "y"), data.constants);
+                dir_z = SafeParseDouble(SafeAttrVal(dir, "z"), data.constants);
+            }
+            double dir_len = std::sqrt(dir_x*dir_x + dir_y*dir_y + dir_z*dir_z);
+            if(dir_len == 0) {
+                auto* rho_attr = dir ? dir->first_attribute("rho") : nullptr;
+                auto* phi_attr = dir ? dir->first_attribute("phi") : nullptr;
+                if(rho_attr || phi_attr) {
+                    EmitWarning(data, options, "replicavol in volume '" + vol.name + "': cylindrical axis replication not supported; skipping");
+                } else {
+                    EmitWarning(data, options, "replicavol in volume '" + vol.name + "': no direction specified; skipping");
+                }
+                continue;
+            }
+            dir_x /= dir_len;
+            dir_y /= dir_len;
+            dir_z /= dir_len;
+
+            double width = 0;
+            auto* w_node = raa->first_node("width");
+            if(w_node) {
+                width = ParseLength(SafeAttrVal(w_node, "value"),
+                                    SafeAttrVal(w_node, "unit"), data.constants);
+            }
+
+            double offset = 0;
+            auto* o_node = raa->first_node("offset");
+            if(o_node) {
+                offset = ParseLength(SafeAttrVal(o_node, "value"),
+                                     SafeAttrVal(o_node, "unit"), data.constants);
+            }
+
+            for(int i = 0; i < ncopies; ++i) {
+                double t = offset + (i + 0.5 - ncopies / 2.0) * width;
+                GDMLPhysVol pv;
+                pv.volume_ref = child_vol_ref;
+                pv.position = Vector3D(t * dir_x, t * dir_y, t * dir_z);
+                pv.rotation = Quaternion();
+                vol.children.push_back(pv);
+            }
+        }
+
+        if(!vol.name.empty()) {
+            std::string original_name(SafeAttrVal(vol_node, "name"));
+            volume_tracker.Store(original_name, vol, vol_eq);
+        }
+    }
+
+    auto vol_set_name = [](GDMLVolume & v, std::string const & n) { v.name = n; };
+    volume_tracker.Flatten(data.volumes, nullptr, vol_set_name);
+
+    // Parent-defined volumes shadow file-internal names: Flatten
+    // overwrites sub-file entries in data.volumes, so the parent's
+    // definition wins and the name is no longer file-internal.
+    for(auto const & pair : volume_tracker.Instances()) {
+        if(pair.second.size() == 1) {
+            file_internal_volumes.erase(pair.first);
+            file_volumes.erase(pair.first);
+        } else {
+            for(int i = 0; i < (int)pair.second.size(); ++i) {
+                file_internal_volumes.erase(volume_tracker.FlatName(pair.first, i));
+                file_volumes.erase(volume_tracker.FlatName(pair.first, i));
+            }
+        }
+    }
+
+    // Resolve volumeref and replicavol child refs now that all volumes
+    // are flattened and aliases are finalized.
+    for(auto & vpair : data.volumes) {
+        for(auto & child : vpair.second.children) {
+            std::string const & raw = child.volume_ref;
+            auto ait = data.name_aliases.find(raw);
+            if(ait != data.name_aliases.end()) {
+                child.volume_ref = ait->second;
+            } else {
+                std::string stripped = StripPointerSuffix(raw, options.strip_pointer_suffixes);
+                if(stripped != raw) {
+                    child.volume_ref = stripped;
+                }
+            }
+        }
+    }
+
+    // Scope isolation: parent-defined volumes must not reference
+    // sub-file internal volumes. Only the exposed world volume of
+    // each <file> sub-module is accessible to the parent scope.
+    if(!file_internal_volumes.empty()) {
+        for(auto const & vpair : data.volumes) {
+            if(file_volumes.count(vpair.first)) continue;
+            for(auto const & child : vpair.second.children) {
+                if(file_internal_volumes.count(child.volume_ref)) {
+                    data.errors.push_back(
+                        "GDML scope error: volume '" + vpair.first
+                        + "' references '" + child.volume_ref
+                        + "' which is internal to a <file> sub-module");
+                }
+            }
+        }
+        data.ThrowIfErrors();
+    }
+}
+
+
+// Parse the <setup> section to find the world volume
+void ParseSetup(rapidxml::xml_node<>* setup_node, GDMLData & data, GDMLParseOptions const & options) {
+    if(!setup_node) return;
+
+    auto* world_node = setup_node->first_node("world");
+    if(world_node) {
+        data.world_volume = StripPointerSuffix(SafeAttrVal(world_node, "ref"), options.strip_pointer_suffixes);
+    }
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/gdml/GDMLUnits.cxx
+++ b/projects/detector/private/gdml/GDMLUnits.cxx
@@ -268,7 +268,7 @@ static GDMLQuantityType TypeFromUnit(std::string const & u) {
 static GDMLQuantityType TypeFromTypeAttr(std::string const & type_str) {
     if(type_str.empty()) return GDMLQuantityType::NONE;
     std::string t = type_str;
-    std::transform(t.begin(), t.end(), t.begin(), ::tolower);
+    std::transform(t.begin(), t.end(), t.begin(), [](unsigned char c){ return std::tolower(c); });
     if(t == "length" || t == "lenght" || t == "coordinate")
         return GDMLQuantityType::LENGTH;
     if(t == "angle") return GDMLQuantityType::ANGLE;

--- a/projects/detector/private/gdml/GDMLUnits.cxx
+++ b/projects/detector/private/gdml/GDMLUnits.cxx
@@ -1,0 +1,330 @@
+#include "GDMLParserPrivate.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <unordered_set>
+
+#include "SIREN/math/EulerQuaternionConversions.h"
+#include "SIREN/utilities/Constants.h"
+
+using namespace siren::math;
+
+namespace siren {
+namespace detector {
+namespace gdml {
+// ---- Built-in constants (CLHEP/Geant4 unit system) ----
+// Single source of truth for all constants seeded before user-defined <define>.
+// Values are in CLHEP base units: mm=1 (length), MeV=1 (energy), radian=1
+// (angle), nanosecond=1 (time), kelvin=1 (temp), mole=1 (amount).
+// ParseLength/ParseAngle handle conversion from CLHEP units to SIREN units.
+//
+// Unit values derived from CLHEP SystemOfUnits.h and PhysicalConstants.h:
+//   https://gitlab.cern.ch/CLHEP/CLHEP/-/blob/master/Units/Units/SystemOfUnits.h
+// Math constants from CLHEP Evaluator (setStdMath):
+//   https://gitlab.cern.ch/CLHEP/CLHEP/-/blob/master/Evaluator/src/Evaluator.cc
+//
+// GDML schema and element semantics per GDML User's Guide v2.9:
+//   https://gdml.web.cern.ch/doc/GDMLmanual.pdf
+
+struct BuiltInEntry {
+    const char* name;
+    double value;
+};
+
+static const BuiltInEntry kBuiltInConstants[] = {
+    // Math (from CLHEP Evaluator::setStdMath)
+    {"pi", M_PI},
+    {"twopi", 2.0 * M_PI},
+    {"TWOPI", 2.0 * M_PI},
+    {"halfpi", M_PI / 2.0},
+    {"e", 2.7182818284590452354},
+    {"gamma", 0.5772156649015328606},
+
+    // Angle (radian = 1)
+    {"rad", 1.0},
+    {"radian", 1.0},
+    {"mrad", 1e-3},
+    {"milliradian", 1e-3},
+    {"deg", M_PI / 180.0},
+    {"degree", M_PI / 180.0},
+
+    // Length (mm = 1)
+    {"mm", 1.0},
+    {"millimeter", 1.0},
+    {"cm", 10.0},
+    {"centimeter", 10.0},
+    {"m", 1000.0},
+    {"meter", 1000.0},
+    {"km", 1e6},
+    {"kilometer", 1e6},
+    {"um", 1e-3},
+    {"micrometer", 1e-3},
+    {"nm", 1e-6},
+    {"nanometer", 1e-6},
+    {"angstrom", 1e-7},
+    {"fermi", 1e-12},
+    {"inch", 25.4},
+    {"in", 25.4},
+
+    // Energy (MeV = 1)
+    {"eV", 1e-6},
+    {"keV", 1e-3},
+    {"MeV", 1.0},
+    {"GeV", 1e3},
+    {"TeV", 1e6},
+    {"PeV", 1e9},
+    {"joule", 6.241509074460763e12},
+
+    // Time (nanosecond = 1)
+    {"ns", 1.0},
+    {"nanosecond", 1.0},
+    {"ps", 1e-3},
+    {"picosecond", 1e-3},
+    {"us", 1e3},
+    {"microsecond", 1e3},
+    {"ms", 1e6},
+    {"millisecond", 1e6},
+    {"second", 1e9},
+
+    // Mass (derived: kg = joule * s^2 / m^2)
+    {"milligram", 6.241509074460763e18},
+    {"gram", 6.241509074460763e21},
+    {"kg", 6.241509074460763e24},
+    {"kilogram", 6.241509074460763e24},
+
+    // Volumic mass (CLHEP mass / mm^3)
+    {"g/cm3", 6.241509074460763e18},
+    {"mg/cm3", 6.241509074460763e15},
+    {"kg/m3", 6.241509074460763e15},
+
+    // Amount (mole = 1)
+    {"mole", 1.0},
+    {"mol", 1.0},
+
+    // Temperature (kelvin = 1)
+    {"kelvin", 1.0},
+};
+
+static const std::unordered_map<std::string, double>& GetBuiltInMap() {
+    static const std::unordered_map<std::string, double> m = []() {
+        std::unordered_map<std::string, double> m;
+        for(auto const & e : kBuiltInConstants) m[e.name] = e.value;
+        return m;
+    }();
+    return m;
+}
+
+static const std::unordered_set<std::string>& GetBuiltInNames() {
+    static const std::unordered_set<std::string> names = []() {
+        std::unordered_set<std::string> s;
+        for(auto const & e : kBuiltInConstants) s.insert(e.name);
+        return s;
+    }();
+    return names;
+}
+
+bool IsBuiltInConstant(std::string const & name) {
+    return GetBuiltInNames().count(name) != 0;
+}
+
+// Names from kBuiltInConstants that carry no dimensional scale and can
+// appear safely inside any numeric expression (e.g. <D value="pi/3.14">).
+// Every other built-in carries a CLHEP-internal scale (mm = 1, gram =
+// 6.24e21, etc.); embedding those in an expression that is then read
+// as a value in a different dimension (density, atomic mass, ...)
+// silently produces a wildly wrong number.
+static const std::unordered_set<std::string>& GetPureMathConstantNames() {
+    static const std::unordered_set<std::string> names = {
+        "pi", "twopi", "TWOPI", "halfpi", "e", "gamma"
+    };
+    return names;
+}
+
+bool ExpressionContainsUnitBuiltIn(std::string const & expr, std::string & found_name) {
+    size_t i = 0;
+    while(i < expr.size()) {
+        char c = expr[i];
+        if(IsIdentStart(c)) {
+            size_t start = i;
+            while(i < expr.size() && IsIdentChar(expr[i])) ++i;
+            std::string name = expr.substr(start, i - start);
+            if(IsBuiltInConstant(name) && GetPureMathConstantNames().count(name) == 0) {
+                found_name = name;
+                return true;
+            }
+        } else {
+            ++i;
+        }
+    }
+    return false;
+}
+
+void SeedBuiltInConstants(GDMLData & data) {
+    for(auto const & e : kBuiltInConstants) {
+        data.constants[e.name] = e.value;
+    }
+}
+
+// Forward decl: TypeFromUnit is defined later in this file.
+static GDMLQuantityType TypeFromUnit(std::string const & u);
+
+// Get the length scale factor for a given unit string.
+//
+// Routes through kBuiltInConstants (CLHEP mm=1 base) so every length unit
+// recognized by TypeFromUnit (inch, angstrom, fermi, long-form names, etc.)
+// is accepted by ParseLength. The built-in map stores values relative to
+// mm; multiplying by SIREN's mm constant yields the SIREN-unit result.
+double LengthScale(const char* unit) {
+    if(!unit || unit[0] == '\0') {
+        return siren::utilities::Constants::mm; // GDML default is mm
+    }
+    std::string u(unit);
+    if(TypeFromUnit(u) != GDMLQuantityType::LENGTH) {
+        throw std::runtime_error("GDML error: unrecognized length unit '" + u + "'");
+    }
+    auto it = GetBuiltInMap().find(u);
+    if(it == GetBuiltInMap().end()) {
+        // Reachable only if TypeFromUnit recognizes a spelling that
+        // kBuiltInConstants does not - keep the two tables in sync.
+        throw std::runtime_error("GDML error: length unit '" + u
+            + "' is recognized by type but not seeded in the built-in table");
+    }
+    return it->second * siren::utilities::Constants::mm;
+}
+
+// Convert a GDML length value+unit to meters (SIREN base unit)
+// GDML default length unit is mm
+double ParseLength(const char* value, const char* unit,
+                   std::unordered_map<std::string, double> const & constants) {
+    if(!value || value[0] == '\0') return 0.0;
+    double val = EvalExpression(std::string(value), constants);
+
+    return val * LengthScale(unit);
+}
+
+// Get the angle scale factor for a given unit string
+double AngleScale(const char* unit) {
+    if(!unit || unit[0] == '\0') {
+        // GDML default angle unit is radians
+        return siren::utilities::Constants::radian;
+    }
+    std::string u(unit);
+    if(u == "deg" || u == "degree") return siren::utilities::Constants::degrees;
+    if(u == "rad" || u == "radian") return siren::utilities::Constants::radian;
+    if(u == "mrad" || u == "milliradian") return siren::utilities::Constants::mrad;
+    throw std::runtime_error("GDML error: unrecognized angle unit '" + u + "'");
+}
+
+// Convert a GDML angle value+unit to radians
+// GDML default angle unit is radians (matches AngleScale)
+double ParseAngle(const char* value, const char* unit,
+                  std::unordered_map<std::string, double> const & constants) {
+    if(!value || value[0] == '\0') return 0.0;
+    double val = EvalExpression(std::string(value), constants);
+    return val * AngleScale(unit);
+}
+
+// GDML rotation convention: extrinsic XYZ (rotate X, then Y, then Z
+// about the static world axes). QFromXYZs computes qz * qy * qx.
+Quaternion QuatFromGDMLRotation(double rx, double ry, double rz) {
+    return siren::math::QFromXYZs(rx, ry, rz);
+}
+
+// Convert a value from the given unit to the GDML default for that unit type.
+// For length: convert to mm (GDML default length)
+// For angle: convert to rad (GDML default angle)
+// For energy: convert to MeV (common default)
+// Returns the scale factor to multiply the raw value by.
+// Infer quantity type from a unit string.
+static GDMLQuantityType TypeFromUnit(std::string const & u) {
+    if(u.empty()) return GDMLQuantityType::NONE;
+    if(u == "mm" || u == "cm" || u == "m" || u == "km" ||
+       u == "um" || u == "nm" || u == "in" ||
+       u == "millimeter" || u == "centimeter" || u == "meter" ||
+       u == "kilometer" || u == "micrometer" || u == "nanometer" ||
+       u == "angstrom" || u == "fermi" || u == "inch")
+        return GDMLQuantityType::LENGTH;
+    if(u == "rad" || u == "deg" || u == "mrad" ||
+       u == "radian" || u == "degree" || u == "milliradian")
+        return GDMLQuantityType::ANGLE;
+    if(u == "eV" || u == "keV" || u == "MeV" || u == "GeV" ||
+       u == "TeV" || u == "PeV" || u == "joule")
+        return GDMLQuantityType::ENERGY;
+    if(u == "ns" || u == "ps" || u == "us" || u == "ms" ||
+       u == "nanosecond" || u == "picosecond" || u == "microsecond" ||
+       u == "millisecond" || u == "second")
+        return GDMLQuantityType::TIME;
+    if(u == "g/cm3" || u == "mg/cm3" || u == "kg/m3")
+        return GDMLQuantityType::DENSITY;
+    if(u == "kelvin")
+        return GDMLQuantityType::TEMPERATURE;
+    if(u == "mole" || u == "mol")
+        return GDMLQuantityType::AMOUNT;
+    return GDMLQuantityType::NONE;
+}
+
+// Infer quantity type from the type attribute string.
+static GDMLQuantityType TypeFromTypeAttr(std::string const & type_str) {
+    if(type_str.empty()) return GDMLQuantityType::NONE;
+    std::string t = type_str;
+    std::transform(t.begin(), t.end(), t.begin(), ::tolower);
+    if(t == "length" || t == "lenght" || t == "coordinate")
+        return GDMLQuantityType::LENGTH;
+    if(t == "angle") return GDMLQuantityType::ANGLE;
+    if(t == "energy" || t == "threshold") return GDMLQuantityType::ENERGY;
+    if(t == "time") return GDMLQuantityType::TIME;
+    if(t == "density") return GDMLQuantityType::DENSITY;
+    if(t == "temperature") return GDMLQuantityType::TEMPERATURE;
+    return GDMLQuantityType::NONE;
+}
+
+// Resolve the quantity type from both the type attribute and the unit string.
+// If both are present and disagree, warn and prefer the unit-inferred type.
+GDMLQuantityType ResolveQuantityType(
+        const char* type_attr, const char* unit,
+        std::string const & name,
+        GDMLData & data, GDMLParseOptions const & options) {
+    GDMLQuantityType from_attr = TypeFromTypeAttr(type_attr ? type_attr : "");
+    GDMLQuantityType from_unit = TypeFromUnit(unit ? unit : "");
+
+    if(from_attr != GDMLQuantityType::NONE && from_unit != GDMLQuantityType::NONE) {
+        if(from_attr != from_unit) {
+            EmitWarning(data, options, "quantity '" + name + "': type '"
+                + std::string(type_attr) + "' conflicts with unit '"
+                + std::string(unit) + "'; using unit-inferred type");
+        }
+        return from_unit;
+    }
+    if(from_unit != GDMLQuantityType::NONE) return from_unit;
+    return from_attr;
+}
+
+// Convert a quantity value from its declared unit to the canonical storage
+// representation for its type.
+//
+// LENGTH/ANGLE/ENERGY/TIME: stored in CLHEP base units (mm, rad, MeV, ns).
+//   These equal the GDML default units, so downstream consumption via
+//   lscale/ascale works correctly.
+// DENSITY: stored in g/cm3. The <D> parser expects g/cm3, so we must NOT
+//   use CLHEP density units here.
+double QuantityUnitScale(const char* unit, GDMLQuantityType resolved_type) {
+    if(!unit || unit[0] == '\0') return 1.0;
+
+    std::string u(unit);
+
+    if(resolved_type == GDMLQuantityType::DENSITY) {
+        if(u == "g/cm3") return 1.0;
+        if(u == "mg/cm3") return 1.0e-3;
+        if(u == "kg/m3") return 1.0e-3;
+        throw std::runtime_error("GDML error: unrecognized density unit '" + u + "'");
+    }
+
+    auto it = GetBuiltInMap().find(u);
+    if(it != GetBuiltInMap().end()) return it->second;
+    throw std::runtime_error("GDML error: unrecognized unit '" + u + "'");
+}
+
+} // namespace gdml
+} // namespace detector
+} // namespace siren

--- a/projects/detector/private/pybindings/Path.h
+++ b/projects/detector/private/pybindings/Path.h
@@ -21,7 +21,6 @@ void register_Path(pybind11::module_ & m) {
         .def("HasDetectorModel", &Path::HasDetectorModel)
         .def("HasPoints", &Path::HasPoints)
         .def("HasIntersections", &Path::HasIntersections)
-        .def("HasColumnDepth", &Path::HasColumnDepth)
 
         .def("GetDetectorModel", &Path::GetDetectorModel)
         .def("GetFirstPoint", [](Path & p)->Vector3D{return p.GetFirstPoint().get(); })

--- a/projects/detector/public/SIREN/detector/GDMLParser.h
+++ b/projects/detector/public/SIREN/detector/GDMLParser.h
@@ -1,0 +1,148 @@
+#pragma once
+#ifndef SIREN_GDMLParser_H
+#define SIREN_GDMLParser_H
+
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <memory>
+
+#include "SIREN/math/Vector3D.h"
+#include "SIREN/math/Quaternion.h"
+#include "SIREN/geometry/Geometry.h"
+#include "SIREN/geometry/Placement.h"
+
+namespace siren {
+namespace detector {
+
+// Parsed GDML data, ready for conversion to DetectorModel sectors
+struct GDMLMaterial {
+    std::string name;
+    double density; // g/cm^3
+    double Z;       // atomic number (for simple materials)
+    double A;       // atomic mass (g/mol, for simple materials)
+    // For composite materials: map of component name -> mass fraction
+    std::map<std::string, double> composition;
+
+    bool operator==(GDMLMaterial const & o) const {
+        return name == o.name && density == o.density
+            && Z == o.Z && A == o.A && composition == o.composition;
+    }
+};
+
+struct GDMLPhysVol {
+    std::string volume_ref;
+    math::Vector3D position;     // in meters (converted from GDML units)
+    math::Quaternion rotation;   // converted from GDML Euler angles
+};
+
+struct GDMLVolume {
+    std::string name;
+    std::string solid_ref;
+    std::string material_ref;
+    bool is_assembly = false;
+    std::vector<GDMLPhysVol> children;
+};
+
+// Physical dimension type for a GDML quantity.
+// Used to check that typed quantities are consumed in compatible contexts
+// and to select the correct unit-conversion path (e.g. density -> g/cm3).
+enum class GDMLQuantityType {
+    NONE, LENGTH, ANGLE, ENERGY, TIME, DENSITY, TEMPERATURE, AMOUNT
+};
+
+// Options controlling GDML parse behavior
+struct GDMLParseOptions {
+    // If true, any warning condition throws std::runtime_error instead of
+    // collecting a warning and continuing. Useful for validating GDML files.
+    bool strict = false;
+
+    // If true (default), strip Geant4 pointer-address suffixes from names
+    // (e.g. "Si0x7f3a4c002a" -> "Si") and dedup identical definitions.
+    // Disable if the stripping interferes with intentional naming.
+    bool strip_pointer_suffixes = true;
+};
+
+struct GDMLData {
+    // Defined positions and rotations (resolved to SIREN units)
+    std::unordered_map<std::string, math::Vector3D> positions;
+    std::unordered_map<std::string, math::Quaternion> rotations;
+    std::unordered_map<std::string, double> constants;
+
+    // Type information for named quantities. Keys are a subset of constants.
+    // Only quantities with explicit type/unit have entries here.
+    std::unordered_map<std::string, GDMLQuantityType> quantity_types;
+
+    // GDML material types, kept in separate namespaces to avoid collisions
+    // between e.g. <element name="Si"> and <material name="Si">.
+    std::unordered_map<std::string, GDMLMaterial> isotopes;
+    std::unordered_map<std::string, GDMLMaterial> elements;
+    std::unordered_map<std::string, GDMLMaterial> materials;
+
+    // Matrix definitions: name -> {coldim, flat_values}
+    std::unordered_map<std::string, std::pair<int, std::vector<double>>> matrices;
+
+    // Solids (as Geometry objects, in SIREN units)
+    std::unordered_map<std::string, std::shared_ptr<geometry::Geometry>> solids;
+
+    // Volume hierarchy
+    std::unordered_map<std::string, GDMLVolume> volumes;
+
+    // World volume name (from <setup>)
+    std::string world_volume;
+
+    // Base directory of the GDML file, for resolving relative <file> paths.
+    std::string base_dir;
+
+    // Name aliases: maps original names (possibly with Geant4 pointer suffixes
+    // like "Si0x7f3a") to their canonical stripped/deduped names ("Si").
+    // Used to resolve references that use the original exported names.
+    std::unordered_map<std::string, std::string> name_aliases;
+
+    // Instance counts: how many definitions of each name were seen during parsing.
+    // Names with count > 1 are ambiguous for direct volume references.
+    // Boolean solids resolve operand references using instance tracking at
+    // definition time, so they are not affected by ambiguity.
+    std::unordered_map<std::string, int> solid_instance_counts;
+    std::unordered_map<std::string, int> material_instance_counts;
+
+    // Warnings collected during parsing (unsupported features, skipped solids, etc.)
+    // In strict mode this stays empty since warnings throw instead.
+    std::vector<std::string> warnings;
+
+    // Fatal errors collected during parsing. Parsing continues to gather as
+    // many diagnostics as possible, then throws with the full list at the end
+    // of each parse phase. Check with ThrowIfErrors() after each phase.
+    std::vector<std::string> errors;
+
+    // Throw a std::runtime_error if any errors have been collected, with a
+    // message listing all of them. Clears the error list after throwing.
+    void ThrowIfErrors();
+
+    // Merge another GDMLData (typically from a <file> sub-parse) into this
+    // one, handling name collisions automatically.
+    //
+    // Identical definitions (same material properties, same solid geometry)
+    // are silently reused. Differing definitions with the same name are
+    // auto-renamed with a numeric suffix in the sub-data before merging.
+    //
+    // Returns a rename map (original name -> new name) for any names that
+    // were changed, so the caller can update volume references.
+    std::unordered_map<std::string, std::string> MergeFrom(GDMLData & other);
+};
+
+/// Parse a GDML file and return the parsed data.
+/// Accepts any root element (e.g. <gdml>, <gdml_simple_extension>) as long as
+/// it contains the standard GDML child sections (define, materials, solids, etc.).
+/// Multiple <solids>/<structure>/<define>/<materials> sections are merged.
+///
+/// @warning ParseGDML resolves ENTITY SYSTEM and xi:include directives
+/// by reading files relative to the GDML file's directory, including
+/// absolute paths. Only call this on trusted GDML input.
+GDMLData ParseGDML(std::string const & filename, GDMLParseOptions const & options = {});
+
+} // namespace detector
+} // namespace siren
+
+#endif // SIREN_GDMLParser_H

--- a/projects/detector/public/SIREN/detector/GDMLParser.h
+++ b/projects/detector/public/SIREN/detector/GDMLParser.h
@@ -3,10 +3,11 @@
 #define SIREN_GDMLParser_H
 
 #include <map>
-#include <string>
-#include <unordered_map>
-#include <vector>
 #include <memory>
+#include <string>
+#include <vector>
+#include <utility>
+#include <unordered_map>
 
 #include "SIREN/math/Vector3D.h"
 #include "SIREN/math/Quaternion.h"

--- a/projects/detector/public/SIREN/detector/Path.h
+++ b/projects/detector/public/SIREN/detector/Path.h
@@ -47,9 +47,6 @@ private:
     DetectorDirection direction_det_;
     bool set_det_points_ = false;
 
-    double column_depth_cached_;
-    bool set_column_depth_ = false;
-
     geometry::Geometry::IntersectionList intersections_;
     bool set_intersections_ = false;
 
@@ -84,7 +81,6 @@ public:
     bool HasDetectorModel();
     bool HasPoints();
     bool HasIntersections();
-    bool HasColumnDepth();
 
     std::shared_ptr<const DetectorModel> GetDetectorModel();
     DetectorPosition const & GetFirstPoint();

--- a/projects/geometry/private/GenericPolycone.cxx
+++ b/projects/geometry/private/GenericPolycone.cxx
@@ -260,13 +260,36 @@ std::vector<Geometry::Intersection> GenericPolycone::ComputeIntersections(
         return a.distance < b.distance;
     };
 
+    // Net-parity dedup: collapse coincident hits from shared edge boundaries.
+    auto net_parity_dedup = [](Intersection* hits, int count) -> std::vector<Intersection> {
+        std::vector<Intersection> result;
+        int i = 0;
+        while(i < count) {
+            int j = i + 1;
+            while(j < count && std::fabs(hits[j].distance - hits[i].distance) <= GEOMETRY_PRECISION)
+                ++j;
+            int net = 0;
+            for(int k = i; k < j; ++k)
+                net += hits[k].entering ? 1 : -1;
+            if(net > 0) {
+                hits[i].entering = true;
+                result.push_back(hits[i]);
+            } else if(net < 0) {
+                hits[i].entering = false;
+                result.push_back(hits[i]);
+            }
+            i = j;
+        }
+        return result;
+    };
+
     if(!has_phi_cut_) {
         if(use_heap) {
             std::sort(heap_hits.begin(), heap_hits.end(), cmp);
-            return heap_hits;
+            return net_parity_dedup(heap_hits.data(), n_hits);
         }
         std::sort(stack_hits, stack_hits + n_hits, cmp);
-        return {stack_hits, stack_hits + n_hits};
+        return net_parity_dedup(stack_hits, n_hits);
     }
 
     // Phi cut: merge surface hits with infinite wedge hits and run CSG walk.
@@ -345,7 +368,7 @@ std::vector<Geometry::Intersection> GenericPolycone::ComputeIntersections(
         }
         was_inside = now_inside;
     }
-    return result;
+    return net_parity_dedup(result.data(), (int)result.size());
 }
 
 AABB GenericPolycone::GetBoundingBox() const {

--- a/projects/geometry/private/Polyhedra.cxx
+++ b/projects/geometry/private/Polyhedra.cxx
@@ -667,13 +667,36 @@ std::vector<Geometry::Intersection> Polyhedra::ComputeIntersections(siren::math:
         return a.distance < b.distance;
     };
 
+    // Net-parity dedup: collapse coincident hits from shared face boundaries.
+    auto net_parity_dedup = [](Intersection* hits, int count) -> std::vector<Intersection> {
+        std::vector<Intersection> result;
+        int i = 0;
+        while(i < count) {
+            int j = i + 1;
+            while(j < count && std::fabs(hits[j].distance - hits[i].distance) <= GEOMETRY_PRECISION)
+                ++j;
+            int net = 0;
+            for(int k = i; k < j; ++k)
+                net += hits[k].entering ? 1 : -1;
+            if(net > 0) {
+                hits[i].entering = true;
+                result.push_back(hits[i]);
+            } else if(net < 0) {
+                hits[i].entering = false;
+                result.push_back(hits[i]);
+            }
+            i = j;
+        }
+        return result;
+    };
+
     if(!has_phi_cut_) {
         if(using_heap) {
             std::sort(heap_hits.begin(), heap_hits.end(), cmp);
-            return heap_hits;
+            return net_parity_dedup(heap_hits.data(), n_hits);
         }
         std::sort(stack_hits, stack_hits + n_hits, cmp);
-        return {stack_hits, stack_hits + n_hits};
+        return net_parity_dedup(stack_hits, n_hits);
     }
 
     // Phi boundary face intersections for partial-phi polyhedra.
@@ -727,10 +750,10 @@ std::vector<Geometry::Intersection> Polyhedra::ComputeIntersections(siren::math:
 
     if(using_heap) {
         std::sort(heap_hits.begin(), heap_hits.end(), cmp);
-        return heap_hits;
+        return net_parity_dedup(heap_hits.data(), n_hits);
     }
     std::sort(stack_hits, stack_hits + n_hits, cmp);
-    return {stack_hits, stack_hits + n_hits};
+    return net_parity_dedup(stack_hits, n_hits);
 }
 
 // ------------------------------------------------------------------------- //

--- a/projects/geometry/private/Trd.cxx
+++ b/projects/geometry/private/Trd.cxx
@@ -255,7 +255,27 @@ std::vector<Geometry::Intersection> Trd::ComputeIntersections(siren::math::Vecto
     std::sort(hits, hits + n_hits, [](Intersection const & a, Intersection const & b) {
         return a.distance < b.distance;
     });
-    return {hits, hits + n_hits};
+
+    // Net-parity dedup: collapse coincident hits from shared face boundaries.
+    std::vector<Intersection> result;
+    int i = 0;
+    while(i < n_hits) {
+        int j = i + 1;
+        while(j < n_hits && std::fabs(hits[j].distance - hits[i].distance) <= GEOMETRY_PRECISION)
+            ++j;
+        int net = 0;
+        for(int k = i; k < j; ++k)
+            net += hits[k].entering ? 1 : -1;
+        if(net > 0) {
+            hits[i].entering = true;
+            result.push_back(hits[i]);
+        } else if(net < 0) {
+            hits[i].entering = false;
+            result.push_back(hits[i]);
+        }
+        i = j;
+    }
+    return result;
 }
 
 // ------------------------------------------------------------------------- //

--- a/projects/geometry/private/test/ShapeInvariants_TEST.cxx
+++ b/projects/geometry/private/test/ShapeInvariants_TEST.cxx
@@ -1225,6 +1225,92 @@ TEST(ShapeInvariants, TangentRaysGenericPolycone) {
     }
 }
 
+// =========================================================================
+// Polyhedra edge and vertex-aimed rays
+// =========================================================================
+TEST(ShapeInvariants, PolyhedraEdgeAndVertexRays) {
+    // Solid hexagonal prism: 6 sides, start_phi=0, z from -5 to 5, rmin=0, rmax=4
+    Polyhedra hex(6, 0, {-5, 5}, {0, 0}, {4, 4});
+
+    // Ray aimed at a lateral edge where two side faces meet.
+    // For a regular hexagon, apothem=4, circumradius = 4/cos(pi/6).
+    double cr = 4.0 / std::cos(M_PI / 6.0);
+    // First vertex is at angle 0: (cr, 0, z)
+    {
+        Vector3D dir = Vector3D(cr, 0, 0);
+        dir.normalize();
+        auto hits = hex.Intersections(Vector3D(cr * 2, 0, 0), Vector3D(-dir.GetX(), -dir.GetY(), -dir.GetZ()));
+        EXPECT_TRUE(hits.size() == 0 || hits.size() == 2)
+            << "Polyhedra lateral-edge ray: expected 0 or 2, got " << hits.size();
+    }
+
+    // Ray aimed at a top-cap vertex (cr, 0, 5)
+    {
+        Vector3D target(cr, 0, 5);
+        Vector3D origin = target * 2;
+        Vector3D dir = target - origin;
+        dir.normalize();
+        auto hits = hex.Intersections(origin, dir);
+        EXPECT_TRUE(hits.size() == 0 || hits.size() == 2)
+            << "Polyhedra cap-vertex ray: expected 0 or 2, got " << hits.size();
+    }
+
+    // Tapered polyhedra: different rmax at top and bottom
+    Polyhedra tapered(6, 0, {-5, 5}, {0, 0}, {4, 2});
+    {
+        auto hits = tapered.Intersections(Vector3D(10, 0, 0), Vector3D(-1, 0, 0));
+        EXPECT_EQ(hits.size(), 2u)
+            << "Tapered polyhedra center ray: expected 2, got " << hits.size();
+    }
+
+    // Hollow hexagonal prism: rmin=2, rmax=4
+    Polyhedra hollow(6, 0, {-5, 5}, {2, 2}, {4, 4});
+    {
+        auto hits = hollow.Intersections(Vector3D(10, 0, 0), Vector3D(-1, 0, 0));
+        EXPECT_EQ(hits.size(), 4u)
+            << "Hollow polyhedra center ray: expected 4, got " << hits.size();
+    }
+
+    // Multi-section polyhedra with a step discontinuity
+    Polyhedra stepped(6, 0, {-5, 0, 0, 5}, {0, 0, 0, 0}, {4, 4, 3, 3});
+    {
+        // Ray at the step boundary z=0
+        auto hits = stepped.Intersections(Vector3D(10, 0, 0), Vector3D(-1, 0, 0));
+        EXPECT_EQ(hits.size() % 2, 0u)
+            << "Stepped polyhedra center ray: odd count " << hits.size();
+    }
+}
+
+// =========================================================================
+// Polycone edge rays: verify cap-ownership prevents coincident hits
+// =========================================================================
+TEST(ShapeInvariants, PolyconeEdgeRays) {
+    // Multi-section polycone
+    Polycone pc({-5, 0, 5}, {0, 0, 0}, {4, 5, 3});
+
+    // Horizontal ray at z=0 section boundary
+    {
+        auto hits = pc.Intersections(Vector3D(10, 0, 0), Vector3D(-1, 0, 0));
+        EXPECT_EQ(hits.size(), 2u)
+            << "Polycone section-boundary ray: expected 2, got " << hits.size();
+    }
+
+    // Ray along z-axis
+    {
+        auto hits = pc.Intersections(Vector3D(0, 0, -10), Vector3D(0, 0, 1));
+        EXPECT_EQ(hits.size(), 2u)
+            << "Polycone z-axis ray: expected 2, got " << hits.size();
+    }
+
+    // Hollow polycone at section boundary
+    Polycone hollow_pc({-5, 0, 5}, {2, 3, 1}, {4, 5, 3});
+    {
+        auto hits = hollow_pc.Intersections(Vector3D(10, 0, 0), Vector3D(-1, 0, 0));
+        EXPECT_EQ(hits.size(), 4u)
+            << "Hollow polycone center ray: expected 4, got " << hits.size();
+    }
+}
+
 TEST(ShapeInvariants, PhiCutZAxisIncluded) {
     double sp = M_PI / 5.0;
     double dp = M_PI / 3.0;


### PR DESCRIPTION
## Summary

Part B of the stacked GDML compatibility refactor. Base: #134.

- Path: reuse cached intersections when a new ray is collinear with the previous, drop unused column-depth cache
- GDML parser modules (one per concern):
  - Scaffolding: public/private headers
  - Expression evaluator (shunting-yard)
  - Typed-quantity unit system
  - Read utilities + <define> parser
  - Preprocessor (loops, defines, entity expansion)
  - <materials> parser (separate isotope/element/material namespaces)
  - <solids> parser (every GDML shape type)
  - <structure> parser (volumes, assemblies, physvol, file references)
- GDML parser entry point: ParseGDML(filename, options) -> ParsedGeometry, document-order dispatch

**Stack:**
- Part A: #134 (this PR is stacked on top)
- Part C (#138): DetectorModel BVH + LoadGDML integration + remaining tests + build cleanup

## Test plan

- [x] Every commit builds in isolation
- [x] UnitTest_Path passes at tip
- [x] Pre-existing failures unchanged