### PR TITLE
SBN geometry loader with PREM Earth model

### DIFF
--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -2212,7 +2212,7 @@ void DetectorModel::LoadConcentricShellsFromLegacyFile(std::string model_fname, 
     double radius, param;
     int nparams;
 
-    int level = -sectors_.size();
+    int level = -static_cast<int>(sectors_.size());
     double max_radius = 0;
     while(getline(in,buf)) {
         {
@@ -2285,14 +2285,17 @@ void DetectorModel::LoadConcentricShellsFromLegacyFile(std::string model_fname, 
         saw_ice |= in_ice;
 
         if(not saw_ice) {
-            // In the Earth, keep increasing the radius
-            if(solid)
-                earth_radius = ((Sphere *)(sector.geo.get()))->GetRadius();
+            if(solid) {
+                auto const * sp = dynamic_cast<Sphere const *>(sector.geo.get());
+                if(sp) earth_radius = sp->GetRadius();
+            }
         }
         else if(in_ice) {
-            // In the ice, keep increasing the radius
-            ice_radius = ((Sphere *)(sector.geo.get()))->GetRadius();
-            ice_layers.push_back(i);
+            auto const * sp = dynamic_cast<Sphere const *>(sector.geo.get());
+            if(sp) {
+                ice_radius = sp->GetRadius();
+                ice_layers.push_back(i);
+            }
         }
         else {
             // Out of the ice, stop counting layers

--- a/projects/detector/private/gdml/GDMLSolidParser.cxx
+++ b/projects/detector/private/gdml/GDMLSolidParser.cxx
@@ -108,8 +108,12 @@ std::shared_ptr<Geometry> BuildBooleanGeometry(BooleanOperation op,
 }
 
 std::shared_ptr<Geometry> ParseBox(SolidContext const & ctx) {
-    // GDML <box> x,y,z are half-widths; SIREN Box takes full widths.
-    return Box(L(ctx, "x") * 2.0, L(ctx, "y") * 2.0, L(ctx, "z") * 2.0).create();
+    // GDML <box> x,y,z are half-widths
+    // SIREN Box constructor takes full widths as arguments
+    double const x_full_width = L(ctx, "x") * 2.0;
+    double const y_full_width = L(ctx, "y") * 2.0;
+    double const z_full_width = L(ctx, "z") * 2.0;
+    return Box(x_full_width, y_full_width, z_full_width).create();
 }
 
 std::shared_ptr<Geometry> ParseSphere(SolidContext const & ctx) {

--- a/projects/detector/private/pybindings/DetectorModel.h
+++ b/projects/detector/private/pybindings/DetectorModel.h
@@ -17,7 +17,7 @@ void register_DetectorModel(pybind11::module_ & m) {
         .def(init<>())
         .def(init<std::string const &, std::string const &>())
         .def(init<std::string const &, std::string const &, std::string const &>())
-        .def("LoadDetectorModel",&DetectorModel::LoadDetectorModel)
+        .def("LoadDetectorModel",&DetectorModel::LoadDetectorModel, arg("detector_model"))
         .def("LoadMaterialModel",&DetectorModel::LoadMaterialModel)
         .def("LoadGDML",&DetectorModel::LoadGDML, arg("filename"), arg("strict") = false)
         .def("GetMassDensity", (

--- a/projects/detector/private/pybindings/RadialAxisExponentialDensityDistribution.h
+++ b/projects/detector/private/pybindings/RadialAxisExponentialDensityDistribution.h
@@ -1,0 +1,61 @@
+#include <set>
+#include <memory>
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "../../public/SIREN/detector/DetectorModel.h"
+#include "../../public/SIREN/detector/RadialAxisExponentialDensityDistribution.h"
+#include "../../../geometry/public/SIREN/geometry/Geometry.h"
+
+void register_RadialAxisExponentialDensityDistribution(pybind11::module_ & m) {
+    using namespace pybind11;
+    using namespace siren::detector;
+
+    typedef RadialAxis1D AxisT;
+    typedef ExponentialDistribution1D DistributionT;
+    typedef DensityDistribution1D<AxisT,DistributionT> DDist1DT;
+
+
+    std::string name = "RadialAxisExponentialDensityDistribution";
+
+    class_<DDist1DT, std::shared_ptr<DDist1DT>, DensityDistribution>(m, name.c_str())
+        .def(init<>())
+        .def(init<AxisT, DistributionT>())
+        .def(init<DDist1DT>())
+        .def("_compare", &DDist1DT::compare)
+        .def("_clone", &DDist1DT::clone)
+        .def("_create", &DDist1DT::create)
+        .def("Derivative", &DDist1DT::Derivative)
+        .def("AntiDerivative", &DDist1DT::AntiDerivative)
+        .def("Integral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &,
+                        double) const)(&DDist1DT::Integral)
+                    )
+        .def("Integral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &) const)(&DDist1DT::Integral)
+                    )
+        .def("InverseIntegral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &,
+                        double,
+                        double) const)(&DDist1DT::InverseIntegral)
+                    )
+        .def("InverseIntegral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &,
+                        double,
+                        double,
+                        double) const)(&DDist1DT::InverseIntegral)
+                    )
+        .def("Evaluate", &DDist1DT::Evaluate)
+        ;
+}

--- a/projects/detector/private/pybindings/RadialAxisPolynomialDensityDistribution.h
+++ b/projects/detector/private/pybindings/RadialAxisPolynomialDensityDistribution.h
@@ -1,0 +1,61 @@
+#include <set>
+#include <memory>
+#include <string>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "../../public/SIREN/detector/DetectorModel.h"
+#include "../../public/SIREN/detector/RadialAxisPolynomialDensityDistribution.h"
+#include "../../../geometry/public/SIREN/geometry/Geometry.h"
+
+void register_RadialAxisPolynomialDensityDistribution(pybind11::module_ & m) {
+    using namespace pybind11;
+    using namespace siren::detector;
+
+    typedef RadialAxis1D AxisT;
+    typedef PolynomialDistribution1D DistributionT;
+    typedef DensityDistribution1D<AxisT,DistributionT> DDist1DT;
+
+
+    std::string name = "RadialAxisPolynomialDensityDistribution";
+
+    class_<DDist1DT, std::shared_ptr<DDist1DT>, DensityDistribution>(m, name.c_str())
+        .def(init<>())
+        .def(init<AxisT, DistributionT>())
+        .def(init<DDist1DT>())
+        .def("_compare", &DDist1DT::compare)
+        .def("_clone", &DDist1DT::clone)
+        .def("_create", &DDist1DT::create)
+        .def("Derivative", &DDist1DT::Derivative)
+        .def("AntiDerivative", &DDist1DT::AntiDerivative)
+        .def("Integral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &,
+                        double) const)(&DDist1DT::Integral)
+                    )
+        .def("Integral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &) const)(&DDist1DT::Integral)
+                    )
+        .def("InverseIntegral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &,
+                        double,
+                        double) const)(&DDist1DT::InverseIntegral)
+                    )
+        .def("InverseIntegral", (
+                    double (DDist1DT::*)(
+                        siren::math::Vector3D const &,
+                        siren::math::Vector3D const &,
+                        double,
+                        double,
+                        double) const)(&DDist1DT::InverseIntegral)
+                    )
+        .def("Evaluate", &DDist1DT::Evaluate)
+        ;
+}

--- a/projects/detector/private/pybindings/detector.cxx
+++ b/projects/detector/private/pybindings/detector.cxx
@@ -15,6 +15,8 @@
 #include "./CartesianAxis1D.h"
 #include "./CartesianAxisExponentialDensityDistribution.h"
 #include "./CartesianAxisPolynomialDensityDistribution.h"
+#include "./RadialAxisExponentialDensityDistribution.h"
+#include "./RadialAxisPolynomialDensityDistribution.h"
 #include "./ConstantDensityDistribution.h"
 #include "./MaterialModel.h"
 
@@ -36,6 +38,8 @@ PYBIND11_MODULE(detector,m) {
 
     register_CartesianAxisExponentialDensityDistribution(m);
     register_CartesianAxisPolynomialDensityDistribution(m);
+    register_RadialAxisExponentialDensityDistribution(m);
+    register_RadialAxisPolynomialDensityDistribution(m);
     register_ConstantDensityDistribution(m);
 
     register_MaterialModel(m);

--- a/projects/geometry/private/Box.cxx
+++ b/projects/geometry/private/Box.cxx
@@ -19,19 +19,19 @@
 namespace siren {
 namespace geometry {
 
-Box::Box() : Geometry("Box"), x_(0), y_(0), z_(0) { RecomputeWorldAABB(); }
-Box::Box(double x, double y, double z) : Geometry("Box"), x_(x), y_(y), z_(z) { RecomputeWorldAABB(); }
-Box::Box(Placement const & p) : Geometry("Box", p), x_(0), y_(0), z_(0) { RecomputeWorldAABB(); }
-Box::Box(Placement const & p, double x, double y, double z) : Geometry("Box", p), x_(x), y_(y), z_(z) { RecomputeWorldAABB(); }
-Box::Box(const Box& o) : Geometry(o), x_(o.x_), y_(o.y_), z_(o.z_) { RecomputeWorldAABB(); }
+Box::Box() : Geometry("Box"), full_width_x_(0), full_width_y_(0), full_width_z_(0) { RecomputeWorldAABB(); }
+Box::Box(double x, double y, double z) : Geometry("Box"), full_width_x_(x), full_width_y_(y), full_width_z_(z) { RecomputeWorldAABB(); }
+Box::Box(Placement const & p) : Geometry("Box", p), full_width_x_(0), full_width_y_(0), full_width_z_(0) { RecomputeWorldAABB(); }
+Box::Box(Placement const & p, double full_width_x, double full_width_y, double full_width_z) : Geometry("Box", p), full_width_x_(full_width_x), full_width_y_(full_width_y), full_width_z_(full_width_z) { RecomputeWorldAABB(); }
+Box::Box(const Box& o) : Geometry(o), full_width_x_(o.full_width_x_), full_width_y_(o.full_width_y_), full_width_z_(o.full_width_z_) { RecomputeWorldAABB(); }
 
-SIREN_GEOMETRY_SWAP(Box, x_, y_, z_)
+SIREN_GEOMETRY_SWAP(Box, full_width_x_, full_width_y_, full_width_z_)
 SIREN_GEOMETRY_ASSIGN(Box)
-SIREN_GEOMETRY_EQUAL(Box, x_, y_, z_)
-SIREN_GEOMETRY_LESS(Box, x_, y_, z_)
+SIREN_GEOMETRY_EQUAL(Box, full_width_x_, full_width_y_, full_width_z_)
+SIREN_GEOMETRY_LESS(Box, full_width_x_, full_width_y_, full_width_z_)
 
 void Box::print(std::ostream& os) const {
-    os << "Box(" << x_ << ", " << y_ << ", " << z_ << ")\n";
+    os << "Box(" << full_width_x_ << ", " << full_width_y_ << ", " << full_width_z_ << ")\n";
 }
 
 // ------------------------------------------------------------------------- //
@@ -39,7 +39,7 @@ std::vector<Geometry::Intersection> Box::ComputeIntersections(siren::math::Vecto
     double px = position.GetX(), py = position.GetY(), pz = position.GetZ();
     double dx = direction.GetX(), dy = direction.GetY(), dz = direction.GetZ();
 
-    double hx = 0.5 * x_, hy = 0.5 * y_, hz = 0.5 * z_;
+    double hx = 0.5 * full_width_x_, hy = 0.5 * full_width_y_, hz = 0.5 * full_width_z_;
 
     // Use the slab method: find the ray parameter ranges where the ray is
     // inside each pair of parallel planes, then intersect the three ranges.
@@ -109,9 +109,9 @@ std::vector<Geometry::Intersection> Box::ComputeIntersections(siren::math::Vecto
 
 // ------------------------------------------------------------------------- //
 AABB Box::GetBoundingBox() const {
-    double hx = x_ * 0.5;
-    double hy = y_ * 0.5;
-    double hz = z_ * 0.5;
+    double hx = full_width_x_ * 0.5;
+    double hy = full_width_y_ * 0.5;
+    double hz = full_width_z_ * 0.5;
     return AABB(
         math::Vector3D(-hx, -hy, -hz),
         math::Vector3D( hx,  hy,  hz)

--- a/projects/geometry/public/SIREN/geometry/Box.h
+++ b/projects/geometry/public/SIREN/geometry/Box.h
@@ -26,7 +26,7 @@ namespace geometry {
 class Box : public Geometry {
 public:
     Box();
-    Box(double x, double y, double z);
+    Box(double full_width_x, double full_width_y, double full_width_z);
     Box(Placement const &);
     Box(Placement const &, double x, double y, double z);
     Box(const Box&);
@@ -34,9 +34,9 @@ public:
     template<typename Archive>
     void serialize(Archive & archive, std::uint32_t const version) {
         if(version == 0) {
-            archive(::cereal::make_nvp("XWidth", x_));
-            archive(::cereal::make_nvp("YWidth", y_));
-            archive(::cereal::make_nvp("ZWidth", z_));
+            archive(::cereal::make_nvp("XFullWidth", full_width_x_));
+            archive(::cereal::make_nvp("YFullWidth", full_width_y_));
+            archive(::cereal::make_nvp("ZFullWidth", full_width_z_));
             archive(cereal::virtual_base_class<Geometry>(this));
         } else {
             throw std::runtime_error("Box only supports version <= 0!");
@@ -56,22 +56,22 @@ public:
     AABB GetBoundingBox() const override;
 
     // Getter & Setter
-    double GetX() const { return x_; }
-    double GetY() const { return y_; }
-    double GetZ() const { return z_; }
+    double GetX() const { return full_width_x_; }
+    double GetY() const { return full_width_y_; }
+    double GetZ() const { return full_width_z_; }
 
-    void SetX(double x) { x_ = x; RecomputeWorldAABB(); };
-    void SetY(double y) { y_ = y; RecomputeWorldAABB(); };
-    void SetZ(double z) { z_ = z; RecomputeWorldAABB(); };
+    void SetX(double full_width_x) { full_width_x_ = full_width_x; RecomputeWorldAABB(); };
+    void SetY(double full_width_y) { full_width_y_ = full_width_y; RecomputeWorldAABB(); };
+    void SetZ(double full_width_z) { full_width_z_ = full_width_z; RecomputeWorldAABB(); };
 protected:
     virtual bool equal(const Geometry&) const override;
     virtual bool less(const Geometry&) const override;
 private:
     void print(std::ostream&) const override;
 
-    double x_; //!< width of box in x-direction
-    double y_; //!< width of box in y-direction
-    double z_; //!< width of box in z-direction
+    double full_width_x_; //!< full width of box in x-direction
+    double full_width_y_; //!< full width of box in y-direction
+    double full_width_z_; //!< full width of box in z-direction
 };
 
 

--- a/projects/math/private/Matrix3D.cxx
+++ b/projects/math/private/Matrix3D.cxx
@@ -123,13 +123,13 @@ bool Matrix3D::operator==(const Matrix3D& matrix_3d) const
 {
     return (this == &matrix_3d) or (
         xx_ == matrix_3d.xx_ and
-        xy_ == matrix_3d.yy_ and
-        xz_ == matrix_3d.zz_ and
-        yx_ == matrix_3d.xx_ and
+        xy_ == matrix_3d.xy_ and
+        xz_ == matrix_3d.xz_ and
+        yx_ == matrix_3d.yx_ and
         yy_ == matrix_3d.yy_ and
-        yz_ == matrix_3d.zz_ and
-        zx_ == matrix_3d.xx_ and
-        zy_ == matrix_3d.yy_ and
+        yz_ == matrix_3d.yz_ and
+        zx_ == matrix_3d.zx_ and
+        zy_ == matrix_3d.zy_ and
         zz_ == matrix_3d.zz_);
 }
 
@@ -333,7 +333,7 @@ Matrix3D matrix_product(const Matrix3D& mat1, const Matrix3D& mat2)
     p.xx_ = mat1.xx_ * mat2.xx_ +
             mat1.xy_ * mat2.yx_ +
             mat1.xz_ * mat2.zx_;
-    p.xx_ = mat1.xx_ * mat2.xy_ +
+    p.xy_ = mat1.xx_ * mat2.xy_ +
             mat1.xy_ * mat2.yy_ +
             mat1.xz_ * mat2.zy_;
     p.xz_ = mat1.xx_ * mat2.xz_ +
@@ -342,7 +342,7 @@ Matrix3D matrix_product(const Matrix3D& mat1, const Matrix3D& mat2)
     p.yx_ = mat1.yx_ * mat2.xx_ +
             mat1.yy_ * mat2.yx_ +
             mat1.yz_ * mat2.zx_;
-    p.yx_ = mat1.yx_ * mat2.xy_ +
+    p.yy_ = mat1.yx_ * mat2.xy_ +
             mat1.yy_ * mat2.yy_ +
             mat1.yz_ * mat2.zy_;
     p.yz_ = mat1.yx_ * mat2.xz_ +
@@ -351,7 +351,7 @@ Matrix3D matrix_product(const Matrix3D& mat1, const Matrix3D& mat2)
     p.zx_ = mat1.zx_ * mat2.xx_ +
             mat1.zy_ * mat2.yx_ +
             mat1.zz_ * mat2.zx_;
-    p.zx_ = mat1.zx_ * mat2.xy_ +
+    p.zy_ = mat1.zx_ * mat2.xy_ +
             mat1.zy_ * mat2.yy_ +
             mat1.zz_ * mat2.zy_;
     p.zz_ = mat1.zx_ * mat2.xz_ +

--- a/projects/math/private/pybindings/math.cxx
+++ b/projects/math/private/pybindings/math.cxx
@@ -49,6 +49,17 @@ PYBIND11_MODULE(math,m) {
         .def_static("vector_product", [](Vector3D const & a, Vector3D const & b)->Vector3D{return vector_product(a, b);})
         .def_static("cross_product", [](Vector3D const & a, Vector3D const & b)->Vector3D{return cross_product(a, b);});
 
+    class_<Matrix3D, std::shared_ptr<Matrix3D>>(m, "Matrix3D")
+        .def(init<>())
+        .def(init<double,double,double,double,double,double,double,double,double>(),
+             arg("xx"), arg("xy"), arg("xz"),
+             arg("yx"), arg("yy"), arg("yz"),
+             arg("zx"), arg("zy"), arg("zz"))
+        .def(init<const Matrix3D &>())
+        .def("__str__", [](Matrix3D const & m) { std::stringstream ss; ss << m; return ss.str(); })
+        .def(self == self)
+        .def(self != self);
+
     class_<Quaternion, std::shared_ptr<Quaternion>>(m, "Quaternion")
         .def(init<>())
         .def(init<const double, const double, const double, const double>())
@@ -86,8 +97,14 @@ PYBIND11_MODULE(math,m) {
         .def("GetAxisAngle", (void (Quaternion::*)(Vector3D &, double &) const)(&Quaternion::GetAxisAngle))
         .def("GetAxisAngle", (std::tuple<Vector3D, double> (Quaternion::*)()const)(&Quaternion::GetAxisAngle))
         .def("GetEulerAngles", &Quaternion::GetEulerAngles)
-        .def("GetEulerAnglesZXZr", &Quaternion::GetEulerAnglesZXZr)
-        .def("GetEulerAnglesXYZs", &Quaternion::GetEulerAnglesXYZs)
+        .def("GetEulerAnglesZXZr", [](Quaternion const & q) {
+            double a, b, g; q.GetEulerAnglesZXZr(a, b, g);
+            return std::make_tuple(a, b, g);
+        })
+        .def("GetEulerAnglesXYZs", [](Quaternion const & q) {
+            double a, b, g; q.GetEulerAnglesXYZs(a, b, g);
+            return std::make_tuple(a, b, g);
+        })
         .def("SetEulerAngles", &Quaternion::SetEulerAngles)
         .def("SetEulerAnglesZXZr", &Quaternion::SetEulerAnglesZXZr)
         .def("SetEulerAnglesXYZs", &Quaternion::SetEulerAnglesXYZs)

--- a/python/download.py
+++ b/python/download.py
@@ -81,6 +81,25 @@ def writable_data_dir(module_dir: str) -> str:
     return fallback
 
 
+def resolve_data_path(install_dir: str, download_dir: str,
+                      filename: str) -> str:
+    """Resolve a data file path, preferring *install_dir* when the file
+    already exists there.
+
+    Resource loaders download files into *download_dir* (the writable
+    location returned by :func:`writable_data_dir`).  When the package
+    is installed into a read-only tree the writable directory differs
+    from the original install directory.  If the file was shipped with
+    the package (or cached from a previous writable install), it may
+    still be present at *install_dir* -- use it directly and avoid a
+    redundant download.
+    """
+    local = os.path.join(install_dir, filename)
+    if os.path.isfile(local):
+        return local
+    return os.path.join(download_dir, filename)
+
+
 # ======================================================================
 # Core download primitives
 # ======================================================================
@@ -291,14 +310,18 @@ def _cached_zip(dest_dir: str, record_id: str, filename: str,
 
     # Check for an existing cached file for this record/filename
     tag = f"{record_id}_{filename}"
-    existing = [f for f in os.listdir(cache_dir)
-                if f.startswith(tag + ".") and f.endswith(".zip")]
+    existing = sorted(
+        (f for f in os.listdir(cache_dir)
+         if f.startswith(tag + ".") and f.endswith(".zip")),
+        key=lambda f: os.path.getmtime(os.path.join(cache_dir, f)),
+        reverse=True,
+    )
     if existing:
         return os.path.join(cache_dir, existing[0])
 
     # Download, hash, rename into cache
     url = zenodo_file_url(record_id, filename, token)
-    tmp_path = os.path.join(cache_dir, f"{tag}.tmp")
+    tmp_path = os.path.join(cache_dir, f"{tag}.{os.getpid()}.tmp")
     try:
         download_file(url, tmp_path, label=filename)
         sha = _sha256_file(tmp_path)
@@ -316,14 +339,20 @@ _EXTRACTED_SENTINEL = ".zenodo_extracted"
 
 def _safe_extract(zf: zipfile.ZipFile, dest_dir: str,
                   members: list[str] | None = None) -> None:
-    """Extract zip members, rejecting paths that escape dest_dir (Zip Slip)."""
+    """Extract zip members, rejecting paths that escape dest_dir (Zip Slip).
+
+    Extracts one member at a time and re-validates the resolved path
+    after each extraction so that symlink entries created by earlier
+    members cannot redirect later entries outside dest_dir.
+    """
     abs_dest = os.path.realpath(dest_dir)
-    for name in (members if members is not None else zf.namelist()):
+    names = members if members is not None else zf.namelist()
+    for name in names:
         target = os.path.realpath(os.path.join(dest_dir, name))
         if not target.startswith(abs_dest + os.sep) and target != abs_dest:
             raise ValueError(
                 f"Zip entry '{name}' would extract outside {dest_dir}")
-    zf.extractall(dest_dir, members)
+        zf.extract(name, dest_dir)
 
 
 def ensure_zenodo_archive(record_id: str, filename: str, dest_dir: str,
@@ -416,13 +445,14 @@ def _cmd_fetch(names: list[str]) -> int:
               file=sys.stderr)
         return 1
 
-    # Build a map of name -> resource_type for all installed resources
-    resource_map: dict[str, str] = {}
+    # Build a map of name -> resource_type for all installed resources.
+    # A name may appear in multiple categories; store all of them.
+    resource_map: dict[str, list[str]] = {}
     for resource_type, lister in [("detector", _util.list_detectors),
                                   ("flux", _util.list_fluxes),
                                   ("processes", _util.list_processes)]:
         for n in lister():
-            resource_map[n] = resource_type
+            resource_map.setdefault(n, []).append(resource_type)
 
     if not names:
         names = list(resource_map.keys())
@@ -430,24 +460,25 @@ def _cmd_fetch(names: list[str]) -> int:
     ret = 0
     for name in names:
         print(f"--- {name} ---")
-        resource_type = resource_map.get(name)
-        if resource_type is None:
+        resource_types = resource_map.get(name)
+        if resource_types is None:
             print(f"  (unknown resource '{name}')")
             ret = 1
             continue
-        try:
-            mod = _util.import_resource(resource_type, name)
-            if mod is None:
-                print("  (no loader script)")
-                continue
-            if hasattr(mod, "fetch_data"):
-                mod.fetch_data()
-                print("  OK")
-            else:
-                print("  (no fetch_data function, skipping)")
-        except Exception as e:
-            print(f"  Error: {e}", file=sys.stderr)
-            ret = 1
+        for resource_type in resource_types:
+            try:
+                mod = _util.import_resource(resource_type, name)
+                if mod is None:
+                    print(f"  (no {resource_type} loader script)")
+                    continue
+                if hasattr(mod, "fetch_data"):
+                    mod.fetch_data()
+                    print(f"  OK ({resource_type})")
+                else:
+                    print(f"  (no fetch_data function for {resource_type}, skipping)")
+            except Exception as e:
+                print(f"  Error ({resource_type}): {e}", file=sys.stderr)
+                ret = 1
     return ret
 
 
@@ -477,13 +508,17 @@ Examples:
         parser.print_help()
         return 0
 
-    if args.list:
-        return _cmd_list()
+    try:
+        if args.list:
+            return _cmd_list()
 
-    names = args.fetch or []
-    if args.fetch_all:
-        names = []  # empty = all
-    return _cmd_fetch(names)
+        names = args.fetch or []
+        if args.fetch_all:
+            names = []  # empty = all
+        return _cmd_fetch(names)
+    except (OSError, ConnectionError, urllib.error.URLError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/resources/detectors/SBN/SBN-v1/.gitignore
+++ b/resources/detectors/SBN/SBN-v1/.gitignore
@@ -1,0 +1,4 @@
+# Generated at load time -- do not commit or ship
+composite_*.gdml
+gdml/
+__pycache__/

--- a/resources/detectors/SBN/SBN-v1/detector.py
+++ b/resources/detectors/SBN/SBN-v1/detector.py
@@ -1,0 +1,206 @@
+"""
+SBN detector loader.
+
+Composes BNB beamline + NuMI beamline + detector GDML files into a single
+composite geometry in BNB-frame coordinates, then loads via the SIREN GDML
+parser. Missing GDML files are downloaded automatically.
+
+Usage:
+    from siren._util import load_detector
+
+    # Local-only (default): just the GDML site geology (~500 m around
+    # detectors). Use for beam neutrino studies where all interactions
+    # are near the beamline and detector.
+    model = load_detector("SBN", detector="ICARUS")
+
+    # Full Earth model (PREM + atmosphere + local Moho correction).
+    # Use for atmospheric neutrinos or BSM searches with interactions
+    # far from the detector.
+    model = load_detector("SBN", detector="ICARUS", earth_model=True)
+"""
+
+import importlib.util
+import os
+import sys
+
+_THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def _load_sibling(name, filename):
+    fqn = f"siren._sbn.{name}"
+    if fqn in sys.modules:
+        return sys.modules[fqn]
+    spec = importlib.util.spec_from_file_location(
+        fqn, os.path.join(_THIS_DIR, filename))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[fqn] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        del sys.modules[fqn]
+        raise
+    return mod
+
+
+geo = _load_sibling("sbn_geometry", "sbn_geometry.py")
+sbn_loader = _load_sibling("sbn_loader", "sbn_loader.py")
+
+from siren.download import writable_data_dir
+_ABS_DIR = writable_data_dir(_THIS_DIR)
+
+_DATA_BASE = (
+    "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/"
+    "main/detectors/SBN/v1"
+)
+
+
+def _beamline_sources():
+    T_numi = geo.transform("NuMI", "BNB")
+    numi_origin_bnb = T_numi.apply([0.0, 0.0, 0.0])
+    numi_rx, numi_ry, numi_rz = geo.gdml_rotation_angles(T_numi.R.T)
+    return [
+        {
+            "file": "gdml/BooNE_50m.gdml",
+            "prefix": "bnb",
+            "position": (0.0, 0.0, -geo.BNB_TARGET_Z_SAND_M),
+            "rotation": None,
+            "unwrap": False,
+            "url": f"{_DATA_BASE}/BNB/BooNE_50m.gdml",
+            "sha256": "70d3a5ef55062b8bfc3c94cc7ddc559dce09dec03d670dddd5286518d80f12da",
+        },
+        {
+            "file": "gdml/numi_g4export_2026-05-19.gdml",
+            "prefix": "numi",
+            "position": tuple(numi_origin_bnb),
+            "rotation": (numi_rx, numi_ry, numi_rz),
+            "unwrap": False,
+            "url": f"{_DATA_BASE}/NuMI/numi_g4export_2026-05-19.gdml",
+            "sha256": "39670d52a6181352a8ae7c798387a9c58de950462c634e57da7d39fb23abe30a",
+        },
+    ]
+
+_DETECTOR_SPECS = {
+    "ICARUS": {
+        "file": "gdml/icarus_refactored_nounderscore_20230918_nowires.gdml",
+        "prefix": "icarus",
+        "unwrap": True,
+        "url": f"{_DATA_BASE}/ICARUS/icarus_refactored_nounderscore_20230918_nowires.gdml",
+        "sha256": "3f68961a21fa037d3278c3235e48920cfc85a306adc5437f296dd7c09f095cd1",
+    },
+    "SBND": {
+        "file": "gdml/sbnd_v02_06.gdml",
+        "prefix": "sbnd",
+        "unwrap": True,
+        "url": f"{_DATA_BASE}/SBND/sbnd_v02_06.gdml",
+        "sha256": "224a0efa55e66b1fb3b527937e4a899854c2bbab367db3659e55466c4e7f013a",
+    },
+}
+
+
+def fetch_data():
+    """Download GDML files for all detectors (called by siren-download --fetch)."""
+    all_sources = list(_beamline_sources())
+    for spec in _DETECTOR_SPECS.values():
+        if spec.get("file"):
+            all_sources.append(spec)
+    sbn_loader._ensure_gdml_files(_ABS_DIR, all_sources)
+
+
+def load_detector(detector=None, earth_model=False):
+    """Load an SBN detector model.
+
+    Parameters
+    ----------
+    detector : str
+        Which detector to load ("ICARUS" or "SBND").
+    earth_model : bool, optional
+        If *False* (default), only load the GDML site-geology volume
+        (beamlines, detector, local stratigraphy within ~500 m).
+        Use this for beam-neutrino studies where all interactions
+        are near the beamline.
+
+        If *True*, embed the GDML geometry in a full PREM Earth
+        model with a multi-shell atmosphere and a local Moho
+        correction for the Midwest crust.  Use this for atmospheric
+        neutrino studies or BSM searches where interactions can occur
+        far from the detector.
+
+    Returns
+    -------
+    DetectorModel
+    """
+    if detector is None:
+        raise TypeError(
+            '"detector" is a required argument. '
+            'Choose from: ' + ", ".join(_DETECTOR_SPECS.keys()))
+
+    detector = str(detector)
+    if detector not in _DETECTOR_SPECS:
+        raise ValueError(
+            f'Unknown detector "{detector}". '
+            f'Choose from: {", ".join(_DETECTOR_SPECS.keys())}')
+
+    spec = _DETECTOR_SPECS[detector]
+
+    from siren.detector import DetectorModel, GeometryPosition
+    from siren.math import Vector3D, Quaternion, Matrix3D
+
+    T_det_to_bnb = geo.detector_transform(detector, "BNB")
+    origin_bnb = T_det_to_bnb.t
+
+    # DetectorRotation is an active rotation (r_geo = R @ r_det + origin),
+    # so it uses the det-to-bnb rotation directly.
+    R = T_det_to_bnb.R
+    det_quat = Quaternion()
+    det_quat.SetMatrix(Matrix3D(
+        R[0, 0], R[0, 1], R[0, 2],
+        R[1, 0], R[1, 1], R[1, 2],
+        R[2, 0], R[2, 1], R[2, 2]))
+
+    # GDML <physvol> rotation is passive (SIREN applies M^T), so we need
+    # M = R_det_to_bnb^T (the inverse rotation). None when identity.
+    det_rotation = None
+    is_rotated = (abs(det_quat.X) > 1e-12
+                  or abs(det_quat.Y) > 1e-12
+                  or abs(det_quat.Z) > 1e-12)
+    if is_rotated:
+        rx, ry, rz = geo.gdml_rotation_angles(T_det_to_bnb.R.T)
+        det_rotation = (rx, ry, rz)
+
+    sources = list(_beamline_sources())
+    if spec["file"] is not None:
+        sources.append({
+            "file": spec["file"],
+            "prefix": spec["prefix"],
+            "position": tuple(origin_bnb),
+            "rotation": det_rotation,
+            "unwrap": spec["unwrap"],
+            "url": spec.get("url"),
+            "sha256": spec.get("sha256", ""),
+        })
+
+    cache_name = f"composite_{detector.lower()}.gdml"
+    cache_path = sbn_loader.build_composite(_ABS_DIR, sources, cache_name)
+
+    model = DetectorModel()
+    model.LoadGDML(cache_path)
+
+    if earth_model:
+        earth = _load_sibling("earth_model", "earth_model.py")
+        earth.add_earth_model(model)
+
+    # DetectorOrigin is the point in BNB (geometry) coordinates that
+    # corresponds to (0,0,0) in DetectorCoordinates. We place it at
+    # the geometric center of the LAr volume (from the Detector entry
+    # in sbn_geometry) so that injectors aiming at the detector origin
+    # hit the middle of the active volume, not e.g. the cathode plane.
+    #
+    # DetectorRotation is the active rotation from detector-local axes
+    # to geometry (BNB) axes: r_geo = R @ r_det + DetectorOrigin.
+    det_info = geo.DETECTORS[detector]
+    det_center_bnb = T_det_to_bnb.apply(det_info.center_native)
+    model.DetectorOrigin = GeometryPosition(
+        Vector3D(det_center_bnb[0], det_center_bnb[1], det_center_bnb[2]))
+    model.DetectorRotation = det_quat
+
+    return model

--- a/resources/detectors/SBN/SBN-v1/earth_model.py
+++ b/resources/detectors/SBN/SBN-v1/earth_model.py
@@ -2,9 +2,8 @@
 PREM Earth model for the SBN detector at Fermilab.
 
 Adds concentric PREM spherical shells and a multi-shell atmosphere to
-a DetectorModel that was loaded via LoadGDML. The GDML volumes (which
-carry positive levels) always take priority over these Earth sectors
-(which carry negative levels) wherever both exist.
+a DetectorModel that was loaded via LoadGDML. The GDML volumes always
+take priority over these Earth sectors wherever both exist.
 
 The PREM layers follow Dziewonski & Anderson, PEPI 25 (1981) 297,
 with the standard global-average Moho at 24.4 km depth. A local

--- a/resources/detectors/SBN/SBN-v1/earth_model.py
+++ b/resources/detectors/SBN/SBN-v1/earth_model.py
@@ -1,0 +1,236 @@
+"""
+PREM Earth model for the SBN detector at Fermilab.
+
+Adds concentric PREM spherical shells and a multi-shell atmosphere to
+a DetectorModel that was loaded via LoadGDML. The GDML volumes (which
+carry positive levels) always take priority over these Earth sectors
+(which carry negative levels) wherever both exist.
+
+The PREM layers follow Dziewonski & Anderson, PEPI 25 (1981) 297,
+with the standard global-average Moho at 24.4 km depth. A local
+crustal thickening correction overrides the upper mantle with crust
+(ROCK) in the Midwest region from Fermilab to the DUNE far detector
+at Sanford Lab, reflecting the ~45 km Moho depth measured by
+CRUST1.0 (Laske et al. 2013) for this stable continental interior.
+
+The local correction is an Earth-centered spherical shell spanning
+the depth range from 24.4 km (PREM Moho) to 45 km (local Moho),
+with a polar-angle cut limiting it to ~17 degrees (~1900 km) around
+the radial direction through Fermilab. This covers the entire
+Fermilab-to-Sanford-Lab baseline (1285 km) with margin.
+
+The atmosphere approximates the US Standard Atmosphere 1976 as 6
+constant-density spherical shells.
+
+Earth center in BNB coordinates:
+  The BNB frame has y = up, origin at the BNB target. Fermilab grade
+  is _GRADE_Y_BNB = 7.62 m above the target. We equate grade with
+  the PREM surface radius (6371 km), so the Earth center sits at
+  (0, -(R_PREM - _GRADE_Y_BNB), 0) in BNB coordinates.
+
+References:
+  PREM: Dziewonski & Anderson, PEPI 25 (1981) 297
+  Atmosphere: US Standard Atmosphere 1976
+  CRUST1.0: Laske et al. 2013 (1x1 degree global crustal model)
+  DUNE beam path: Roe 2016, arXiv:1608.03802
+  Fermilab geology: FNAL ESH regional site characterization
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+R_PREM = 6371000.0
+_GRADE_Y_BNB = 7.62
+_PREM_MOHO_DEPTH = 24400.0
+_LOCAL_MOHO_DEPTH = 45000.0
+
+# Angular half-opening of the local crustal thickening correction,
+# measured from the radial direction through Fermilab.  0.3 rad
+# corresponds to ~1900 km on the surface, comfortably covering the
+# 1285 km Fermilab-to-Sanford-Lab baseline with ~600 km margin.
+_LOCAL_MOHO_THETA = 0.3
+
+
+# PREM Earth layers, ordered from innermost to outermost.
+# Each entry: (name, outer_radius_m, material, density_type, density_params)
+#   density_type: "constant" or "polynomial"
+#   density_params: single float for constant, list of coefficients for polynomial
+#     polynomial: rho(r) = p[0] + p[1]*r + p[2]*r^2 + ...  (r in meters, rho in g/cm3)
+_PREM_LAYERS = [
+    ("innercore_boundary",    1221500, "INNERCORE", "polynomial",
+     [13.0885, 0.0, -2.17742748697875934e-13]),
+    ("coremantle_boundary",   3480000, "OUTERCORE", "polynomial",
+     [12.5815, -1.98367603202009108e-07, -8.97421093229181259e-14,
+      -2.13773109929070169e-20]),
+    ("lowermantle_boundary",  5701000, "MANTLE", "polynomial",
+     [7.9565, -1.01649662533354259e-06, 1.36199775701391389e-13,
+      -1.19131495406828110e-20]),
+    ("lower_transition",      5771000, "MANTLE", "polynomial",
+     [5.3197, -2.32867681682624407e-07]),
+    ("middle_transition",     5971000, "MANTLE", "polynomial",
+     [11.2494, -1.26036728927954783e-06]),
+    ("upper_transition",      6151000, "MANTLE", "polynomial",
+     [7.1089, -5.97159001726573544e-07]),
+    ("moho_boundary",    int(R_PREM - _PREM_MOHO_DEPTH), "MANTLE", "polynomial",
+     [2.691, 1.08679956050855438e-07]),
+    ("inner_crust",           6356000, "ROCK", "constant", 2.900),
+    ("upper_crust",     int(R_PREM),  "ROCK", "constant", 2.600),
+]
+
+# Atmosphere shells approximating US Standard Atmosphere 1976.
+# Average density per shell from: rho_avg = rho_0*H*(exp(-h1/H) - exp(-h2/H))/(h2-h1)
+# where rho_0 = 1.225e-3 g/cm3 and H = 8500 m (scale height).
+_RHO_0 = 1.225e-3
+_SCALE_HEIGHT = 8500.0
+
+_ATMO_SHELL_ALTS = [
+    (0,      4000),
+    (4000,   10000),
+    (10000,  20000),
+    (20000,  40000),
+    (40000,  80000),
+    (80000,  180000),
+]
+
+
+def _atmo_avg_density(h1: float, h2: float) -> float:
+    return (_RHO_0 * _SCALE_HEIGHT
+            * (math.exp(-h1 / _SCALE_HEIGHT) - math.exp(-h2 / _SCALE_HEIGHT))
+            / (h2 - h1))
+
+
+_ATMO_LAYERS = []
+for _i, (_h1, _h2) in enumerate(_ATMO_SHELL_ALTS):
+    _ATMO_LAYERS.append((
+        f"atmo_{_h1 // 1000}_{_h2 // 1000}km",
+        int(R_PREM + _h2),
+        "AIR",
+        "constant",
+        _atmo_avg_density(_h1, _h2),
+    ))
+
+
+def _all_layers():
+    """All layers from innermost to outermost."""
+    return list(_PREM_LAYERS) + list(_ATMO_LAYERS)
+
+
+def add_earth_model(model: Any) -> None:
+    """Add PREM + atmosphere sectors to a DetectorModel loaded from GDML.
+
+    Must be called after model.LoadGDML() so that the GDML volumes already
+    have positive levels. The PREM sectors get negative levels and serve
+    as the background Earth wherever the GDML geometry does not reach.
+
+    A local crustal thickening sector is added between the PREM upper
+    mantle and crustal layers. It is an Earth-centered spherical shell
+    (depths 24.4--45 km) with a polar-angle cut (~17 deg around
+    Fermilab) that overrides the PREM mantle with ROCK in the Midwest,
+    where the continental Moho is ~45 km deep (CRUST1.0).
+    """
+    from siren.math import Vector3D, Quaternion
+    from siren.geometry import Sphere, Placement
+    from siren.detector import (
+        DetectorSector,
+        RadialAxis1D,
+        PolynomialDistribution1D,
+        RadialAxisPolynomialDensityDistribution,
+        ConstantDensityDistribution,
+    )
+
+    # PREM materials (ROCK, MANTLE, AIR, etc.) are defined in the
+    # composite GDML alongside the detector materials, so they go
+    # through the GDML MergeFrom pipeline and get proper collision
+    # handling.  No separate LoadMaterialModel call is needed.
+
+    earth_center = Vector3D(0.0, -(R_PREM - _GRADE_Y_BNB), 0.0)
+    placement = Placement(earth_center)
+    radial_axis = RadialAxis1D(earth_center)
+
+    # --- Build the full layer list with local correction inserted ---
+    # The local crustal thickening correction goes between
+    # upper_transition and moho_boundary so that its level sits
+    # between them in the priority ordering.
+    prem = _all_layers()
+    moho_idx = next(i for i, (n, *_) in enumerate(prem) if n == "moho_boundary")
+
+    # Rotate so the Sphere's +z axis (theta=0 direction) aligns with
+    # the BNB +y axis (radially outward through Fermilab).
+    rot = Quaternion.rotation_between(Vector3D(0, 0, 1), Vector3D(0, 1, 0))
+    rotated_placement = Placement(earth_center, rot)
+
+    local_moho_entry = {
+        "name": "local_thick_crust",
+        "material": "ROCK",
+        "density_type": "constant",
+        "density_params": 2.9,
+        "geo": Sphere(
+            rotated_placement,
+            R_PREM - _PREM_MOHO_DEPTH,   # outer: PREM Moho depth
+            R_PREM - _LOCAL_MOHO_DEPTH,   # inner: local Moho depth
+            0.0, 2.0 * math.pi,          # full azimuth
+            0.0, _LOCAL_MOHO_THETA,       # polar cap around Fermilab
+        ),
+    }
+
+    sectors = model.Sectors
+
+    prem_names = {name for name, *_ in prem}
+    prem_names.add("local_thick_crust")
+    for s in sectors:
+        if s.name in prem_names:
+            raise RuntimeError(
+                "add_earth_model has already been applied to this model "
+                "(sector '{}' already exists)".format(s.name))
+
+    min_level = min([s.level for s in sectors if s.name != "UNIVERSE"], default=0)
+
+    num_new_sectors = len(prem) + 1  # +1 for local correction
+
+    # Shift existing levels down to make room for the new sectors
+    for s in sectors:
+        if s.name != "UNIVERSE" and s.level >= min_level:
+            s.level = s.level - min_level + num_new_sectors
+
+    base_level = num_new_sectors - 1
+
+    # Prepend the new sectors in order from innermost to outermost
+    # Decrementing the level each time
+    for i, (name, outer_radius, material, dtype, params) in enumerate(prem):
+        # Insert local correction right before moho_boundary
+        if i == moho_idx:
+            lm = local_moho_entry
+            sector = DetectorSector()
+            sector.name = lm["name"]
+            sector.material_id = model.GetMaterials().GetMaterialId(lm["material"])
+            sector.level = base_level
+            sector.geo = lm["geo"]
+            sector.density = ConstantDensityDistribution(float(lm["density_params"]))
+            sectors.append(sector)
+            base_level -= 1
+
+        sector = DetectorSector()
+        sector.name = name
+        sector.material_id = model.GetMaterials().GetMaterialId(material)
+        sector.level = base_level
+        sector.geo = Sphere(placement, float(outer_radius), 0.0)
+
+        if dtype == "constant":
+            sector.density = ConstantDensityDistribution(float(params))
+        else:
+            poly = PolynomialDistribution1D(list(params))
+            sector.density = RadialAxisPolynomialDensityDistribution(
+                radial_axis, poly)
+
+        base_level -= 1
+        sectors.append(sector)
+    if base_level != -1:
+        raise RuntimeError(
+            "Earth model level assignment error: expected base_level == -1, "
+            "got {}".format(base_level))
+
+    # Sort the sectors by level before putting them back in the model
+    sectors = sorted(sectors, key=lambda s: s.level)
+    model.Sectors = sectors

--- a/resources/detectors/SBN/SBN-v1/earth_model.py
+++ b/resources/detectors/SBN/SBN-v1/earth_model.py
@@ -120,8 +120,10 @@ def add_earth_model(model: Any) -> None:
     """Add PREM + atmosphere sectors to a DetectorModel loaded from GDML.
 
     Must be called after model.LoadGDML() so that the GDML volumes already
-    have positive levels. The PREM sectors get negative levels and serve
-    as the background Earth wherever the GDML geometry does not reach.
+    have assigned levels. The PREM and atmosphere sectors are inserted at
+    the lowest levels, and the pre-existing GDML sector levels are shifted
+    upward so the Earth model serves as the background wherever the GDML
+    geometry does not reach.
 
     A local crustal thickening sector is added between the PREM upper
     mantle and crustal layers. It is an Earth-centered spherical shell

--- a/resources/detectors/SBN/SBN-v1/sbn_geometry.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_geometry.py
@@ -134,11 +134,11 @@ R_ICARUS_TO_NUMI = np.array([
 ])
 T_ICARUS_IN_NUMI_M = np.array([4.503730, 80.153901, 795.112945])
 
-# Z-position of the BNB target center in the BooNE GDML (SAND) frame,
-# traced through the volume hierarchy:
-#   SAND -> CAVE (+426.8 mm) -> CAVI (0) -> PILE (~0) -> PICV (-426.8 mm) -> TARG (+390.525 mm)
-# Total: 390.525 mm = 0.390525 m
-BNB_TARGET_Z_SAND_M = 0.390525
+# The BNB frame origin coincides with the SAND world volume center
+# in the BooNE GDML. G4BNB bsim::Location detector positions and
+# dk2nu flux ray origins are all expressed relative to this point.
+# The BNB target sits ~39 cm downstream (z = +0.3905 m in SAND).
+BNB_TARGET_Z_SAND_M = 0.0
 
 
 # ======================================================================
@@ -149,7 +149,7 @@ def _build_graph() -> FrameGraph:
 
     g.add_frame(Frame("BNB",
         "Booster Neutrino Beam global frame (g4bnb bsim::Location).",
-        "BNB beryllium target at MI-12",
+        "G4BNB SAND world volume center (target is ~39 cm downstream)",
         "horizontal west", "up", "along BNB beam axis (north)"))
 
     # The NuMI frame origin is MCZERO (Horn 1 upstream face). The GDML

--- a/resources/detectors/SBN/SBN-v1/sbn_geometry.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_geometry.py
@@ -1,0 +1,321 @@
+"""
+SBN geometry: coordinate frames and rigid transforms.
+
+Minimal port of the transform graph from g4bnb/sbn_geometry.py into SIREN.
+Provides composable frame-to-frame transforms for the Fermilab SBN program
+detectors (ICARUS, SBND, MicroBooNE) and beamlines (BNB, NuMI).
+
+World coordinate system (BNB frame):
+  Origin : BNB beryllium target at MI-12
+  x      : horizontal west
+  y      : up
+  z      : along BNB beam axis (approximately north)
+  Units  : meters
+
+References:
+  ICARUS-NuMI rotation matrix and translation vector from the production
+  GNuMIFlux.xml in icaruscode (public):
+    https://github.com/SBNSoftware/icaruscode/blob/develop/fcl/gen/numi/GNuMIFlux.xml
+  Confirmed by SBN DocDB 22998-v2 (A. Aduszkiewicz, 2022-10-26; restricted).
+
+  Detector positions in BNB frame from G4BNB bsim::Location tuples (public):
+    https://github.com/SBNSoftware/G4BNB
+  Confirmed by SBN DocDB 22998-v2 for ICARUS z = 600 m.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Frame:
+    name: str
+    description: str
+    origin: str
+    x_axis: str
+    y_axis: str
+    z_axis: str
+
+
+@dataclass(frozen=True)
+class Transform:
+    """Rigid transform: r_target = R @ r_source + t (meters)."""
+    source: str
+    target: str
+    R: np.ndarray
+    t: np.ndarray
+    reference: str = ""
+
+    def __post_init__(self):
+        object.__setattr__(self, "R", np.array(self.R, dtype=float))
+        object.__setattr__(self, "t", np.array(self.t, dtype=float))
+        self.R.flags.writeable = False
+        self.t.flags.writeable = False
+
+    def apply(self, r: np.ndarray) -> np.ndarray:
+        return self.R @ np.asarray(r, dtype=float) + self.t
+
+    def inverse(self) -> Transform:
+        Rt = self.R.T
+        return Transform(self.target, self.source, Rt, -Rt @ self.t,
+                         self.reference + " (inverted)")
+
+    def compose(self, other: Transform) -> Transform:
+        return Transform(self.source, other.target,
+                         other.R @ self.R, other.R @ self.t + other.t,
+                         f"({self.reference}) then ({other.reference})")
+
+    @classmethod
+    def identity(cls, name: str) -> Transform:
+        return cls(name, name, np.eye(3), np.zeros(3), "identity")
+
+    @classmethod
+    def translation(cls, src: str, tgt: str, t: Sequence[float],
+                    reference: str = "") -> Transform:
+        return cls(src, tgt, np.eye(3), np.asarray(t, dtype=float), reference)
+
+
+class FrameGraph:
+    def __init__(self) -> None:
+        self.frames: dict[str, Frame] = {}
+        self.edges: list[Transform] = []
+
+    def add_frame(self, frame: Frame) -> None:
+        self.frames[frame.name] = frame
+
+    def add_transform(self, xform: Transform) -> None:
+        self.edges.append(xform)
+
+    def compose(self, src: str, dst: str) -> Transform:
+        if src == dst:
+            return Transform.identity(src)
+        adjacency: dict[str, list[Transform]] = {}
+        for e in self.edges:
+            adjacency.setdefault(e.source, []).append(e)
+            adjacency.setdefault(e.target, []).append(e.inverse())
+        queue: deque[tuple[str, list[Transform]]] = deque([(src, [])])
+        visited = {src}
+        while queue:
+            current, partial = queue.popleft()
+            for edge in adjacency.get(current, []):
+                if edge.target in visited:
+                    continue
+                new_partial = partial + [edge]
+                if edge.target == dst:
+                    out = new_partial[0]
+                    for nxt in new_partial[1:]:
+                        out = out.compose(nxt)
+                    return out
+                visited.add(edge.target)
+                queue.append((edge.target, new_partial))
+        raise ValueError(f"No transform path: {src} -> {dst}")
+
+    def convert(self, r: Iterable[float], src: str, dst: str) -> np.ndarray:
+        return self.compose(src, dst).apply(np.asarray(r, dtype=float))
+
+
+# ======================================================================
+# ICARUS LArSoft -> NuMI rotation and translation
+#
+# Source: icaruscode GNuMIFlux.xml <beamdir>/<beampos> elements
+#   https://github.com/SBNSoftware/icaruscode/blob/develop/fcl/gen/numi/GNuMIFlux.xml
+# Confirmed by SBN DocDB 22998-v2 Eq. (3) (restricted).
+# ======================================================================
+R_ICARUS_TO_NUMI = np.array([
+    [ 0.921035925,  0.0,         -0.389477631],
+    [ 0.022715103,  0.998297825,  0.053716629],
+    [ 0.388814672, -0.058321970,  0.919468161],
+])
+T_ICARUS_IN_NUMI_M = np.array([4.503730, 80.153901, 795.112945])
+
+BNB_TARGET_Z_SAND_M = 0.81733
+
+
+# ======================================================================
+# Build the frame graph
+# ======================================================================
+def _build_graph() -> FrameGraph:
+    g = FrameGraph()
+
+    g.add_frame(Frame("BNB",
+        "Booster Neutrino Beam global frame (g4bnb bsim::Location).",
+        "BNB beryllium target at MI-12",
+        "horizontal west", "up", "along BNB beam axis (north)"))
+
+    # The NuMI frame origin is MCZERO (Horn 1 upstream face). The GDML
+    # world volume for the NuMI beamline must be centered at this same
+    # point so that the physvol placement T_numi.apply([0,0,0]) is correct.
+    g.add_frame(Frame("NuMI",
+        "NuMI beam frame (GNuMIFlux.xml convention in icaruscode).",
+        "NuMI Horn 1 upstream face (MCZERO)",
+        "horizontal southwest", "up",
+        "along NuMI beam axis (northwest, slightly downward)"))
+
+    g.add_frame(Frame("ICARUS_LArSoft",
+        "ICARUS detector LArSoft World frame (axes = BNB axes).",
+        "center of ICARUS TPC system",
+        "horizontal west", "up", "along BNB beam axis (north)"))
+
+    g.add_frame(Frame("SBND_LArSoft",
+        "SBND detector LArSoft World frame (axes assumed = BNB axes).",
+        "SBND LArSoft World origin",
+        "horizontal west", "up", "along BNB beam axis"))
+
+    g.add_frame(Frame("MicroBooNE_LArSoft",
+        "MicroBooNE detector LArSoft World frame (axes assumed = BNB axes).",
+        "MicroBooNE LArSoft World origin",
+        "horizontal west", "up", "along BNB beam axis"))
+
+    # ICARUS LArSoft -> NuMI (from icaruscode GNuMIFlux.xml, confirmed by DocDB 22998)
+    g.add_transform(Transform(
+        "ICARUS_LArSoft", "NuMI", R_ICARUS_TO_NUMI, T_ICARUS_IN_NUMI_M,
+        "icaruscode GNuMIFlux.xml beamdir/beampos; confirmed by SBN DocDB 22998-v2"))
+
+    # ICARUS LArSoft -> BNB: pure translation (0, 0, 600) m
+    # G4BNB bsim::Location for ICARUS; confirmed by DocDB 22998.
+    g.add_transform(Transform.translation(
+        "ICARUS_LArSoft", "BNB", [0.0, 0.0, 600.0],
+        "G4BNB ICARUS Location (0, 0, 60000) cm; confirmed by SBN DocDB 22998-v2"))
+
+    # SBND LArSoft -> BNB (G4BNB bsim::Location)
+    g.add_transform(Transform.translation(
+        "SBND_LArSoft", "BNB", [0.7378, 0.0, 110.0],
+        "G4BNB SBND Location (73.78, 0, 11000) cm"))
+
+    # MicroBooNE LArSoft -> BNB (G4BNB bsim::Location)
+    g.add_transform(Transform.translation(
+        "MicroBooNE_LArSoft", "BNB", [0.0, 0.0, 470.0],
+        "G4BNB MicroBooNE Location (0, 0, 47000) cm"))
+
+    return g
+
+
+GRAPH: FrameGraph = _build_graph()
+
+
+# ======================================================================
+# Detector active-volume data
+# ======================================================================
+@dataclass(frozen=True)
+class Detector:
+    name: str
+    native_frame: str
+    center_native: np.ndarray
+    active_min: np.ndarray
+    active_max: np.ndarray
+
+    def __post_init__(self):
+        for field in ("center_native", "active_min", "active_max"):
+            arr = np.array(getattr(self, field), dtype=float)
+            arr.flags.writeable = False
+            object.__setattr__(self, field, arr)
+
+    def active_size(self) -> np.ndarray:
+        return self.active_max - self.active_min
+
+
+def _build_detectors() -> dict[str, Detector]:
+    detectors: dict[str, Detector] = {}
+
+    _ic_y = -0.202
+    _ic_hh = 1.58
+    _ic_hl = 8.975
+    detectors["ICARUS"] = Detector(
+        "ICARUS", "ICARUS_LArSoft",
+        np.array([0.0, _ic_y, 0.0]),
+        np.array([-3.60, _ic_y - _ic_hh, -_ic_hl]),
+        np.array([+3.60, _ic_y + _ic_hh, +_ic_hl]))
+
+    for tag, xc in (("ICARUS_C0", -2.10215), ("ICARUS_C1", +2.10215)):
+        detectors[tag] = Detector(
+            tag, "ICARUS_LArSoft",
+            np.array([xc, _ic_y, 0.0]),
+            np.array([xc - 1.50, _ic_y - _ic_hh, -_ic_hl]),
+            np.array([xc + 1.50, _ic_y + _ic_hh, +_ic_hl]))
+
+    # SBND LArSoft World origin is at the cathode plane (x=0).
+    # The LAr volume is symmetric in x (two drift volumes), but offset
+    # in y and z relative to the LArSoft origin.
+    #
+    # LAr extent measured from sbnd_v02_06.gdml (1cm resolution):
+    #   x: -5.19 to +5.19 m  (cathode at x=0, anodes at ~x=+/-2m,
+    #                          inactive LAr fills the rest of the cryostat)
+    #   y: -3.50 to +2.32 m  (center at y=-0.59)
+    #   z: -1.39 to +7.22 m  (center at z=+2.92)
+    #
+    # The center_native below is the geometric center of the LAr volume,
+    # which is offset from the LArSoft origin. This is used as the
+    # DetectorCoordinates origin so that injectors aiming at (0,0,0)
+    # hit the center of the detector.
+    detectors["SBND"] = Detector(
+        "SBND", "SBND_LArSoft",
+        np.array([0.0, -0.59, 2.92]),
+        np.array([-5.19, -3.50, -1.39]),
+        np.array([+5.19, +2.32, +7.22]))
+
+    detectors["MicroBooNE"] = Detector(
+        "MicroBooNE", "MicroBooNE_LArSoft",
+        np.array([0.0, 0.0, 0.0]),
+        np.array([-1.281750, -1.165, -5.184]),
+        np.array([+1.281750, +1.165, +5.184]))
+
+    detectors["MiniBooNE"] = Detector(
+        "MiniBooNE", "BNB",
+        np.array([0.0, 1.89614, 541.34]),
+        np.array([0.0, 1.89614, 541.34]) - 6.1,
+        np.array([0.0, 1.89614, 541.34]) + 6.1)
+
+    return detectors
+
+
+DETECTORS: dict[str, Detector] = _build_detectors()
+
+
+# ======================================================================
+# Public API
+# ======================================================================
+def convert(r: Iterable[float], src: str, dst: str) -> np.ndarray:
+    """Convert a position (meters) from frame src to frame dst."""
+    return GRAPH.convert(r, src, dst)
+
+
+def transform(src: str, dst: str) -> Transform:
+    """Return the composed Transform from src to dst."""
+    return GRAPH.compose(src, dst)
+
+
+def detector_center(name: str, frame: str) -> np.ndarray:
+    """Active-volume geometric center in the given frame (meters)."""
+    d = DETECTORS[name]
+    return GRAPH.convert(d.center_native, d.native_frame, frame)
+
+
+def detector_origin(name: str, frame: str) -> np.ndarray:
+    """Native-frame origin of a detector, expressed in the given frame (meters)."""
+    d = DETECTORS[name]
+    return GRAPH.convert(np.zeros(3), d.native_frame, frame)
+
+
+def detector_transform(name: str, frame: str) -> Transform:
+    """Full rigid transform from a detector's native frame to the given frame."""
+    d = DETECTORS[name]
+    return GRAPH.compose(d.native_frame, frame)
+
+
+
+def gdml_rotation_angles(R: np.ndarray):
+    """Decompose rotation matrix to GDML Euler angles (rx, ry, rz) in radians.
+
+    GDML convention is extrinsic XYZ (static frame): R = Rz(rz) @ Ry(ry) @ Rx(rx).
+    This matches the SIREN GDML parser which calls QFromXYZs(rx, ry, rz).
+    """
+    from siren.math import Quaternion, Matrix3D
+    q = Quaternion()
+    q.SetMatrix(Matrix3D(*R.flatten()))
+    return q.GetEulerAnglesXYZs()

--- a/resources/detectors/SBN/SBN-v1/sbn_geometry.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_geometry.py
@@ -6,7 +6,8 @@ Provides composable frame-to-frame transforms for the Fermilab SBN program
 detectors (ICARUS, SBND, MicroBooNE) and beamlines (BNB, NuMI).
 
 World coordinate system (BNB frame):
-  Origin : BNB beryllium target at MI-12
+  Origin : SAND center, close to BNB beryllium target at MI-12
+           The BNB beryllium target is centered at z = +0.3905 m
   x      : horizontal west
   y      : up
   z      : along BNB beam axis (approximately north)

--- a/resources/detectors/SBN/SBN-v1/sbn_geometry.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_geometry.py
@@ -134,7 +134,11 @@ R_ICARUS_TO_NUMI = np.array([
 ])
 T_ICARUS_IN_NUMI_M = np.array([4.503730, 80.153901, 795.112945])
 
-BNB_TARGET_Z_SAND_M = 0.81733
+# Z-position of the BNB target center in the BooNE GDML (SAND) frame,
+# traced through the volume hierarchy:
+#   SAND -> CAVE (+426.8 mm) -> CAVI (0) -> PILE (~0) -> PICV (-426.8 mm) -> TARG (+390.525 mm)
+# Total: 390.525 mm = 0.390525 m
+BNB_TARGET_Z_SAND_M = 0.390525
 
 
 # ======================================================================

--- a/resources/detectors/SBN/SBN-v1/sbn_loader.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_loader.py
@@ -1,0 +1,212 @@
+"""
+Shared GDML composition engine for SBN detector loaders.
+
+Generates a stub GDML that references source GDML files via the <file>
+element. The SIREN GDML parser handles name collision resolution
+automatically via GDMLData::MergeFrom.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def _ensure_gdml_files(abs_dir: str, sources: list[dict[str, Any]]) -> None:
+    """Download missing GDML files using siren.download."""
+    from siren.download import ensure_files
+    specs = []
+    for src in sources:
+        if not src.get("file"):
+            continue
+        specs.append({
+            "path": os.path.join(abs_dir, src["file"]),
+            "url": src.get("url", ""),
+            "sha256": src.get("sha256", ""),
+        })
+    ensure_files(specs)
+
+
+# Isotope table: (Z, A, molar_mass_g_per_mol).
+# Each entry produces an <isotope> and a single-fraction <element>.
+_ISOTOPES = [
+    (1,   1,   1.008),
+    (6,  12,  12.0),
+    (7,  14,  14.0),
+    (8,  16,  16.0),
+    (12, 24,  24.0),
+    (13, 27,  26.982),
+    (14, 28,  28.086),
+    (20, 40,  40.0),
+    (26, 56,  55.845),
+]
+
+# Material table: (name, state, density_g_cm3, {element_key: mass_fraction}).
+# element_key is (Z, A) referencing an entry in _ISOTOPES.
+_MATERIALS = [
+    # -- Site geology (used by GDML volumes) --
+    ("env_GlacialTill", "solid", 1.9, {
+        (14, 28): 0.303830, (8, 16): 0.534889, (13, 27): 0.079387,
+        (26, 56): 0.034971, (20, 40): 0.035734, (1, 1): 0.011190,
+    }),
+    ("env_Dolomite", "solid", 2.6, {
+        (20, 40): 0.2171, (12, 24): 0.1318,
+        (6, 12): 0.1304, (8, 16): 0.5207,
+    }),
+    ("env_Air", "gas", 0.001225, {(7, 14): 0.7562, (8, 16): 0.2438}),
+    # -- PREM Earth model (used by AddSector layers; density here is
+    #    nominal -- actual density comes from each sector's
+    #    DensityDistribution). --
+    ("ROCK",      "solid",  2.6,   {(14, 28): 0.4674, (8, 16): 0.5326}),
+    ("MANTLE",    "solid",  3.3,   {(14, 28): 0.4674, (8, 16): 0.5326}),
+    ("OUTERCORE", "solid", 10.0,   {(26, 56): 1.0}),
+    ("INNERCORE", "solid", 13.0,   {(26, 56): 1.0}),
+    ("AIR",       "gas",    0.001225, {(7, 14): 0.7562, (8, 16): 0.2438}),
+]
+
+
+def _build_materials_xml() -> str:
+    """Generate GDML <materials> content from the isotope and material tables."""
+    lines = []
+    for Z, A, mass in _ISOTOPES:
+        iso = f"env_Z{Z}_A{A}"
+        el = f"env_el_Z{Z}_A{A}"
+        lines.append(f'    <isotope N="{A}" Z="{Z}" name="{iso}">')
+        lines.append(f'      <atom unit="g/mole" value="{mass}"/>')
+        lines.append(f'    </isotope>')
+        lines.append(f'    <element name="{el}">')
+        lines.append(f'      <fraction n="1.0" ref="{iso}"/>')
+        lines.append(f'    </element>')
+    for name, state, density, comp in _MATERIALS:
+        lines.append(f'    <material name="{name}" state="{state}">')
+        lines.append(f'      <D value="{density}" unit="g/cm3"/>')
+        for (Z, A), frac in comp.items():
+            lines.append(f'      <fraction n="{frac}" ref="env_el_Z{Z}_A{A}"/>')
+        lines.append(f'    </material>')
+    return "\n".join(lines)
+
+
+# Ground-level elevation in BNB coordinates (meters above the BNB target).
+# Fermilab grade is approximately 7.62 m above the BNB beam axis.
+_GRADE_Y_BNB = 7.62
+
+# Glacial till thickness below grade (meters). The Quaternary glacial
+# deposits at Fermilab are 18-30 m thick; we use 20 m as a representative
+# value. Below this is Silurian dolomite bedrock.
+_TILL_THICKNESS = 20.0
+
+
+def build_composite(
+    abs_dir: str,
+    sources: list[dict[str, Any]],
+    cache_name: str = "composite.gdml",
+) -> str:
+    """Build a stub GDML that references source files via <file> elements.
+
+    Each source dict has keys:
+      file     : relative path to GDML file
+      prefix   : name prefix (used for physvol naming only)
+      position : (x, y, z) in meters (BNB frame)
+      rotation : (rx, ry, rz) GDML Euler angles in radians, or None
+      unwrap   : if True, set as_assembly="true" on the <file> element
+
+    Returns the path to the written stub GDML.
+    """
+    cache_path = os.path.join(abs_dir, cache_name)
+
+    _ensure_gdml_files(abs_dir, sources)
+
+    physvols = []
+    for spec in sources:
+        if not spec.get("file"):
+            continue
+        prefix = spec["prefix"]
+        pos = spec["position"]
+        rot = spec.get("rotation")
+        as_asm = ' as_assembly="true"' if spec.get("unwrap", False) else ""
+
+        pv = []
+        pv.append(f'      <physvol name="pv_{prefix}">')
+        pv.append(f'        <file name="{spec["file"]}"{as_asm}/>')
+        pv.append(f'        <position unit="m" x="{pos[0]:.6f}" y="{pos[1]:.6f}" z="{pos[2]:.6f}"/>')
+        if rot is not None:
+            pv.append(f'        <rotation unit="rad" x="{rot[0]:.10f}" y="{rot[1]:.10f}" z="{rot[2]:.10f}"/>')
+        pv.append('      </physvol>')
+        physvols.append("\n".join(pv))
+
+    source_physvols = "\n".join(physvols)
+
+    # GDML <box> x/y/z are half-widths
+    # So this gives a full 1600 m x 400 m x 1800 m box
+    box_half_x = 800.0
+    box_half_y = 200.0
+    box_half_z = 900.0
+    margin = 10.0
+
+    bedrock_y = _GRADE_Y_BNB - _TILL_THICKNESS
+
+    atmo_height = box_half_y - _GRADE_Y_BNB
+    atmo_center_y = _GRADE_Y_BNB + atmo_height / 2.0
+    atmo_half_height = atmo_height / 2.0
+
+    bedrock_height = box_half_y + bedrock_y
+    bedrock_center_y = bedrock_y - bedrock_height / 2.0
+    bedrock_half_height = bedrock_height / 2.0
+
+    child_half_x = box_half_x - margin
+    child_half_z = box_half_z - margin
+
+    materials_xml = _build_materials_xml()
+
+    stub = f"""\
+<?xml version="1.0"?>
+<gdml>
+  <define/>
+  <materials>
+{materials_xml}
+  </materials>
+  <solids>
+    <box name="sol_site_volume" lunit="m" x="{box_half_x}" y="{box_half_y}" z="{box_half_z}"/>
+    <box name="sol_atmosphere" lunit="m" x="{child_half_x}" y="{atmo_half_height}" z="{child_half_z}"/>
+    <box name="sol_dolomite_bedrock" lunit="m" x="{child_half_x}" y="{bedrock_half_height}" z="{child_half_z}"/>
+  </solids>
+  <structure>
+    <volume name="vol_atmosphere">
+      <materialref ref="env_Air"/>
+      <solidref ref="sol_atmosphere"/>
+    </volume>
+    <volume name="vol_dolomite_bedrock">
+      <materialref ref="env_Dolomite"/>
+      <solidref ref="sol_dolomite_bedrock"/>
+    </volume>
+    <volume name="vol_site_geology">
+      <materialref ref="env_GlacialTill"/>
+      <solidref ref="sol_site_volume"/>
+      <physvol name="pv_atmosphere">
+        <volumeref ref="vol_atmosphere"/>
+        <position unit="m" x="0" y="{atmo_center_y:.4f}" z="0"/>
+      </physvol>
+      <physvol name="pv_dolomite_bedrock">
+        <volumeref ref="vol_dolomite_bedrock"/>
+        <position unit="m" x="0" y="{bedrock_center_y:.4f}" z="0"/>
+      </physvol>
+{source_physvols}
+    </volume>
+  </structure>
+  <setup name="Default" version="1.0">
+    <world ref="vol_site_geology"/>
+  </setup>
+</gdml>
+"""
+
+    tmp_path = cache_path + ".tmp"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            f.write(stub)
+        os.replace(tmp_path, cache_path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise
+
+    return cache_path

--- a/resources/fluxes/Atmospheric/Atmospheric-v1.0/flux.py
+++ b/resources/fluxes/Atmospheric/Atmospheric-v1.0/flux.py
@@ -1,8 +1,8 @@
 import os
 import numpy as np
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 
 _DATA_BASE = (
     "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/"
@@ -21,19 +21,26 @@ _NPZ_SHA256 = {
     "honda2006": "9afe3fe86e67e6653e95ae1e9629964a73d1063c5abaf6e39eabf5444c964559",
 }
 
-_NPZ_FILES = [
-    {
-        "path": os.path.join(_ABS_DIR, f"{model}.npz"),
-        "url": f"{_DATA_BASE}/{model}.npz",
-        "sha256": _NPZ_SHA256[model],
-    }
-    for model in MODELS
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
     """Download all atmospheric flux npz files."""
-    ensure_files(_NPZ_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {
+            "path": os.path.join(abs_dir, f"{model}.npz"),
+            "url": f"{_DATA_BASE}/{model}.npz",
+            "sha256": _NPZ_SHA256[model],
+        }
+        for model in MODELS
+    ])
 
 
 def load_flux(tag):
@@ -71,11 +78,12 @@ def load_flux(tag):
 
     fetch_data()
 
-    output_flux_file = os.path.join(_ABS_DIR, f"Atmospheric_{tag}_flux.txt")
+    abs_dir = _get_abs_dir()
+    output_flux_file = os.path.join(abs_dir, f"Atmospheric_{tag}_flux.txt")
     if os.path.isfile(output_flux_file):
         return output_flux_file
 
-    npz_path = os.path.join(_ABS_DIR, f"{model}.npz")
+    npz_path = resolve_data_path(_INSTALL_DIR, abs_dir, f"{model}.npz")
     with np.load(npz_path) as npz:
         energy = npz["energy"]
         cos_theta = npz["cos_theta"]
@@ -92,7 +100,9 @@ def load_flux(tag):
                 tot_flux += grid
 
     ee, cc = np.meshgrid(energy, cos_theta, indexing='ij')
-    np.savetxt(output_flux_file,
+    tmp = output_flux_file + ".tmp"
+    np.savetxt(tmp,
                np.column_stack([ee.ravel(), cc.ravel(), tot_flux.ravel()]))
+    os.replace(tmp, output_flux_file)
 
     return output_flux_file

--- a/resources/fluxes/BNB/BNB-v1.0/flux.py
+++ b/resources/fluxes/BNB/BNB-v1.0/flux.py
@@ -1,20 +1,27 @@
 import os
 import siren
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/BNB/BNB-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "BNB_FHC.dat"), "url": f"{_DATA_BASE}/BNB_FHC.dat",
-     "sha256": "093a46a07c66c170ad08278ebded5ae6c314c2a73c7696884623181dd03dd887"},
-    {"path": os.path.join(_ABS_DIR, "BNB_RHC.dat"), "url": f"{_DATA_BASE}/BNB_RHC.dat",
-     "sha256": "3b16ada8932faae4ef6412dcefad2a29ef3d450e8af60f925eaf6f2ca1de1369"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "BNB_FHC.dat"), "url": f"{_DATA_BASE}/BNB_FHC.dat",
+         "sha256": "093a46a07c66c170ad08278ebded5ae6c314c2a73c7696884623181dd03dd887"},
+        {"path": os.path.join(abs_dir, "BNB_RHC.dat"), "url": f"{_DATA_BASE}/BNB_RHC.dat",
+         "sha256": "3b16ada8932faae4ef6412dcefad2a29ef3d450e8af60f925eaf6f2ca1de1369"},
+    ])
 
 
 def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=True):
@@ -32,13 +39,17 @@ def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=
         raise RuntimeError("Neither or both \"min_energy\" and \"max_energy\" must be provided")
     has_energy_range = min_energy is not None
 
-    mode, particle = tag.split("_")
+    parts = tag.split("_", maxsplit=1)
+    if len(parts) != 2:
+        raise ValueError(
+            "Tag %r is not valid. Expected {FHC,RHC}_{nue,nuebar,numu,numubar}" % tag)
+    mode, particle = parts
     if mode not in ["FHC", "RHC"]:
         raise ValueError("%s beam mode specified in tag %s is not valid" % (mode, tag))
     if particle not in ["nue", "numu", "nuebar", "numubar"]:
         raise ValueError("%s particle specified in tag %s is not valid" % (particle, tag))
 
-    input_flux_file = os.path.join(_ABS_DIR, "BNB_%s.dat" % mode)
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(), "BNB_%s.dat" % mode)
 
     with open(input_flux_file, "r") as f:
         all_lines = f.readlines()

--- a/resources/fluxes/HE_SN/HE_SN-v1.0/flux.py
+++ b/resources/fluxes/HE_SN/HE_SN-v1.0/flux.py
@@ -1,19 +1,26 @@
 import os
 import siren
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/HE_SN/HE_SN-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt"),
-     "url": f"{_DATA_BASE}/dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt",
-     "sha256": "b6dc394dbcccbfb19a09273656b9305d0611f625e1f523a9f04e3b51cbbfb00c"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt"),
+         "url": f"{_DATA_BASE}/dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt",
+         "sha256": "b6dc394dbcccbfb19a09273656b9305d0611f625e1f523a9f04e3b51cbbfb00c"},
+    ])
 
 
 def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=True):
@@ -27,8 +34,8 @@ def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=
 
     has_energy_range = min_energy is not None
 
-    input_flux_file = os.path.join(_ABS_DIR,
-                                   "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt")
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(),
+                                       "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt")
 
     with open(input_flux_file, "r") as f:
         all_lines = f.readlines()

--- a/resources/fluxes/NUMI/NUMI-v1.0/flux.py
+++ b/resources/fluxes/NUMI/NUMI-v1.0/flux.py
@@ -1,27 +1,36 @@
 import os
 import siren
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/NUMI/NUMI-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, f"NUMI_{mode}_{energy}.dat"),
-     "url": f"{_DATA_BASE}/NUMI_{mode}_{energy}.dat",
-     "sha256": sha}
-    for mode, energy, sha in [
-        ("FHC", "LE", "38fc38719d88dd96fdd0f849c9921fcee224a9faaa6a4f0d0a569d408bc3b372"),
-        ("FHC", "ME", "2401354dc561a51a84de87e5f47308fdb736b2739316b275fd0959e1428c9860"),
-        ("FHC", "ME_unofficial", "3c5e1b3afe0e992602442bac13b07f2359a290dfe31c45a6b0026bf1542befd1"),
-        ("RHC", "LE", "e994bb199e441a0aa695ec4a6b1698dbbf4d876e17e0c650d252c9943cd7da2c"),
-        ("RHC", "ME", "52c538efd182b03bcf45577bdf81172575fe4247eec5cc980a41764e08fbabf4"),
-        ("RHC", "ME_unofficial", "63bfbff1b27303ee04c7aade3841481a22416b2f5b39cd807398a797c61c90d4"),
-    ]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
+
+_DATA_ENTRIES = [
+    ("FHC", "LE", "38fc38719d88dd96fdd0f849c9921fcee224a9faaa6a4f0d0a569d408bc3b372"),
+    ("FHC", "ME", "2401354dc561a51a84de87e5f47308fdb736b2739316b275fd0959e1428c9860"),
+    ("FHC", "ME_unofficial", "3c5e1b3afe0e992602442bac13b07f2359a290dfe31c45a6b0026bf1542befd1"),
+    ("RHC", "LE", "e994bb199e441a0aa695ec4a6b1698dbbf4d876e17e0c650d252c9943cd7da2c"),
+    ("RHC", "ME", "52c538efd182b03bcf45577bdf81172575fe4247eec5cc980a41764e08fbabf4"),
+    ("RHC", "ME_unofficial", "63bfbff1b27303ee04c7aade3841481a22416b2f5b39cd807398a797c61c90d4"),
 ]
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, f"NUMI_{mode}_{energy}.dat"),
+         "url": f"{_DATA_BASE}/NUMI_{mode}_{energy}.dat",
+         "sha256": sha}
+        for mode, energy, sha in _DATA_ENTRIES
+    ])
 
 
 def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=True):
@@ -39,16 +48,22 @@ def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=
         raise RuntimeError("Neither or both \"min_energy\" and \"max_energy\" must be provided")
     has_energy_range = min_energy is not None
 
-    mode, energy, particle = tag.split("_")
+    parts = tag.split("_")
+    if len(parts) < 3:
+        raise ValueError(
+            "Tag %r is not valid. Expected {FHC,RHC}_{LE,ME,ME_unofficial}_{particle}" % tag)
+    mode = parts[0]
+    particle = parts[-1]
+    energy = "_".join(parts[1:-1])
     if mode not in ["FHC","RHC"]:
         raise ValueError("%s beam mode specified in tag %s is not valid"%(mode,tag))
-    if energy not in ["LE","ME"]:
+    if energy not in ["LE","ME","ME_unofficial"]:
         raise ValueError("%s energy mode specified in tag %s is not valid"%(energy,tag))
     if particle not in ["nue","numu","nuebar","numubar"]:
         raise ValueError("%s particle specified in tag %s is not valid"%(particle,tag))
 
-    input_flux_file = os.path.join(_ABS_DIR,
-                                   "NUMI_%s_%s.dat" % (mode, energy))
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(),
+                                       "NUMI_%s_%s.dat" % (mode, energy))
 
     with open(input_flux_file, "r") as f:
         all_lines = f.readlines()

--- a/resources/fluxes/T2K_Kaons/T2K_Kaons-v1.0/flux.py
+++ b/resources/fluxes/T2K_Kaons/T2K_Kaons-v1.0/flux.py
@@ -1,34 +1,41 @@
 from scipy.interpolate import interp1d
 import numpy as np
 import os
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/T2K_Kaons/T2K_Kaons-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "kaon-flux-data.dat"), "url": f"{_DATA_BASE}/kaon-flux-data.dat",
-     "sha256": "32e06bb7f454547fa30ac4f6f34caf50700c53683ec40963a904c1fb91f87d56"},
-    {"path": os.path.join(_ABS_DIR, "ratio.dat"), "url": f"{_DATA_BASE}/ratio.dat",
-     "sha256": "ae85fd610073a6158065b4b24ab351d42a353ad7f704d1dbb58d3c6cdf911e98"},
-    {"path": os.path.join(_ABS_DIR, "TOT_PLUS_NUMU.dat"), "url": f"{_DATA_BASE}/TOT_PLUS_NUMU.dat",
-     "sha256": "fdce382924d17d4841c1b2e8da6dcc7932d7a3dc9c5ee68b0a438035083a8b20"},
-    {"path": os.path.join(_ABS_DIR, "TOT_MINUS_NUMUBAR.dat"), "url": f"{_DATA_BASE}/TOT_MINUS_NUMUBAR.dat",
-     "sha256": "347a94e69261a25b3fb5174c193e0abbae167e817f5d5e50c9da213270e26531"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "kaon-flux-data.dat"), "url": f"{_DATA_BASE}/kaon-flux-data.dat",
+         "sha256": "32e06bb7f454547fa30ac4f6f34caf50700c53683ec40963a904c1fb91f87d56"},
+        {"path": os.path.join(abs_dir, "ratio.dat"), "url": f"{_DATA_BASE}/ratio.dat",
+         "sha256": "ae85fd610073a6158065b4b24ab351d42a353ad7f704d1dbb58d3c6cdf911e98"},
+        {"path": os.path.join(abs_dir, "TOT_PLUS_NUMU.dat"), "url": f"{_DATA_BASE}/TOT_PLUS_NUMU.dat",
+         "sha256": "fdce382924d17d4841c1b2e8da6dcc7932d7a3dc9c5ee68b0a438035083a8b20"},
+        {"path": os.path.join(abs_dir, "TOT_MINUS_NUMUBAR.dat"), "url": f"{_DATA_BASE}/TOT_MINUS_NUMUBAR.dat",
+         "sha256": "347a94e69261a25b3fb5174c193e0abbae167e817f5d5e50c9da213270e26531"},
+    ])
 
 
 def bar_scaling():
-    energy, ratio = np.loadtxt(os.path.join(_ABS_DIR, 'ratio.dat'), usecols=(0, 1), unpack=True)
+    energy, ratio = np.loadtxt(resolve_data_path(_INSTALL_DIR, _get_abs_dir(), 'ratio.dat'), usecols=(0, 1), unpack=True)
     return interp1d(energy, ratio, kind='linear', bounds_error=False, fill_value=(ratio[0], ratio[-1]))
 
 def MakeFluxFile(tag, output_dir=None):
     if output_dir is None:
-        output_dir = _ABS_DIR
+        output_dir = _get_abs_dir()
 
     parts = tag.split("_")
     if len(parts) != 2:
@@ -46,7 +53,7 @@ def MakeFluxFile(tag, output_dir=None):
     if particle not in ["numu", "numubar"]:
         raise ValueError(f"\"{particle}\" particle specified in tag \"{tag}\" is not valid")
 
-    input_flux_file = os.path.join(_ABS_DIR, "kaon-flux-data.dat")
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(), "kaon-flux-data.dat")
 
     if bar:
         output_flux_file = os.path.join(output_dir, f"kaon-flux-{particle}_bar.dat")

--- a/resources/fluxes/T2K_NEAR/T2K_NEAR-v1.0/flux.py
+++ b/resources/fluxes/T2K_NEAR/T2K_NEAR-v1.0/flux.py
@@ -1,19 +1,26 @@
 import os
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/T2K_NEAR/T2K_NEAR-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "T2K_PLUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_PLUS_250kA.dat",
-     "sha256": "bc7958cda04788976d5c0e75a5efca075b62d63d82cce0a67f7fea539bb33eab"},
-    {"path": os.path.join(_ABS_DIR, "T2K_MINUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_MINUS_250kA.dat",
-     "sha256": "e2d6bedd56f4c30ad765ec0320970565ad2d63faf5cb4cdd9004d4f6cd965ffe"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "T2K_PLUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_PLUS_250kA.dat",
+         "sha256": "bc7958cda04788976d5c0e75a5efca075b62d63d82cce0a67f7fea539bb33eab"},
+        {"path": os.path.join(abs_dir, "T2K_MINUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_MINUS_250kA.dat",
+         "sha256": "e2d6bedd56f4c30ad765ec0320970565ad2d63faf5cb4cdd9004d4f6cd965ffe"},
+    ])
 
 
 def load_flux(tag):
@@ -25,17 +32,22 @@ def load_flux(tag):
 
     fetch_data()
 
-    enhance, particle = tag.split("_")
+    parts = tag.split("_", maxsplit=1)
+    if len(parts) != 2:
+        raise ValueError(
+            "Tag %r is not valid. Expected {PLUS,MINUS}_{nue,nuebar,numu,numubar}" % tag)
+    enhance, particle = parts
 
     if enhance not in ["MINUS", "PLUS"]:
         raise ValueError("%s 250kA enhancement specified in tag %s is not valid" % (enhance, tag))
     if particle not in ["numu", "numubar", "nue", "nuebar"]:
         raise ValueError("%s particle specified in tag %s is not valid" % (particle, tag))
 
-    input_flux_file = os.path.join(_ABS_DIR,
-                                   "T2K_%s_250kA.dat"%(enhance))
+    abs_dir = _get_abs_dir()
+    input_flux_file = resolve_data_path(_INSTALL_DIR, abs_dir,
+                                       "T2K_%s_250kA.dat"%(enhance))
 
-    output_flux_file = os.path.join(_ABS_DIR,
+    output_flux_file = os.path.join(abs_dir,
                                     "T2KOUT_%s.dat"%(tag))
 
     with open(input_flux_file,"r") as fin:

--- a/resources/processes/CSMSDISSplines/CSMSDISSplines-v1.0/processes.py
+++ b/resources/processes/CSMSDISSplines/CSMSDISSplines-v1.0/processes.py
@@ -2,19 +2,29 @@ import os
 from typing import Tuple, List, Any, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
 _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/CSMSDISSplines/CSMSDISSplines-v1.0"
-_RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+
+_RESOURCES_ROOT = None
+_DOWNLOAD_DIR = None
+
+def _get_dirs():
+    global _RESOURCES_ROOT, _DOWNLOAD_DIR
+    if _RESOURCES_ROOT is None:
+        _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+        _DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+    return _RESOURCES_ROOT, _DOWNLOAD_DIR
 
 
 def fetch_data():
     """Download data files from Zenodo (called by siren-download --fetch)."""
-    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, _RESOURCES_ROOT,
+    resources_root, _ = _get_dirs()
+    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, resources_root,
                           prefix=_ZENODO_PREFIX)
 
 neutrinos = [
@@ -107,11 +117,12 @@ def load_processes(
     primary_processes = []
     primary_processes_dict = collections.defaultdict(list)
 
+    _, download_dir = _get_dirs()
     for process_type in process_types:
         for primaries, nunubar in [[neutrinos, "nu"], [antineutrinos, "nubar"]]:
             if isoscalar:
-                dxs_file = os.path.join(base_path, f"dsdxdy_{nunubar}_{process_type}_iso.fits")
-                xs_file = os.path.join(base_path, f"sigma_{nunubar}_{process_type}_iso.fits")
+                dxs_file = resolve_data_path(base_path, download_dir, f"dsdxdy_{nunubar}_{process_type}_iso.fits")
+                xs_file = resolve_data_path(base_path, download_dir, f"sigma_{nunubar}_{process_type}_iso.fits")
                 xs = siren.interactions.DISFromSpline(dxs_file, xs_file, primaries, target_types, "m")
                 primary_processes.append(xs)
                 for primary_type in primaries:

--- a/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0/processes.py
+++ b/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -12,6 +12,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -96,8 +97,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDipoleDISFromSpline(dxs_file, xs_file,
                                                            m4_GeV, dipole_couplings,
                                                            [primary],

--- a/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0/processes.py
+++ b/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +10,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -94,8 +95,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDipoleDISFromSpline(dxs_file, xs_file,
                                                            m4_GeV, dipole_couplings,
                                                            [primary],

--- a/resources/processes/HNLDISSplines/HNLDISSplines-v1.0/processes.py
+++ b/resources/processes/HNLDISSplines/HNLDISSplines-v1.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +10,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/HNLDISSplines/HNLDISSplines-v1.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -95,8 +96,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDISFromSpline(dxs_file, xs_file,
                                                      m4_GeV, mixings,
                                                      siren.utilities.Constants.isoscalarMass,

--- a/resources/processes/HNLDISSplines/HNLDISSplines-v2.0/processes.py
+++ b/resources/processes/HNLDISSplines/HNLDISSplines-v2.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +10,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/HNLDISSplines/HNLDISSplines-v2.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -95,8 +96,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDISFromSpline(dxs_file, xs_file,
                                                      m4_GeV, mixings,
                                                      siren.utilities.Constants.isoscalarMass,

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -6,6 +6,28 @@ from pathlib import Path
 import pytest
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="run tests that require network access")
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "network: test requires network access")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-network"):
+        return
+    skip_network = pytest.mark.skip(reason="requires --run-network")
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+
+
 @pytest.fixture(scope="session")
 def project_root() -> Path:
     here = Path(__file__).resolve()

--- a/tests/python/test_sbn_geometry.py
+++ b/tests/python/test_sbn_geometry.py
@@ -1,0 +1,356 @@
+"""Tests for SBN geometry coordinate transforms and rotation utilities."""
+from __future__ import annotations
+
+import importlib.util
+import math
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_SBN_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "resources", "detectors",
+    "SBN", "SBN-v1")
+
+
+def test_detector_loader_imports_without_preloaded_siblings():
+    """Importing detector.py must load dataclass sibling modules itself."""
+    module_names = ("sbn_detector_import_smoke",
+                     "siren._sbn.sbn_geometry", "siren._sbn.sbn_loader")
+    previous_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "sbn_detector_import_smoke",
+            os.path.join(_SBN_DIR, "detector.py"))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        assert callable(mod.load_detector)
+        assert "ICARUS" in mod._DETECTOR_SPECS
+        assert mod.geo.DETECTORS["ICARUS"].name == "ICARUS"
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        for name, module in previous_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+
+
+def test_sbn_resource_loader_imports_from_source_tree(monkeypatch):
+    """The public resource loader path must import the SBN detector loader."""
+    from siren import _util
+
+    resources_root = os.path.abspath(os.path.join(_SBN_DIR, "..", "..", ".."))
+    module_names = ("siren-detector-SBN",
+                     "siren._sbn.sbn_geometry", "siren._sbn.sbn_loader")
+    previous_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    monkeypatch.setattr(_util, "resource_package_dir", lambda: resources_root)
+
+    try:
+        loader = _util.get_resource_loader("detector", "SBN")
+        assert callable(loader)
+        assert "ICARUS" in loader._DETECTOR_SPECS
+        assert "SBND" in loader._DETECTOR_SPECS
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        for name, module in previous_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+
+
+@pytest.fixture(scope="module")
+def geo():
+    fqn = "siren._sbn.sbn_geometry"
+    previous = sys.modules.get(fqn)
+    spec = importlib.util.spec_from_file_location(
+        fqn, os.path.join(_SBN_DIR, "sbn_geometry.py"))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[fqn] = mod
+    spec.loader.exec_module(mod)
+    yield mod
+    sys.modules.pop(fqn, None)
+    if previous is not None:
+        sys.modules[fqn] = previous
+
+
+# ======================================================================
+# gdml_rotation_angles: round-trip via matrix reconstruction
+# ======================================================================
+
+def _reconstruct_matrix(rx, ry, rz):
+    """Build R = Rz(rz) @ Ry(ry) @ Rx(rx) (extrinsic XYZ / GDML convention)."""
+    cx, sx = math.cos(rx), math.sin(rx)
+    cy, sy = math.cos(ry), math.sin(ry)
+    cz, sz = math.cos(rz), math.sin(rz)
+    Rx = np.array([[1, 0, 0], [0, cx, -sx], [0, sx, cx]])
+    Ry = np.array([[cy, 0, sy], [0, 1, 0], [-sy, 0, cy]])
+    Rz = np.array([[cz, -sz, 0], [sz, cz, 0], [0, 0, 1]])
+    return Rz @ Ry @ Rx
+
+
+class TestGDMLRotationAngles:
+
+    def test_identity(self, geo):
+        rx, ry, rz = geo.gdml_rotation_angles(np.eye(3))
+        assert abs(rx) < 1e-15
+        assert abs(ry) < 1e-15
+        assert abs(rz) < 1e-15
+
+    def test_single_axis_x(self, geo):
+        angle = 0.7
+        R = _reconstruct_matrix(angle, 0, 0)
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        assert abs(rx - angle) < 1e-14
+        assert abs(ry) < 1e-14
+        assert abs(rz) < 1e-14
+
+    def test_single_axis_y(self, geo):
+        angle = -0.4
+        R = _reconstruct_matrix(0, angle, 0)
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        assert abs(rx) < 1e-14
+        assert abs(ry - angle) < 1e-14
+        assert abs(rz) < 1e-14
+
+    def test_single_axis_z(self, geo):
+        angle = 1.2
+        R = _reconstruct_matrix(0, 0, angle)
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        assert abs(rx) < 1e-14
+        assert abs(ry) < 1e-14
+        assert abs(rz - angle) < 1e-14
+
+    def test_combined_rotation(self, geo):
+        R = _reconstruct_matrix(0.3, -0.5, 0.8)
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        R_recon = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(R, R_recon, atol=1e-14)
+
+    def test_90_degree_z(self, geo):
+        R = np.array([[0, -1, 0], [1, 0, 0], [0, 0, 1]], dtype=float)
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        R_recon = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(R, R_recon, atol=1e-14)
+
+    def test_icarus_rotation(self, geo):
+        """The real ICARUS->NuMI rotation matrix must round-trip."""
+        R = geo.R_ICARUS_TO_NUMI
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        R_recon = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(R, R_recon, atol=1e-9)
+
+    def test_numi_to_bnb_transform(self, geo):
+        T = geo.transform("NuMI", "BNB")
+        rx, ry, rz = geo.gdml_rotation_angles(T.R)
+        R_recon = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(T.R, R_recon, atol=1e-9)
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_random_rotations(self, geo, seed):
+        rng = np.random.RandomState(seed)
+        M = rng.randn(3, 3)
+        Q, _ = np.linalg.qr(M)
+        if np.linalg.det(Q) < 0:
+            Q[:, 0] *= -1
+        rx, ry, rz = geo.gdml_rotation_angles(Q)
+        R_recon = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(Q, R_recon, atol=1e-14)
+
+    def test_near_gimbal_lock(self, geo):
+        R = _reconstruct_matrix(0.3, math.pi / 2 - 1e-8, 0.5)
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        R_recon = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(R, R_recon, atol=1e-7)
+
+
+# ======================================================================
+# gdml_rotation_angles + quaternion: match C++ GDML parser path
+# ======================================================================
+
+class TestGDMLRotationMatchesCpp:
+    """Verify that Quaternion.SetMatrix and gdml_rotation_angles ->
+    SetEulerAnglesXYZs produce the same quaternion for a given matrix."""
+
+    @staticmethod
+    def _q_dot(a, b):
+        v = np.array([a.X, a.Y, a.Z, a.W])
+        w = np.array([b.X, b.Y, b.Z, b.W])
+        return abs(np.dot(v, w))
+
+    def _check(self, geo, R, atol=1e-10):
+        from siren.math import Quaternion, Matrix3D
+        # Path 1: matrix -> quaternion directly
+        q_mat = Quaternion()
+        q_mat.SetMatrix(Matrix3D(*R.flatten()))
+        # Path 2: matrix -> Euler angles -> quaternion
+        rx, ry, rz = geo.gdml_rotation_angles(R)
+        q_euler = Quaternion()
+        q_euler.SetEulerAnglesXYZs(rx, ry, rz)
+
+        dot = self._q_dot(q_mat, q_euler)
+        assert abs(dot - 1.0) < atol, (
+            f"Quaternion mismatch: dot={dot}, "
+            f"mat=({q_mat.X},{q_mat.Y},{q_mat.Z},{q_mat.W}), "
+            f"euler=({q_euler.X},{q_euler.Y},{q_euler.Z},{q_euler.W})")
+
+    def test_identity(self, geo):
+        self._check(geo, np.eye(3))
+
+    def test_icarus_rotation(self, geo):
+        self._check(geo, geo.R_ICARUS_TO_NUMI)
+
+    def test_numi_to_bnb(self, geo):
+        T = geo.transform("NuMI", "BNB")
+        self._check(geo, T.R)
+
+    def test_combined_45deg(self, geo):
+        self._check(geo, _reconstruct_matrix(
+            math.pi / 4, math.pi / 4, math.pi / 4))
+
+    @pytest.mark.parametrize("seed", range(10))
+    def test_random_rotations(self, geo, seed):
+        rng = np.random.RandomState(seed)
+        M = rng.randn(3, 3)
+        Q, _ = np.linalg.qr(M)
+        if np.linalg.det(Q) < 0:
+            Q[:, 0] *= -1
+        self._check(geo, Q)
+
+
+# ======================================================================
+# Matrix3D -> Quaternion (via SetMatrix)
+# ======================================================================
+
+class TestSetMatrixQuaternion:
+
+    def test_identity(self, geo):
+        from siren.math import Quaternion, Matrix3D
+        q = Quaternion()
+        q.SetMatrix(Matrix3D(*np.eye(3).flatten()))
+        assert abs(q.X) < 1e-15
+        assert abs(q.Y) < 1e-15
+        assert abs(q.Z) < 1e-15
+        assert abs(q.W - 1.0) < 1e-15
+
+    def test_180_about_z(self, geo):
+        from siren.math import Quaternion, Matrix3D
+        R = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]], dtype=float)
+        q = Quaternion()
+        q.SetMatrix(Matrix3D(*R.flatten()))
+        assert abs(abs(q.Z) - 1.0) < 1e-14
+        assert abs(q.W) < 1e-14
+        assert abs(q.X) < 1e-14
+        assert abs(q.Y) < 1e-14
+
+    def test_unit_quaternion(self, geo):
+        """Output must always be a unit quaternion."""
+        from siren.math import Quaternion, Matrix3D
+        rng = np.random.RandomState(99)
+        for _ in range(20):
+            M = rng.randn(3, 3)
+            Q, _ = np.linalg.qr(M)
+            if np.linalg.det(Q) < 0:
+                Q[:, 0] *= -1
+            q = Quaternion()
+            q.SetMatrix(Matrix3D(*Q.flatten()))
+            norm = math.sqrt(q.X**2 + q.Y**2 + q.Z**2 + q.W**2)
+            assert abs(norm - 1.0) < 1e-14
+
+    def test_roundtrip_with_euler(self, geo):
+        """Euler -> matrix -> SetMatrix quaternion should match the original."""
+        from siren.math import Quaternion, Matrix3D
+        q_orig = Quaternion()
+        q_orig.SetEulerAnglesXYZs(0.3, -0.7, 1.1)
+        R = _reconstruct_matrix(0.3, -0.7, 1.1)
+        q_rt = Quaternion()
+        q_rt.SetMatrix(Matrix3D(*R.flatten()))
+        dot = abs(q_orig.X*q_rt.X + q_orig.Y*q_rt.Y
+                  + q_orig.Z*q_rt.Z + q_orig.W*q_rt.W)
+        assert abs(dot - 1.0) < 1e-12
+
+
+# ======================================================================
+# Frame graph transforms
+# ======================================================================
+
+class TestFrameGraph:
+
+    def test_identity_transform(self, geo):
+        T = geo.transform("BNB", "BNB")
+        np.testing.assert_allclose(T.R, np.eye(3), atol=1e-15)
+        np.testing.assert_allclose(T.t, np.zeros(3), atol=1e-15)
+
+    def test_inverse_roundtrip(self, geo):
+        T = geo.transform("ICARUS_LArSoft", "BNB")
+        T_inv = T.inverse()
+        T_rt = T.compose(T_inv)
+        np.testing.assert_allclose(T_rt.R, np.eye(3), atol=1e-12)
+        np.testing.assert_allclose(T_rt.t, np.zeros(3), atol=1e-12)
+
+    def test_icarus_at_600m(self, geo):
+        """ICARUS is at z=600m in BNB frame (pure translation)."""
+        T = geo.transform("ICARUS_LArSoft", "BNB")
+        np.testing.assert_allclose(T.t, [0.0, 0.0, 600.0], atol=1e-10)
+        np.testing.assert_allclose(T.R, np.eye(3), atol=1e-15)
+
+    def test_sbnd_position(self, geo):
+        T = geo.transform("SBND_LArSoft", "BNB")
+        np.testing.assert_allclose(T.t, [0.7378, 0.0, 110.0], atol=1e-10)
+
+    def test_convert_origin(self, geo):
+        origin_bnb = geo.convert([0, 0, 0], "ICARUS_LArSoft", "BNB")
+        np.testing.assert_allclose(origin_bnb, [0.0, 0.0, 600.0], atol=1e-10)
+
+    def test_detector_center(self, geo):
+        c = geo.detector_center("ICARUS", "BNB")
+        assert abs(c[2] - 600.0) < 1.0
+
+    def test_numi_transform_has_rotation(self, geo):
+        T = geo.transform("NuMI", "BNB")
+        assert not np.allclose(T.R, np.eye(3), atol=1e-3)
+
+
+# ======================================================================
+# GDML placement convention: passive rotation (M^T applied)
+# ======================================================================
+
+class TestGDMLPlacementConvention:
+    """Verify that gdml_rotation_angles produces angles for the GDML passive
+    convention: SIREN applies r_parent = M^T @ r_child + position.
+
+    For a child volume in frame S placed in parent frame P, the GDML rotation
+    matrix M must satisfy M^T = R_child_to_parent, i.e. M = R_parent_to_child.
+    """
+
+    def test_numi_placement_roundtrip(self, geo):
+        """NuMI GDML placed in BNB frame: M^T should equal R(NuMI->BNB)."""
+        from siren.math import Quaternion
+        T = geo.transform("NuMI", "BNB")
+        # GDML angles should encode M = R(NuMI->BNB)^T = R(BNB->NuMI)
+        rx, ry, rz = geo.gdml_rotation_angles(T.R.T)
+        M = _reconstruct_matrix(rx, ry, rz)
+        # SIREN applies M^T, which should equal R(NuMI->BNB)
+        np.testing.assert_allclose(M.T, T.R, atol=1e-9)
+
+    def test_identity_placement(self, geo):
+        """Pure translation (ICARUS/SBND) should give zero angles."""
+        R_identity = np.eye(3)
+        rx, ry, rz = geo.gdml_rotation_angles(R_identity.T)
+        assert abs(rx) < 1e-15
+        assert abs(ry) < 1e-15
+        assert abs(rz) < 1e-15
+
+    @pytest.mark.parametrize("seed", range(5))
+    def test_random_placement(self, geo, seed):
+        """For any rotation R(child->parent), GDML angles of R^T should
+        reconstruct M such that M^T = R."""
+        rng = np.random.RandomState(seed + 100)
+        M = rng.randn(3, 3)
+        R_child_to_parent, _ = np.linalg.qr(M)
+        if np.linalg.det(R_child_to_parent) < 0:
+            R_child_to_parent[:, 0] *= -1
+        rx, ry, rz = geo.gdml_rotation_angles(R_child_to_parent.T)
+        M_gdml = _reconstruct_matrix(rx, ry, rz)
+        np.testing.assert_allclose(M_gdml.T, R_child_to_parent, atol=1e-14)

--- a/tests/python/test_sbn_loader_offline.py
+++ b/tests/python/test_sbn_loader_offline.py
@@ -1,0 +1,442 @@
+"""Offline fixtures for the SBN detector loader.
+
+These tests exercise detector.py and sbn_loader.py with tiny local GDML files
+pre-seeded at the same relative paths as the downloadable SBN data.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from siren.detector import DetectorPosition, GeometryPosition
+from siren.math import Vector3D
+
+LAR_DENSITY = 1.39
+
+_SBN_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "resources", "detectors",
+    "SBN", "SBN-v1")
+
+
+@pytest.fixture
+def sbn_detector_module():
+    module_names = ("sbn_detector_offline",
+                     "siren._sbn.sbn_geometry", "siren._sbn.sbn_loader",
+                     "siren._sbn.earth_model")
+    previous_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "sbn_detector_offline", os.path.join(_SBN_DIR, "detector.py"))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        for name, module in previous_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+
+
+def _material_block(name, density):
+    return f"""\
+    <isotope N="14" Z="7" name="{name}_N14">
+      <atom unit="g/mole" value="14"/>
+    </isotope>
+    <element name="{name}_N">
+      <fraction n="1.0" ref="{name}_N14"/>
+    </element>
+    <material name="{name}" state="gas">
+      <D value="{density}" unit="g/cm3"/>
+      <fraction n="1.0" ref="{name}_N"/>
+    </material>"""
+
+
+def _beamline_fixture_gdml(prefix, material):
+    return f"""\
+<?xml version="1.0"?>
+<gdml>
+  <define/>
+  <materials>
+{_material_block(material, 0.001225)}
+  </materials>
+  <solids>
+    <box name="{prefix}_world_box" lunit="m" x="10" y="10" z="10"/>
+  </solids>
+  <structure>
+    <volume name="{prefix}_world">
+      <materialref ref="{material}"/>
+      <solidref ref="{prefix}_world_box"/>
+    </volume>
+  </structure>
+  <setup name="Default" version="1.0">
+    <world ref="{prefix}_world"/>
+  </setup>
+</gdml>
+"""
+
+
+def _detector_fixture_gdml(prefix):
+    return f"""\
+<?xml version="1.0"?>
+<gdml>
+  <define/>
+  <materials>
+    <isotope N="40" Z="18" name="{prefix}_Ar40">
+      <atom unit="g/mole" value="39.95"/>
+    </isotope>
+    <element name="{prefix}_Ar">
+      <fraction n="1.0" ref="{prefix}_Ar40"/>
+    </element>
+    <material name="{prefix}_LAr" state="liquid">
+      <D value="{LAR_DENSITY}" unit="g/cm3"/>
+      <fraction n="1.0" ref="{prefix}_Ar"/>
+    </material>
+    <isotope N="14" Z="7" name="{prefix}_N14">
+      <atom unit="g/mole" value="14"/>
+    </isotope>
+    <element name="{prefix}_N">
+      <fraction n="1.0" ref="{prefix}_N14"/>
+    </element>
+    <material name="{prefix}_Air" state="gas">
+      <D value="0.001225" unit="g/cm3"/>
+      <fraction n="1.0" ref="{prefix}_N"/>
+    </material>
+  </materials>
+  <solids>
+    <box name="{prefix}_world_box" lunit="m" x="40" y="40" z="40"/>
+    <box name="{prefix}_lar_box" lunit="m" x="10" y="10" z="10"/>
+  </solids>
+  <structure>
+    <volume name="{prefix}_lar">
+      <materialref ref="{prefix}_LAr"/>
+      <solidref ref="{prefix}_lar_box"/>
+    </volume>
+    <volume name="{prefix}_world">
+      <materialref ref="{prefix}_Air"/>
+      <solidref ref="{prefix}_world_box"/>
+      <physvol name="pv_{prefix}_lar">
+        <volumeref ref="{prefix}_lar"/>
+        <position unit="m" x="0" y="0" z="0"/>
+      </physvol>
+    </volume>
+  </structure>
+  <setup name="Default" version="1.0">
+    <world ref="{prefix}_world"/>
+  </setup>
+</gdml>
+"""
+
+
+def _write_fixture_file(root, rel_path, content):
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+@pytest.fixture
+def offline_sbn_cache(tmp_path):
+    _write_fixture_file(
+        tmp_path, "gdml/BooNE_50m.gdml",
+        _beamline_fixture_gdml("bnb_fixture", "BNBFixtureAir"))
+    _write_fixture_file(
+        tmp_path, "gdml/numi_g4export_2026-05-19.gdml",
+        _beamline_fixture_gdml("numi_fixture", "NuMIFixtureAir"))
+    _write_fixture_file(
+        tmp_path, "gdml/icarus_refactored_nounderscore_20230918_nowires.gdml",
+        _detector_fixture_gdml("icarus_fixture"))
+    _write_fixture_file(
+        tmp_path, "gdml/sbnd_v02_06.gdml",
+        _detector_fixture_gdml("sbnd_fixture"))
+    return tmp_path
+
+
+def _forbid_download(*args, **kwargs):
+    raise AssertionError("offline SBN fixture test attempted a network download")
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS", "SBND"])
+def test_load_detector_with_preseeded_gdml_offline(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    import siren.download as download
+
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name)
+    rho = model.GetMassDensity(DetectorPosition(Vector3D(0, 0, 0)))
+    assert abs(rho - LAR_DENSITY) < 1e-12
+
+    geo = sbn_detector_module.geo
+    transform = geo.detector_transform(detector_name, "BNB")
+    expected_origin = transform.apply(geo.DETECTORS[detector_name].center_native)
+    actual_origin = model.GetDetectorOrigin().get()
+    np.testing.assert_allclose(
+        [actual_origin.GetX(), actual_origin.GetY(), actual_origin.GetZ()],
+        expected_origin,
+        atol=1e-12)
+
+    composite = offline_sbn_cache / f"composite_{detector_name.lower()}.gdml"
+    assert composite.is_file()
+
+
+def test_fetch_data_uses_preseeded_gdml_offline(
+        sbn_detector_module, offline_sbn_cache, monkeypatch):
+    import siren.download as download
+
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    sbn_detector_module.fetch_data()
+
+
+def test_public_load_detector_with_preseeded_gdml_offline(
+        offline_sbn_cache, monkeypatch):
+    import siren.download as download
+    from siren import _util
+
+    resources_root = os.path.abspath(os.path.join(_SBN_DIR, "..", "..", ".."))
+    module_names = ("siren-detector-SBN",
+                     "siren._sbn.sbn_geometry", "siren._sbn.sbn_loader",
+                     "siren._sbn.earth_model")
+    previous_modules = {name: sys.modules.pop(name, None) for name in module_names}
+
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(download, "writable_data_dir", lambda module_dir: str(offline_sbn_cache))
+    monkeypatch.setattr(_util, "resource_package_dir", lambda: resources_root)
+
+    try:
+        model = _util.load_detector("SBN", detector="ICARUS")
+        rho = model.GetMassDensity(DetectorPosition(Vector3D(0, 0, 0)))
+        assert abs(rho - LAR_DENSITY) < 1e-12
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+        for name, module in previous_modules.items():
+            if module is not None:
+                sys.modules[name] = module
+
+
+# ---------------------------------------------------------------------------
+# Earth model integration tests
+# ---------------------------------------------------------------------------
+
+def _geo_density(model, x, y, z):
+    """Get mass density at a point given in BNB (geometry) coordinates."""
+    gp = GeometryPosition(Vector3D(x, y, z))
+    dp = model.GeoPositionToDetPosition(gp)
+    return model.GetMassDensity(dp)
+
+
+def _geo_sector_name(model, x, y, z):
+    """Get containing sector name at a point in BNB (geometry) coordinates."""
+    gp = GeometryPosition(Vector3D(x, y, z))
+    dp = model.GeoPositionToDetPosition(gp)
+    return model.GetContainingSector(dp).name
+
+
+def _load_earth_constants():
+    """Import earth_model module constants without full load."""
+    import importlib.util as ilu
+    spec = ilu.spec_from_file_location(
+        "earth_model_consts", os.path.join(_SBN_DIR, "earth_model.py"))
+    mod = ilu.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_earth_model_sector_count(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """The loaded model should have PREM + atmosphere sectors alongside GDML."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    sectors = model.Sectors
+    names = [s.name for s in sectors]
+
+    earth = _load_earth_constants()
+    expected_earth_count = len(earth._PREM_LAYERS) + len(earth._ATMO_LAYERS)
+    earth_names = [name for name, *_ in earth._all_layers()]
+    for en in earth_names:
+        assert en in names, f"Missing earth sector: {en}"
+
+    assert len(sectors) > expected_earth_count
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_detector_center_is_lar(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Detector origin (0,0,0 in detector coords) should still be LAr."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    rho = model.GetMassDensity(DetectorPosition(Vector3D(0, 0, 0)))
+    assert abs(rho - LAR_DENSITY) < 1e-12
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_atmosphere_column_depth(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Vertical column depth through atmosphere should be ~1030 g/cm2."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    earth = _load_earth_constants()
+
+    column_depth = 0.0
+    for h1, h2 in earth._ATMO_SHELL_ALTS:
+        avg_rho = earth._atmo_avg_density(h1, h2)
+        thickness_cm = (h2 - h1) * 100.0
+        column_depth += avg_rho * thickness_cm
+
+    assert 980 < column_depth < 1080, f"Column depth {column_depth:.1f} g/cm2 out of range"
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_prem_density_upper_crust(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Upper crust density should be 2.6 g/cm3 (PREM constant layer)."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    earth = _load_earth_constants()
+
+    r_crust = earth.R_PREM - 5000.0
+    y_bnb = r_crust - (earth.R_PREM - earth._GRADE_Y_BNB)
+
+    rho = _geo_density(model, 0, y_bnb, 0)
+    assert abs(rho - 2.6) < 0.01, f"Upper crust density {rho} != 2.6"
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_prem_density_upper_mantle(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Upper mantle (just below local Moho) should follow PREM polynomial."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    earth = _load_earth_constants()
+
+    r_mantle = earth.R_PREM - earth._LOCAL_MOHO_DEPTH - 1000.0
+    y_bnb = r_mantle - (earth.R_PREM - earth._GRADE_Y_BNB)
+
+    rho = _geo_density(model, 0, y_bnb, 0)
+    coeffs = [2.691, 1.08679956050855438e-07]
+    expected = coeffs[0] + coeffs[1] * r_mantle
+    assert abs(rho - expected) < 0.01, f"Mantle density {rho} vs expected {expected}"
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_local_moho_at_45km(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Near Fermilab, the local Moho correction should place the
+    crust/mantle boundary at 45 km (CRUST1.0), not PREM's 24.4 km."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    earth = _load_earth_constants()
+
+    # 30 km depth: between PREM Moho (24.4 km) and local Moho (45 km).
+    # Should be ROCK thanks to the local correction.
+    r_30 = earth.R_PREM - 30000.0
+    y_30 = r_30 - (earth.R_PREM - earth._GRADE_Y_BNB)
+    sector_30 = _geo_sector_name(model, 0, y_30, 0)
+    assert sector_30 == "local_thick_crust", \
+        f"30 km depth near Fermilab should be local_thick_crust, got {sector_30}"
+
+    # 44 km depth: still above local Moho -> local_thick_crust
+    r_44 = earth.R_PREM - 44000.0
+    y_44 = r_44 - (earth.R_PREM - earth._GRADE_Y_BNB)
+    sector_44 = _geo_sector_name(model, 0, y_44, 0)
+    assert sector_44 == "local_thick_crust", \
+        f"44 km depth near Fermilab should be local_thick_crust, got {sector_44}"
+
+    # 46 km depth: below local Moho -> PREM mantle
+    r_46 = earth.R_PREM - 46000.0
+    y_46 = r_46 - (earth.R_PREM - earth._GRADE_Y_BNB)
+    sector_46 = _geo_sector_name(model, 0, y_46, 0)
+    assert sector_46 == "moho_boundary", \
+        f"46 km depth near Fermilab should be moho_boundary, got {sector_46}"
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_prem_moho_far_from_fermilab(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Far from Fermilab (beyond the theta cap), the standard PREM Moho
+    at 24.4 km should apply -- 30 km depth should be mantle, not crust."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    earth = _load_earth_constants()
+
+    # A point at 30 km depth, 2500 km arc distance from Fermilab.
+    # This is outside the local correction theta cap (0.3 rad ~ 1900 km).
+    r = earth.R_PREM - 30000.0
+    import math
+    alpha = 2500000.0 / earth.R_PREM
+    x = r * math.sin(alpha)
+    y = r * math.cos(alpha) - (earth.R_PREM - earth._GRADE_Y_BNB)
+    sector = _geo_sector_name(model, x, y, 0)
+    assert sector == "moho_boundary", \
+        f"30 km depth at 2500 km from Fermilab should be PREM mantle, got {sector}"
+
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_innercore_density(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """Inner core (Earth center) density should be ~13 g/cm3."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=True)
+    earth = _load_earth_constants()
+
+    y_center = -(earth.R_PREM - earth._GRADE_Y_BNB)
+    rho = _geo_density(model, 0, y_center, 0)
+    assert 12.5 < rho < 14.0, f"Inner core density {rho} not in [12.5, 14.0]"
+
+
+# ---------------------------------------------------------------------------
+# earth_model=False (beam-only) tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("detector_name", ["ICARUS"])
+def test_load_without_earth_model(
+        sbn_detector_module, offline_sbn_cache, monkeypatch, detector_name):
+    """With earth_model=False, the model should load without PREM sectors."""
+    import siren.download as download
+    monkeypatch.setattr(download, "download_file", _forbid_download)
+    monkeypatch.setattr(sbn_detector_module, "_ABS_DIR", str(offline_sbn_cache))
+
+    model = sbn_detector_module.load_detector(detector_name, earth_model=False)
+
+    # Detector center should still be LAr
+    rho = model.GetMassDensity(DetectorPosition(Vector3D(0, 0, 0)))
+    assert abs(rho - LAR_DENSITY) < 1e-12
+
+    # There should be no PREM sectors
+    sector_names = [s.name for s in model.Sectors]
+    earth = _load_earth_constants()
+    for layer_name, *_ in earth._all_layers():
+        assert layer_name not in sector_names, \
+            f"earth_model=False should not have sector {layer_name}"
+    assert "local_thick_crust" not in sector_names

--- a/tests/python/test_sbn_real_geometry.py
+++ b/tests/python/test_sbn_real_geometry.py
@@ -1,0 +1,309 @@
+"""End-to-end test with real detector GDML: gold nugget in LAr.
+
+Uses the actual SBN detector loader infrastructure (sbn_loader,
+sbn_geometry, detector.py constants) to build a composite GDML with
+the real detector geometry plus a 1cm gold cube, then verifies:
+  - Gold found at the expected position via DetectorCoordinates
+  - Gold found via BNB (GeometryCoordinates)
+  - Gold found via NuMI coordinates
+  - LAr (not air/rock/steel) found 2cm away in every direction
+  - DetectorPosition(0,0,0) maps to the LAr volume center
+  - All coordinate transforms are consistent across frames
+
+Requires --run-network to download GDML files (~5 MB total).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+from siren.detector import DetectorModel, DetectorPosition, GeometryPosition
+from siren.math import Quaternion, Vector3D, Matrix3D
+
+pytestmark = pytest.mark.network
+
+GOLD_DENSITY = 19.3
+LAR_DENSITY = 1.39
+GOLD_SIZE_M = 0.01
+
+_SBN_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "resources", "detectors",
+    "SBN", "SBN-v1")
+
+
+def _load_sbn_module(name, filename):
+    fqn = f"siren._sbn.{name}"
+    path = os.path.join(_SBN_DIR, filename)
+    spec = importlib.util.spec_from_file_location(fqn, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[fqn] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def sbn():
+    """Load the three SBN modules (geo, sbn_loader, detector) as a bundle."""
+    module_names = [
+        "siren._sbn.sbn_geometry",
+        "siren._sbn.sbn_loader",
+        "siren._sbn.sbn_detector",
+    ]
+    previous = {n: sys.modules.get(n) for n in module_names}
+    geo = _load_sbn_module("sbn_geometry", "sbn_geometry.py")
+    loader = _load_sbn_module("sbn_loader", "sbn_loader.py")
+    det = _load_sbn_module("sbn_detector", "detector.py")
+    yield geo, loader, det
+    for n in module_names:
+        sys.modules.pop(n, None)
+        if previous[n] is not None:
+            sys.modules[n] = previous[n]
+
+
+def _gold_gdml():
+    return f"""\
+<?xml version="1.0"?>
+<gdml><define/><materials>
+<isotope N="197" Z="79" name="Au197"><atom unit="g/mole" value="196.967"/></isotope>
+<element name="Gold"><fraction n="1.0" ref="Au197"/></element>
+<material name="GoldMetal" state="solid">
+  <D value="{GOLD_DENSITY}" unit="g/cm3"/><fraction n="1.0" ref="Gold"/>
+</material>
+</materials>
+<solids><box name="gold_box" lunit="m" x="{GOLD_SIZE_M}" y="{GOLD_SIZE_M}" z="{GOLD_SIZE_M}"/></solids>
+<structure>
+<volume name="vol_gold"><materialref ref="GoldMetal"/><solidref ref="gold_box"/></volume>
+</structure>
+<setup name="Default" version="1.0"><world ref="vol_gold"/></setup>
+</gdml>"""
+
+
+def _build_model_with_gold(sbn, detector_name, gold_pos_larsoft, tmpdir):
+    """Build a detector model with a gold nugget, using the same integration
+    path as detector.py:load_detector but with an extra gold physvol.
+
+    Uses the real _beamline_sources(), _DETECTOR_SPECS, and sbn_loader from
+    the detector module, plus the same DetectorOrigin/Rotation logic.
+    """
+    geo, loader, det = sbn
+
+    spec = det._DETECTOR_SPECS[detector_name]
+    T_det_to_bnb = geo.detector_transform(detector_name, "BNB")
+    origin_bnb = T_det_to_bnb.t
+    det_quat = Quaternion()
+    det_quat.SetMatrix(Matrix3D(*T_det_to_bnb.R.flatten()))
+
+    det_rotation = None
+    is_rotated = (abs(det_quat.X) > 1e-12
+                  or abs(det_quat.Y) > 1e-12
+                  or abs(det_quat.Z) > 1e-12)
+    if is_rotated:
+        rx, ry, rz = geo.gdml_rotation_angles(T_det_to_bnb.R.T)
+        det_rotation = (rx, ry, rz)
+
+    # Same sources as load_detector
+    sources = list(det._beamline_sources())
+    if spec["file"] is not None:
+        sources.append({
+            "file": spec["file"],
+            "prefix": spec["prefix"],
+            "position": tuple(origin_bnb),
+            "rotation": det_rotation,
+            "unwrap": spec["unwrap"],
+            "url": spec.get("url"),
+            "sha256": spec.get("sha256", ""),
+        })
+
+    # Add a gold nugget physvol at the gold position in BNB coords
+    gold_pos_bnb = T_det_to_bnb.apply(gold_pos_larsoft)
+    gold_gdml_path = os.path.join(tmpdir, "gold.gdml")
+    with open(gold_gdml_path, "w") as f:
+        f.write(_gold_gdml())
+    sources.append({
+        "file": "gold.gdml",
+        "prefix": "gold",
+        "position": tuple(gold_pos_bnb),
+        "rotation": None,
+        "unwrap": False,
+    })
+
+    cache_name = f"composite_{detector_name.lower()}_gold.gdml"
+    cache_path = loader.build_composite(tmpdir, sources, cache_name)
+
+    dm = DetectorModel()
+    dm.LoadGDML(cache_path)
+
+    # Same DetectorOrigin/Rotation as load_detector
+    det_info = geo.DETECTORS[detector_name]
+    det_center_bnb = T_det_to_bnb.apply(det_info.center_native)
+    dm.DetectorOrigin = GeometryPosition(
+        Vector3D(det_center_bnb[0], det_center_bnb[1], det_center_bnb[2]))
+    dm.DetectorRotation = det_quat
+
+    return dm, det_info.center_native
+
+
+def _vec(v):
+    if hasattr(v, 'get'):
+        v = v.get()
+    return np.array([v.GetX(), v.GetY(), v.GetZ()])
+
+
+# ======================================================================
+# ICARUS
+# ======================================================================
+
+# ICARUS center is all LAr (verified by probing the real GDML)
+ICARUS_GOLD_POS = np.array([0.0, -0.202, 0.0])
+
+
+@pytest.fixture(scope="module")
+def icarus_model(sbn, tmp_path_factory):
+    tmpdir = str(tmp_path_factory.mktemp("icarus"))
+    return _build_model_with_gold(sbn, "ICARUS", ICARUS_GOLD_POS, tmpdir)
+
+
+class TestICARUSGold:
+
+    def test_gold_in_det_coords(self, icarus_model):
+        dm, center = icarus_model
+        gold_det = ICARUS_GOLD_POS - center
+        rho = dm.GetMassDensity(DetectorPosition(Vector3D(*gold_det)))
+        assert abs(rho - GOLD_DENSITY) < 0.5
+
+    def test_lar_2cm_away_all_directions(self, icarus_model):
+        dm, center = icarus_model
+        gold_det = ICARUS_GOLD_POS - center
+        for axis in range(3):
+            for sign in [-1, 1]:
+                offset = np.zeros(3)
+                offset[axis] = sign * 0.02
+                rho = dm.GetMassDensity(
+                    DetectorPosition(Vector3D(*(gold_det + offset))))
+                label = "xyz"[axis]
+                assert abs(rho - LAR_DENSITY) < 0.01, (
+                    f"Expected LAr at {label}{'+' if sign > 0 else '-'}2cm, "
+                    f"got {rho:.4f}")
+
+    def test_gold_via_bnb(self, icarus_model, sbn):
+        dm, _ = icarus_model
+        geo = sbn[0]
+        gold_bnb = geo.transform("ICARUS_LArSoft", "BNB").apply(ICARUS_GOLD_POS)
+        p_det = dm.GeoPositionToDetPosition(GeometryPosition(Vector3D(*gold_bnb)))
+        rho = dm.GetMassDensity(p_det)
+        assert abs(rho - GOLD_DENSITY) < 0.5
+
+    def test_gold_via_numi(self, icarus_model, sbn):
+        dm, _ = icarus_model
+        geo = sbn[0]
+        gold_numi = geo.transform("ICARUS_LArSoft", "NuMI").apply(ICARUS_GOLD_POS)
+        gold_bnb = geo.transform("NuMI", "BNB").apply(gold_numi)
+        p_det = dm.GeoPositionToDetPosition(GeometryPosition(Vector3D(*gold_bnb)))
+        rho = dm.GetMassDensity(p_det)
+        assert abs(rho - GOLD_DENSITY) < 0.5
+
+    def test_det_to_geo_matches_frame_graph(self, icarus_model, sbn):
+        dm, center = icarus_model
+        geo = sbn[0]
+        gold_det = ICARUS_GOLD_POS - center
+        expected_bnb = geo.transform("ICARUS_LArSoft", "BNB").apply(ICARUS_GOLD_POS)
+        actual_bnb = _vec(dm.DetPositionToGeoPosition(
+            DetectorPosition(Vector3D(*gold_det))))
+        np.testing.assert_allclose(actual_bnb, expected_bnb, atol=1e-10)
+
+    def test_detector_origin_is_in_lar(self, icarus_model):
+        """A point near DetectorPosition(0,0,0) should be in LAr."""
+        dm, _ = icarus_model
+        for dx in [-0.1, 0.1]:
+            rho = dm.GetMassDensity(DetectorPosition(Vector3D(dx, 0, 0)))
+            assert abs(rho - LAR_DENSITY) < 0.01, (
+                f"Expected LAr near detector origin (dx={dx}), got {rho:.4f}")
+
+
+# ======================================================================
+# SBND
+# ======================================================================
+
+# SBND LArSoft origin is at the cathode (x=0). Gold placed at x=0.5
+# to be inside the drift volume, away from the cathode.
+SBND_GOLD_POS = np.array([0.5, 0.0, 0.0])
+
+
+@pytest.fixture(scope="module")
+def sbnd_model(sbn, tmp_path_factory):
+    tmpdir = str(tmp_path_factory.mktemp("sbnd"))
+    return _build_model_with_gold(sbn, "SBND", SBND_GOLD_POS, tmpdir)
+
+
+class TestSBNDGold:
+
+    def test_gold_in_det_coords(self, sbnd_model):
+        dm, center = sbnd_model
+        gold_det = SBND_GOLD_POS - center
+        rho = dm.GetMassDensity(DetectorPosition(Vector3D(*gold_det)))
+        assert abs(rho - GOLD_DENSITY) < 0.5
+
+    def test_lar_2cm_away_all_directions(self, sbnd_model):
+        dm, center = sbnd_model
+        gold_det = SBND_GOLD_POS - center
+        for axis in range(3):
+            for sign in [-1, 1]:
+                offset = np.zeros(3)
+                offset[axis] = sign * 0.02
+                rho = dm.GetMassDensity(
+                    DetectorPosition(Vector3D(*(gold_det + offset))))
+                label = "xyz"[axis]
+                assert abs(rho - LAR_DENSITY) < 0.01, (
+                    f"Expected LAr at {label}{'+' if sign > 0 else '-'}2cm, "
+                    f"got {rho:.4f}")
+
+    def test_gold_via_bnb(self, sbnd_model, sbn):
+        dm, _ = sbnd_model
+        geo = sbn[0]
+        gold_bnb = geo.transform("SBND_LArSoft", "BNB").apply(SBND_GOLD_POS)
+        p_det = dm.GeoPositionToDetPosition(GeometryPosition(Vector3D(*gold_bnb)))
+        rho = dm.GetMassDensity(p_det)
+        assert abs(rho - GOLD_DENSITY) < 0.5
+
+    def test_gold_via_numi(self, sbnd_model, sbn):
+        dm, _ = sbnd_model
+        geo = sbn[0]
+        gold_numi = geo.transform("SBND_LArSoft", "NuMI").apply(SBND_GOLD_POS)
+        gold_bnb = geo.transform("NuMI", "BNB").apply(gold_numi)
+        p_det = dm.GeoPositionToDetPosition(GeometryPosition(Vector3D(*gold_bnb)))
+        rho = dm.GetMassDensity(p_det)
+        assert abs(rho - GOLD_DENSITY) < 0.5
+
+    def test_det_to_geo_matches_frame_graph(self, sbnd_model, sbn):
+        dm, center = sbnd_model
+        geo = sbn[0]
+        gold_det = SBND_GOLD_POS - center
+        expected_bnb = geo.transform("SBND_LArSoft", "BNB").apply(SBND_GOLD_POS)
+        actual_bnb = _vec(dm.DetPositionToGeoPosition(
+            DetectorPosition(Vector3D(*gold_det))))
+        np.testing.assert_allclose(actual_bnb, expected_bnb, atol=1e-10)
+
+    def test_detector_origin_is_in_lar(self, sbnd_model):
+        """Points near DetectorPosition(0,0,0) should be in LAr.
+
+        The detector origin is at the LAr volume center. The LAr center
+        sits at x=0 (the cathode) so we offset into one drift volume
+        (x=+0.5m) and check that nearby points are all LAr.
+        """
+        dm, _ = sbnd_model
+        base = np.array([0.5, 0.0, 0.0])
+        for axis in range(3):
+            for sign in [-1, 1]:
+                offset = np.zeros(3)
+                offset[axis] = sign * 0.1
+                rho = dm.GetMassDensity(
+                    DetectorPosition(Vector3D(*(base + offset))))
+                label = "xyz"[axis]
+                assert abs(rho - LAR_DENSITY) < 0.01, (
+                    f"Expected LAr near detector center "
+                    f"({label}{'+' if sign > 0 else '-'}10cm), "
+                    f"got {rho:.4f}")


### PR DESCRIPTION
## Summary

- Compose BNB + NuMI beamline and ICARUS/SBND detector GDML files into a single BNB-frame geometry
- Embed the local geometry in a full PREM Earth model with concentric spherical shells, 6-shell atmosphere (US Standard Atmosphere 1976), and local Moho correction for Midwest crustal thickening (45 km from CRUST1.0 vs PREM 24.4 km global average)
- Correct local geology: glacial till (1.9 g/cm3) over dolomite bedrock (2.6 g/cm3)
- Add earth_model toggle: load_detector("SBN", detector="ICARUS", earth_model=False) for beam-only studies
- Add Python bindings for RadialAxisPolynomialDensityDistribution and RadialAxisExponentialDensityDistribution

Retargeted from PR #139 (which could not be reopened after base branch deletion).

## Test plan

- [x] 13 offline tests covering GDML loading, PREM densities, Moho boundaries, atmosphere column depth, and earth_model toggle
- [x] Network integration test with real GDML downloads (pytest --run-network)