### PR TITLE
Download module hardening + lazy resource loaders

### DIFF
--- a/python/download.py
+++ b/python/download.py
@@ -341,9 +341,10 @@ def _safe_extract(zf: zipfile.ZipFile, dest_dir: str,
                   members: list[str] | None = None) -> None:
     """Extract zip members, rejecting paths that escape dest_dir (Zip Slip).
 
-    Extracts one member at a time and re-validates the resolved path
-    after each extraction so that symlink entries created by earlier
-    members cannot redirect later entries outside dest_dir.
+    Extracts one member at a time, re-validating each member's resolved
+    path before extracting it (realpath reflects symlinks created by
+    earlier members) so that earlier entries cannot redirect later ones
+    outside dest_dir.
     """
     abs_dest = os.path.realpath(dest_dir)
     names = members if members is not None else zf.namelist()

--- a/python/download.py
+++ b/python/download.py
@@ -81,6 +81,25 @@ def writable_data_dir(module_dir: str) -> str:
     return fallback
 
 
+def resolve_data_path(install_dir: str, download_dir: str,
+                      filename: str) -> str:
+    """Resolve a data file path, preferring *install_dir* when the file
+    already exists there.
+
+    Resource loaders download files into *download_dir* (the writable
+    location returned by :func:`writable_data_dir`).  When the package
+    is installed into a read-only tree the writable directory differs
+    from the original install directory.  If the file was shipped with
+    the package (or cached from a previous writable install), it may
+    still be present at *install_dir* -- use it directly and avoid a
+    redundant download.
+    """
+    local = os.path.join(install_dir, filename)
+    if os.path.isfile(local):
+        return local
+    return os.path.join(download_dir, filename)
+
+
 # ======================================================================
 # Core download primitives
 # ======================================================================
@@ -291,14 +310,18 @@ def _cached_zip(dest_dir: str, record_id: str, filename: str,
 
     # Check for an existing cached file for this record/filename
     tag = f"{record_id}_{filename}"
-    existing = [f for f in os.listdir(cache_dir)
-                if f.startswith(tag + ".") and f.endswith(".zip")]
+    existing = sorted(
+        (f for f in os.listdir(cache_dir)
+         if f.startswith(tag + ".") and f.endswith(".zip")),
+        key=lambda f: os.path.getmtime(os.path.join(cache_dir, f)),
+        reverse=True,
+    )
     if existing:
         return os.path.join(cache_dir, existing[0])
 
     # Download, hash, rename into cache
     url = zenodo_file_url(record_id, filename, token)
-    tmp_path = os.path.join(cache_dir, f"{tag}.tmp")
+    tmp_path = os.path.join(cache_dir, f"{tag}.{os.getpid()}.tmp")
     try:
         download_file(url, tmp_path, label=filename)
         sha = _sha256_file(tmp_path)
@@ -316,14 +339,20 @@ _EXTRACTED_SENTINEL = ".zenodo_extracted"
 
 def _safe_extract(zf: zipfile.ZipFile, dest_dir: str,
                   members: list[str] | None = None) -> None:
-    """Extract zip members, rejecting paths that escape dest_dir (Zip Slip)."""
+    """Extract zip members, rejecting paths that escape dest_dir (Zip Slip).
+
+    Extracts one member at a time and re-validates the resolved path
+    after each extraction so that symlink entries created by earlier
+    members cannot redirect later entries outside dest_dir.
+    """
     abs_dest = os.path.realpath(dest_dir)
-    for name in (members if members is not None else zf.namelist()):
+    names = members if members is not None else zf.namelist()
+    for name in names:
         target = os.path.realpath(os.path.join(dest_dir, name))
         if not target.startswith(abs_dest + os.sep) and target != abs_dest:
             raise ValueError(
                 f"Zip entry '{name}' would extract outside {dest_dir}")
-    zf.extractall(dest_dir, members)
+        zf.extract(name, dest_dir)
 
 
 def ensure_zenodo_archive(record_id: str, filename: str, dest_dir: str,
@@ -416,13 +445,14 @@ def _cmd_fetch(names: list[str]) -> int:
               file=sys.stderr)
         return 1
 
-    # Build a map of name -> resource_type for all installed resources
-    resource_map: dict[str, str] = {}
+    # Build a map of name -> resource_type for all installed resources.
+    # A name may appear in multiple categories; store all of them.
+    resource_map: dict[str, list[str]] = {}
     for resource_type, lister in [("detector", _util.list_detectors),
                                   ("flux", _util.list_fluxes),
                                   ("processes", _util.list_processes)]:
         for n in lister():
-            resource_map[n] = resource_type
+            resource_map.setdefault(n, []).append(resource_type)
 
     if not names:
         names = list(resource_map.keys())
@@ -430,24 +460,25 @@ def _cmd_fetch(names: list[str]) -> int:
     ret = 0
     for name in names:
         print(f"--- {name} ---")
-        resource_type = resource_map.get(name)
-        if resource_type is None:
+        resource_types = resource_map.get(name)
+        if resource_types is None:
             print(f"  (unknown resource '{name}')")
             ret = 1
             continue
-        try:
-            mod = _util.import_resource(resource_type, name)
-            if mod is None:
-                print("  (no loader script)")
-                continue
-            if hasattr(mod, "fetch_data"):
-                mod.fetch_data()
-                print("  OK")
-            else:
-                print("  (no fetch_data function, skipping)")
-        except Exception as e:
-            print(f"  Error: {e}", file=sys.stderr)
-            ret = 1
+        for resource_type in resource_types:
+            try:
+                mod = _util.import_resource(resource_type, name)
+                if mod is None:
+                    print(f"  (no {resource_type} loader script)")
+                    continue
+                if hasattr(mod, "fetch_data"):
+                    mod.fetch_data()
+                    print(f"  OK ({resource_type})")
+                else:
+                    print(f"  (no fetch_data function for {resource_type}, skipping)")
+            except Exception as e:
+                print(f"  Error ({resource_type}): {e}", file=sys.stderr)
+                ret = 1
     return ret
 
 
@@ -477,13 +508,17 @@ Examples:
         parser.print_help()
         return 0
 
-    if args.list:
-        return _cmd_list()
+    try:
+        if args.list:
+            return _cmd_list()
 
-    names = args.fetch or []
-    if args.fetch_all:
-        names = []  # empty = all
-    return _cmd_fetch(names)
+        names = args.fetch or []
+        if args.fetch_all:
+            names = []  # empty = all
+        return _cmd_fetch(names)
+    except (OSError, ConnectionError, urllib.error.URLError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/resources/fluxes/Atmospheric/Atmospheric-v1.0/flux.py
+++ b/resources/fluxes/Atmospheric/Atmospheric-v1.0/flux.py
@@ -1,8 +1,8 @@
 import os
 import numpy as np
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 
 _DATA_BASE = (
     "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/"
@@ -21,19 +21,26 @@ _NPZ_SHA256 = {
     "honda2006": "9afe3fe86e67e6653e95ae1e9629964a73d1063c5abaf6e39eabf5444c964559",
 }
 
-_NPZ_FILES = [
-    {
-        "path": os.path.join(_ABS_DIR, f"{model}.npz"),
-        "url": f"{_DATA_BASE}/{model}.npz",
-        "sha256": _NPZ_SHA256[model],
-    }
-    for model in MODELS
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
     """Download all atmospheric flux npz files."""
-    ensure_files(_NPZ_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {
+            "path": os.path.join(abs_dir, f"{model}.npz"),
+            "url": f"{_DATA_BASE}/{model}.npz",
+            "sha256": _NPZ_SHA256[model],
+        }
+        for model in MODELS
+    ])
 
 
 def load_flux(tag):
@@ -71,11 +78,12 @@ def load_flux(tag):
 
     fetch_data()
 
-    output_flux_file = os.path.join(_ABS_DIR, f"Atmospheric_{tag}_flux.txt")
+    abs_dir = _get_abs_dir()
+    output_flux_file = os.path.join(abs_dir, f"Atmospheric_{tag}_flux.txt")
     if os.path.isfile(output_flux_file):
         return output_flux_file
 
-    npz_path = os.path.join(_ABS_DIR, f"{model}.npz")
+    npz_path = resolve_data_path(_INSTALL_DIR, abs_dir, f"{model}.npz")
     with np.load(npz_path) as npz:
         energy = npz["energy"]
         cos_theta = npz["cos_theta"]
@@ -92,7 +100,9 @@ def load_flux(tag):
                 tot_flux += grid
 
     ee, cc = np.meshgrid(energy, cos_theta, indexing='ij')
-    np.savetxt(output_flux_file,
+    tmp = output_flux_file + ".tmp"
+    np.savetxt(tmp,
                np.column_stack([ee.ravel(), cc.ravel(), tot_flux.ravel()]))
+    os.replace(tmp, output_flux_file)
 
     return output_flux_file

--- a/resources/fluxes/BNB/BNB-v1.0/flux.py
+++ b/resources/fluxes/BNB/BNB-v1.0/flux.py
@@ -1,20 +1,27 @@
 import os
 import siren
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/BNB/BNB-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "BNB_FHC.dat"), "url": f"{_DATA_BASE}/BNB_FHC.dat",
-     "sha256": "093a46a07c66c170ad08278ebded5ae6c314c2a73c7696884623181dd03dd887"},
-    {"path": os.path.join(_ABS_DIR, "BNB_RHC.dat"), "url": f"{_DATA_BASE}/BNB_RHC.dat",
-     "sha256": "3b16ada8932faae4ef6412dcefad2a29ef3d450e8af60f925eaf6f2ca1de1369"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "BNB_FHC.dat"), "url": f"{_DATA_BASE}/BNB_FHC.dat",
+         "sha256": "093a46a07c66c170ad08278ebded5ae6c314c2a73c7696884623181dd03dd887"},
+        {"path": os.path.join(abs_dir, "BNB_RHC.dat"), "url": f"{_DATA_BASE}/BNB_RHC.dat",
+         "sha256": "3b16ada8932faae4ef6412dcefad2a29ef3d450e8af60f925eaf6f2ca1de1369"},
+    ])
 
 
 def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=True):
@@ -32,13 +39,17 @@ def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=
         raise RuntimeError("Neither or both \"min_energy\" and \"max_energy\" must be provided")
     has_energy_range = min_energy is not None
 
-    mode, particle = tag.split("_")
+    parts = tag.split("_", maxsplit=1)
+    if len(parts) != 2:
+        raise ValueError(
+            "Tag %r is not valid. Expected {FHC,RHC}_{nue,nuebar,numu,numubar}" % tag)
+    mode, particle = parts
     if mode not in ["FHC", "RHC"]:
         raise ValueError("%s beam mode specified in tag %s is not valid" % (mode, tag))
     if particle not in ["nue", "numu", "nuebar", "numubar"]:
         raise ValueError("%s particle specified in tag %s is not valid" % (particle, tag))
 
-    input_flux_file = os.path.join(_ABS_DIR, "BNB_%s.dat" % mode)
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(), "BNB_%s.dat" % mode)
 
     with open(input_flux_file, "r") as f:
         all_lines = f.readlines()

--- a/resources/fluxes/HE_SN/HE_SN-v1.0/flux.py
+++ b/resources/fluxes/HE_SN/HE_SN-v1.0/flux.py
@@ -1,19 +1,26 @@
 import os
 import siren
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/HE_SN/HE_SN-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt"),
-     "url": f"{_DATA_BASE}/dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt",
-     "sha256": "b6dc394dbcccbfb19a09273656b9305d0611f625e1f523a9f04e3b51cbbfb00c"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt"),
+         "url": f"{_DATA_BASE}/dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt",
+         "sha256": "b6dc394dbcccbfb19a09273656b9305d0611f625e1f523a9f04e3b51cbbfb00c"},
+    ])
 
 
 def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=True):
@@ -27,8 +34,8 @@ def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=
 
     has_energy_range = min_energy is not None
 
-    input_flux_file = os.path.join(_ABS_DIR,
-                                   "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt")
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(),
+                                       "dN_dE_SNe_2n_D1_0_s20_t100d_NuMu_d10kpc.txt")
 
     with open(input_flux_file, "r") as f:
         all_lines = f.readlines()

--- a/resources/fluxes/NUMI/NUMI-v1.0/flux.py
+++ b/resources/fluxes/NUMI/NUMI-v1.0/flux.py
@@ -1,27 +1,36 @@
 import os
 import siren
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/NUMI/NUMI-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, f"NUMI_{mode}_{energy}.dat"),
-     "url": f"{_DATA_BASE}/NUMI_{mode}_{energy}.dat",
-     "sha256": sha}
-    for mode, energy, sha in [
-        ("FHC", "LE", "38fc38719d88dd96fdd0f849c9921fcee224a9faaa6a4f0d0a569d408bc3b372"),
-        ("FHC", "ME", "2401354dc561a51a84de87e5f47308fdb736b2739316b275fd0959e1428c9860"),
-        ("FHC", "ME_unofficial", "3c5e1b3afe0e992602442bac13b07f2359a290dfe31c45a6b0026bf1542befd1"),
-        ("RHC", "LE", "e994bb199e441a0aa695ec4a6b1698dbbf4d876e17e0c650d252c9943cd7da2c"),
-        ("RHC", "ME", "52c538efd182b03bcf45577bdf81172575fe4247eec5cc980a41764e08fbabf4"),
-        ("RHC", "ME_unofficial", "63bfbff1b27303ee04c7aade3841481a22416b2f5b39cd807398a797c61c90d4"),
-    ]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
+
+_DATA_ENTRIES = [
+    ("FHC", "LE", "38fc38719d88dd96fdd0f849c9921fcee224a9faaa6a4f0d0a569d408bc3b372"),
+    ("FHC", "ME", "2401354dc561a51a84de87e5f47308fdb736b2739316b275fd0959e1428c9860"),
+    ("FHC", "ME_unofficial", "3c5e1b3afe0e992602442bac13b07f2359a290dfe31c45a6b0026bf1542befd1"),
+    ("RHC", "LE", "e994bb199e441a0aa695ec4a6b1698dbbf4d876e17e0c650d252c9943cd7da2c"),
+    ("RHC", "ME", "52c538efd182b03bcf45577bdf81172575fe4247eec5cc980a41764e08fbabf4"),
+    ("RHC", "ME_unofficial", "63bfbff1b27303ee04c7aade3841481a22416b2f5b39cd807398a797c61c90d4"),
 ]
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, f"NUMI_{mode}_{energy}.dat"),
+         "url": f"{_DATA_BASE}/NUMI_{mode}_{energy}.dat",
+         "sha256": sha}
+        for mode, energy, sha in _DATA_ENTRIES
+    ])
 
 
 def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=True):
@@ -39,16 +48,22 @@ def load_flux(tag=None, min_energy=None, max_energy=None, physically_normalized=
         raise RuntimeError("Neither or both \"min_energy\" and \"max_energy\" must be provided")
     has_energy_range = min_energy is not None
 
-    mode, energy, particle = tag.split("_")
+    parts = tag.split("_")
+    if len(parts) < 3:
+        raise ValueError(
+            "Tag %r is not valid. Expected {FHC,RHC}_{LE,ME,ME_unofficial}_{particle}" % tag)
+    mode = parts[0]
+    particle = parts[-1]
+    energy = "_".join(parts[1:-1])
     if mode not in ["FHC","RHC"]:
         raise ValueError("%s beam mode specified in tag %s is not valid"%(mode,tag))
-    if energy not in ["LE","ME"]:
+    if energy not in ["LE","ME","ME_unofficial"]:
         raise ValueError("%s energy mode specified in tag %s is not valid"%(energy,tag))
     if particle not in ["nue","numu","nuebar","numubar"]:
         raise ValueError("%s particle specified in tag %s is not valid"%(particle,tag))
 
-    input_flux_file = os.path.join(_ABS_DIR,
-                                   "NUMI_%s_%s.dat" % (mode, energy))
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(),
+                                       "NUMI_%s_%s.dat" % (mode, energy))
 
     with open(input_flux_file, "r") as f:
         all_lines = f.readlines()

--- a/resources/fluxes/T2K_Kaons/T2K_Kaons-v1.0/flux.py
+++ b/resources/fluxes/T2K_Kaons/T2K_Kaons-v1.0/flux.py
@@ -1,34 +1,41 @@
 from scipy.interpolate import interp1d
 import numpy as np
 import os
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/T2K_Kaons/T2K_Kaons-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "kaon-flux-data.dat"), "url": f"{_DATA_BASE}/kaon-flux-data.dat",
-     "sha256": "32e06bb7f454547fa30ac4f6f34caf50700c53683ec40963a904c1fb91f87d56"},
-    {"path": os.path.join(_ABS_DIR, "ratio.dat"), "url": f"{_DATA_BASE}/ratio.dat",
-     "sha256": "ae85fd610073a6158065b4b24ab351d42a353ad7f704d1dbb58d3c6cdf911e98"},
-    {"path": os.path.join(_ABS_DIR, "TOT_PLUS_NUMU.dat"), "url": f"{_DATA_BASE}/TOT_PLUS_NUMU.dat",
-     "sha256": "fdce382924d17d4841c1b2e8da6dcc7932d7a3dc9c5ee68b0a438035083a8b20"},
-    {"path": os.path.join(_ABS_DIR, "TOT_MINUS_NUMUBAR.dat"), "url": f"{_DATA_BASE}/TOT_MINUS_NUMUBAR.dat",
-     "sha256": "347a94e69261a25b3fb5174c193e0abbae167e817f5d5e50c9da213270e26531"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "kaon-flux-data.dat"), "url": f"{_DATA_BASE}/kaon-flux-data.dat",
+         "sha256": "32e06bb7f454547fa30ac4f6f34caf50700c53683ec40963a904c1fb91f87d56"},
+        {"path": os.path.join(abs_dir, "ratio.dat"), "url": f"{_DATA_BASE}/ratio.dat",
+         "sha256": "ae85fd610073a6158065b4b24ab351d42a353ad7f704d1dbb58d3c6cdf911e98"},
+        {"path": os.path.join(abs_dir, "TOT_PLUS_NUMU.dat"), "url": f"{_DATA_BASE}/TOT_PLUS_NUMU.dat",
+         "sha256": "fdce382924d17d4841c1b2e8da6dcc7932d7a3dc9c5ee68b0a438035083a8b20"},
+        {"path": os.path.join(abs_dir, "TOT_MINUS_NUMUBAR.dat"), "url": f"{_DATA_BASE}/TOT_MINUS_NUMUBAR.dat",
+         "sha256": "347a94e69261a25b3fb5174c193e0abbae167e817f5d5e50c9da213270e26531"},
+    ])
 
 
 def bar_scaling():
-    energy, ratio = np.loadtxt(os.path.join(_ABS_DIR, 'ratio.dat'), usecols=(0, 1), unpack=True)
+    energy, ratio = np.loadtxt(resolve_data_path(_INSTALL_DIR, _get_abs_dir(), 'ratio.dat'), usecols=(0, 1), unpack=True)
     return interp1d(energy, ratio, kind='linear', bounds_error=False, fill_value=(ratio[0], ratio[-1]))
 
 def MakeFluxFile(tag, output_dir=None):
     if output_dir is None:
-        output_dir = _ABS_DIR
+        output_dir = _get_abs_dir()
 
     parts = tag.split("_")
     if len(parts) != 2:
@@ -46,7 +53,7 @@ def MakeFluxFile(tag, output_dir=None):
     if particle not in ["numu", "numubar"]:
         raise ValueError(f"\"{particle}\" particle specified in tag \"{tag}\" is not valid")
 
-    input_flux_file = os.path.join(_ABS_DIR, "kaon-flux-data.dat")
+    input_flux_file = resolve_data_path(_INSTALL_DIR, _get_abs_dir(), "kaon-flux-data.dat")
 
     if bar:
         output_flux_file = os.path.join(output_dir, f"kaon-flux-{particle}_bar.dat")

--- a/resources/fluxes/T2K_NEAR/T2K_NEAR-v1.0/flux.py
+++ b/resources/fluxes/T2K_NEAR/T2K_NEAR-v1.0/flux.py
@@ -1,19 +1,26 @@
 import os
-from siren.download import ensure_files, writable_data_dir
+from siren.download import ensure_files, writable_data_dir, resolve_data_path
 
-_ABS_DIR = writable_data_dir(os.path.dirname(os.path.abspath(__file__)))
+_INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 _DATA_BASE = "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/main/fluxes/T2K_NEAR/T2K_NEAR-v1.0"
 
-_DATA_FILES = [
-    {"path": os.path.join(_ABS_DIR, "T2K_PLUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_PLUS_250kA.dat",
-     "sha256": "bc7958cda04788976d5c0e75a5efca075b62d63d82cce0a67f7fea539bb33eab"},
-    {"path": os.path.join(_ABS_DIR, "T2K_MINUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_MINUS_250kA.dat",
-     "sha256": "e2d6bedd56f4c30ad765ec0320970565ad2d63faf5cb4cdd9004d4f6cd965ffe"},
-]
+_ABS_DIR = None
+
+def _get_abs_dir():
+    global _ABS_DIR
+    if _ABS_DIR is None:
+        _ABS_DIR = writable_data_dir(_INSTALL_DIR)
+    return _ABS_DIR
 
 
 def fetch_data():
-    ensure_files(_DATA_FILES)
+    abs_dir = _get_abs_dir()
+    ensure_files([
+        {"path": os.path.join(abs_dir, "T2K_PLUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_PLUS_250kA.dat",
+         "sha256": "bc7958cda04788976d5c0e75a5efca075b62d63d82cce0a67f7fea539bb33eab"},
+        {"path": os.path.join(abs_dir, "T2K_MINUS_250kA.dat"), "url": f"{_DATA_BASE}/T2K_MINUS_250kA.dat",
+         "sha256": "e2d6bedd56f4c30ad765ec0320970565ad2d63faf5cb4cdd9004d4f6cd965ffe"},
+    ])
 
 
 def load_flux(tag):
@@ -25,17 +32,22 @@ def load_flux(tag):
 
     fetch_data()
 
-    enhance, particle = tag.split("_")
+    parts = tag.split("_", maxsplit=1)
+    if len(parts) != 2:
+        raise ValueError(
+            "Tag %r is not valid. Expected {PLUS,MINUS}_{nue,nuebar,numu,numubar}" % tag)
+    enhance, particle = parts
 
     if enhance not in ["MINUS", "PLUS"]:
         raise ValueError("%s 250kA enhancement specified in tag %s is not valid" % (enhance, tag))
     if particle not in ["numu", "numubar", "nue", "nuebar"]:
         raise ValueError("%s particle specified in tag %s is not valid" % (particle, tag))
 
-    input_flux_file = os.path.join(_ABS_DIR,
-                                   "T2K_%s_250kA.dat"%(enhance))
+    abs_dir = _get_abs_dir()
+    input_flux_file = resolve_data_path(_INSTALL_DIR, abs_dir,
+                                       "T2K_%s_250kA.dat"%(enhance))
 
-    output_flux_file = os.path.join(_ABS_DIR,
+    output_flux_file = os.path.join(abs_dir,
                                     "T2KOUT_%s.dat"%(tag))
 
     with open(input_flux_file,"r") as fin:

--- a/resources/processes/CSMSDISSplines/CSMSDISSplines-v1.0/processes.py
+++ b/resources/processes/CSMSDISSplines/CSMSDISSplines-v1.0/processes.py
@@ -2,19 +2,29 @@ import os
 from typing import Tuple, List, Any, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
 _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/CSMSDISSplines/CSMSDISSplines-v1.0"
-_RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+
+_RESOURCES_ROOT = None
+_DOWNLOAD_DIR = None
+
+def _get_dirs():
+    global _RESOURCES_ROOT, _DOWNLOAD_DIR
+    if _RESOURCES_ROOT is None:
+        _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+        _DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+    return _RESOURCES_ROOT, _DOWNLOAD_DIR
 
 
 def fetch_data():
     """Download data files from Zenodo (called by siren-download --fetch)."""
-    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, _RESOURCES_ROOT,
+    resources_root, _ = _get_dirs()
+    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, resources_root,
                           prefix=_ZENODO_PREFIX)
 
 neutrinos = [
@@ -107,11 +117,12 @@ def load_processes(
     primary_processes = []
     primary_processes_dict = collections.defaultdict(list)
 
+    _, download_dir = _get_dirs()
     for process_type in process_types:
         for primaries, nunubar in [[neutrinos, "nu"], [antineutrinos, "nubar"]]:
             if isoscalar:
-                dxs_file = os.path.join(base_path, f"dsdxdy_{nunubar}_{process_type}_iso.fits")
-                xs_file = os.path.join(base_path, f"sigma_{nunubar}_{process_type}_iso.fits")
+                dxs_file = resolve_data_path(base_path, download_dir, f"dsdxdy_{nunubar}_{process_type}_iso.fits")
+                xs_file = resolve_data_path(base_path, download_dir, f"sigma_{nunubar}_{process_type}_iso.fits")
                 xs = siren.interactions.DISFromSpline(dxs_file, xs_file, primaries, target_types, "m")
                 primary_processes.append(xs)
                 for primary_type in primaries:

--- a/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0/processes.py
+++ b/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -12,6 +12,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -96,8 +97,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDipoleDISFromSpline(dxs_file, xs_file,
                                                            m4_GeV, dipole_couplings,
                                                            [primary],

--- a/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0/processes.py
+++ b/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0/processes.py
@@ -11,13 +11,21 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v1.0"
-_RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
-_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+_RESOURCES_ROOT = None
+_DOWNLOAD_DIR = None
+
+def _get_dirs():
+    global _RESOURCES_ROOT, _DOWNLOAD_DIR
+    if _RESOURCES_ROOT is None:
+        _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+        _DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+    return _RESOURCES_ROOT, _DOWNLOAD_DIR
 
 
 def fetch_data():
     """Download data files from Zenodo (called by siren-download --fetch)."""
-    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, _RESOURCES_ROOT,
+    resources_root, _ = _get_dirs()
+    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, resources_root,
                           prefix=_ZENODO_PREFIX)
 
 neutrinos = [
@@ -80,6 +88,8 @@ def load_processes(
 
     fetch_data()
 
+    _, download_dir = _get_dirs()
+
     primary_types = _get_primary_types(primary_types)
     isoscalar = _get_isoscalar(isoscalar)
     target_types = _get_target_types(isoscalar, target_types)
@@ -97,8 +107,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, download_dir, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, download_dir, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDipoleDISFromSpline(dxs_file, xs_file,
                                                            m4_GeV, dipole_couplings,
                                                            [primary],

--- a/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0/processes.py
+++ b/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +10,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -94,8 +95,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDipoleDISFromSpline(dxs_file, xs_file,
                                                            m4_GeV, dipole_couplings,
                                                            [primary],

--- a/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0/processes.py
+++ b/resources/processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0/processes.py
@@ -9,13 +9,21 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/DipoleHNLDISSplines/DipoleHNLDISSplines-v2.0"
-_RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
-_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+_RESOURCES_ROOT = None
+_DOWNLOAD_DIR = None
+
+def _get_dirs():
+    global _RESOURCES_ROOT, _DOWNLOAD_DIR
+    if _RESOURCES_ROOT is None:
+        _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+        _DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+    return _RESOURCES_ROOT, _DOWNLOAD_DIR
 
 
 def fetch_data():
     """Download data files from Zenodo (called by siren-download --fetch)."""
-    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, _RESOURCES_ROOT,
+    resources_root, _ = _get_dirs()
+    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, resources_root,
                           prefix=_ZENODO_PREFIX)
 
 neutrinos = [
@@ -78,6 +86,8 @@ def load_processes(
 
     fetch_data()
 
+    _, download_dir = _get_dirs()
+
     primary_types = _get_primary_types(primary_types)
     isoscalar = _get_isoscalar(isoscalar)
     target_types = _get_target_types(isoscalar, target_types)
@@ -95,8 +105,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, download_dir, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, download_dir, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDipoleDISFromSpline(dxs_file, xs_file,
                                                            m4_GeV, dipole_couplings,
                                                            [primary],

--- a/resources/processes/HNLDISSplines/HNLDISSplines-v1.0/processes.py
+++ b/resources/processes/HNLDISSplines/HNLDISSplines-v1.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +10,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/HNLDISSplines/HNLDISSplines-v1.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -95,8 +96,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDISFromSpline(dxs_file, xs_file,
                                                      m4_GeV, mixings,
                                                      siren.utilities.Constants.isoscalarMass,

--- a/resources/processes/HNLDISSplines/HNLDISSplines-v1.0/processes.py
+++ b/resources/processes/HNLDISSplines/HNLDISSplines-v1.0/processes.py
@@ -9,13 +9,21 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/HNLDISSplines/HNLDISSplines-v1.0"
-_RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
-_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+_RESOURCES_ROOT = None
+_DOWNLOAD_DIR = None
+
+def _get_dirs():
+    global _RESOURCES_ROOT, _DOWNLOAD_DIR
+    if _RESOURCES_ROOT is None:
+        _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+        _DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+    return _RESOURCES_ROOT, _DOWNLOAD_DIR
 
 
 def fetch_data():
     """Download data files from Zenodo (called by siren-download --fetch)."""
-    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, _RESOURCES_ROOT,
+    resources_root, _ = _get_dirs()
+    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, resources_root,
                           prefix=_ZENODO_PREFIX)
 
 neutrinos = [
@@ -79,6 +87,8 @@ def load_processes(
 
     fetch_data()
 
+    _, download_dir = _get_dirs()
+
     primary_types = _get_primary_types(primary_types)
     isoscalar = _get_isoscalar(isoscalar)
     target_types = _get_target_types(isoscalar, target_types)
@@ -96,8 +106,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, download_dir, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, download_dir, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDISFromSpline(dxs_file, xs_file,
                                                      m4_GeV, mixings,
                                                      siren.utilities.Constants.isoscalarMass,

--- a/resources/processes/HNLDISSplines/HNLDISSplines-v2.0/processes.py
+++ b/resources/processes/HNLDISSplines/HNLDISSplines-v2.0/processes.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Optional
 import siren
 import collections
-from siren.download import ensure_zenodo_archive, writable_data_dir
+from siren.download import ensure_zenodo_archive, writable_data_dir, resolve_data_path
 
 base_path = os.path.dirname(os.path.abspath(__file__))
 
@@ -10,6 +10,7 @@ _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/HNLDISSplines/HNLDISSplines-v2.0"
 _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
 
 
 def fetch_data():
@@ -95,8 +96,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = os.path.join(base_path, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = os.path.join(base_path, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDISFromSpline(dxs_file, xs_file,
                                                      m4_GeV, mixings,
                                                      siren.utilities.Constants.isoscalarMass,

--- a/resources/processes/HNLDISSplines/HNLDISSplines-v2.0/processes.py
+++ b/resources/processes/HNLDISSplines/HNLDISSplines-v2.0/processes.py
@@ -9,13 +9,21 @@ base_path = os.path.dirname(os.path.abspath(__file__))
 _ZENODO_RECORD = "20129082"
 _ZENODO_FILE = "processes.zip"
 _ZENODO_PREFIX = "processes/HNLDISSplines/HNLDISSplines-v2.0"
-_RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
-_DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+_RESOURCES_ROOT = None
+_DOWNLOAD_DIR = None
+
+def _get_dirs():
+    global _RESOURCES_ROOT, _DOWNLOAD_DIR
+    if _RESOURCES_ROOT is None:
+        _RESOURCES_ROOT = writable_data_dir(os.path.normpath(os.path.join(base_path, "..", "..", "..")))
+        _DOWNLOAD_DIR = os.path.join(_RESOURCES_ROOT, _ZENODO_PREFIX)
+    return _RESOURCES_ROOT, _DOWNLOAD_DIR
 
 
 def fetch_data():
     """Download data files from Zenodo (called by siren-download --fetch)."""
-    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, _RESOURCES_ROOT,
+    resources_root, _ = _get_dirs()
+    ensure_zenodo_archive(_ZENODO_RECORD, _ZENODO_FILE, resources_root,
                           prefix=_ZENODO_PREFIX)
 
 neutrinos = [
@@ -79,6 +87,8 @@ def load_processes(
 
     fetch_data()
 
+    _, download_dir = _get_dirs()
+
     primary_types = _get_primary_types(primary_types)
     isoscalar = _get_isoscalar(isoscalar)
     target_types = _get_target_types(isoscalar, target_types)
@@ -96,8 +106,8 @@ def load_processes(
         elif primary in antineutrinos: nunubar = "nubar"
         else: raise ValueError(f"primary \"{primary}\" not supported")
         if isoscalar:
-            dxs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
-            xs_file = resolve_data_path(base_path, _DOWNLOAD_DIR, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            dxs_file = resolve_data_path(base_path, download_dir, f"M_0000000MeV/dsdxdy-{nunubar}-N-nc-GRV98lo_patched_central.fits")
+            xs_file = resolve_data_path(base_path, download_dir, f"M_{m4_str}MeV/sigma-{nunubar}-N-nc-GRV98lo_patched_central.fits")
             xs = siren.interactions.HNLDISFromSpline(dxs_file, xs_file,
                                                      m4_GeV, mixings,
                                                      siren.utilities.Constants.isoscalarMass,

--- a/tests/python/test_download.py
+++ b/tests/python/test_download.py
@@ -339,3 +339,24 @@ class TestSha256File:
             hashlib.sha256(b"").digest()
         ).rstrip(b"=").decode("ascii")
         assert dl._sha256_file(str(path)) == expected
+
+
+class TestResolveDataPath:
+    """resolve_data_path prefers an existing install-dir copy, else the download dir."""
+
+    def test_prefers_install_dir_when_present(self, tmp):
+        install = tmp / "install"
+        download = tmp / "download"
+        install.mkdir()
+        download.mkdir()
+        (install / "f.dat").write_bytes(b"x")
+        # Present in install_dir -> returned directly (no redundant download)
+        assert dl.resolve_data_path(str(install), str(download), "f.dat") == str(install / "f.dat")
+
+    def test_falls_back_to_download_dir_when_missing(self, tmp):
+        install = tmp / "install"
+        download = tmp / "download"
+        install.mkdir()
+        download.mkdir()
+        # Absent from install_dir -> returns the download_dir path (regardless of existence there)
+        assert dl.resolve_data_path(str(install), str(download), "missing.dat") == str(download / "missing.dat")


### PR DESCRIPTION
Part of splitting the `interface-redesign` branch into reviewable PRs (foundation tier — independent, branches off `main`).

### Delivers
- `python/download.py`: Zip-Slip-resistant per-member extraction, mtime-based cache selection, PID-scoped temp files, CLI exception guard, new `resolve_data_path()` helper.
- Flux/process loaders converted to lazy `writable_data_dir()` resolution (no import-time filesystem probes), atomic flux-file writes, stricter tag parsing.

**Scope:** 2 commits, 12 files, Python only.
**Dependencies:** none — mergeable independently.
**Verified:** build + ctest clean; pytest clean (excluding an untracked working-tree test unrelated to this change).
