### PR TITLE
Align GDML length conventions with Geant4

### DIFF
--- a/projects/detector/private/gdml/GDMLSolidParser.cxx
+++ b/projects/detector/private/gdml/GDMLSolidParser.cxx
@@ -108,11 +108,12 @@ std::shared_ptr<Geometry> BuildBooleanGeometry(BooleanOperation op,
 }
 
 std::shared_ptr<Geometry> ParseBox(SolidContext const & ctx) {
-    // GDML <box> x,y,z are half-widths
-    // SIREN Box constructor takes full widths as arguments
-    double const x_full_width = L(ctx, "x") * 2.0;
-    double const y_full_width = L(ctx, "y") * 2.0;
-    double const z_full_width = L(ctx, "z") * 2.0;
+    // GDML <box> x,y,z are full-widths
+    // SIREN Box constructor takes full widths
+    // Geant4 Box constructor takes half-widths (confirmed their GDML conversion)
+    double const x_full_width = L(ctx, "x");
+    double const y_full_width = L(ctx, "y");
+    double const z_full_width = L(ctx, "z");
     return Box(x_full_width, y_full_width, z_full_width).create();
 }
 
@@ -135,22 +136,28 @@ std::shared_ptr<Geometry> ParseOrb(SolidContext const & ctx) {
 
 std::shared_ptr<Geometry> ParseTube(SolidContext const & ctx) {
     GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
-    // GDML <tube> z is half-height; SIREN Cylinder takes full height.
-    return Cylinder(L(ctx, "rmax"), L(ctx, "rmin"), L(ctx, "z") * 2.0,
+    // GDML <tube> z is full-height
+    // SIREN Cylinder constructor takes full height
+    // Geant4 G4Tubs constructor takes half-height (confirmed their GDML conversion)
+    return Cylinder(L(ctx, "rmax"), L(ctx, "rmin"), L(ctx, "z"),
                     phi.start, phi.delta).create();
 }
 
 std::shared_ptr<Geometry> ParseCone(SolidContext const & ctx) {
     GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
-    // GDML <cone> z is half-height; SIREN Cone takes full height.
+    // GDML <cone> z is full-height
+    // SIREN Cone takes full height
+    // Geant4 G4Cons takes half-height (confirmed their GDML conversion)
     return Cone(L(ctx, "rmin1"), L(ctx, "rmax1"),
                 L(ctx, "rmin2"), L(ctx, "rmax2"),
-                L(ctx, "z") * 2.0, phi.start, phi.delta).create();
+                L(ctx, "z"), phi.start, phi.delta).create();
 }
 
 std::shared_ptr<Geometry> ParseTrd(SolidContext const & ctx) {
-    // GDML <trd> uses half-widths; SIREN Trd also uses half-widths.
-    return Trd(L(ctx, "x1"), L(ctx, "x2"), L(ctx, "y1"), L(ctx, "y2"), L(ctx, "z")).create();
+    // GDML <trd> x1,x2,y1,y2,z are full-lengths; SIREN Trd takes half-lengths.
+    // (Geant4 applies 0.5 in its GDML reader before calling G4Trd.)
+    return Trd(0.5 * L(ctx, "x1"), 0.5 * L(ctx, "x2"),
+               0.5 * L(ctx, "y1"), 0.5 * L(ctx, "y2"), 0.5 * L(ctx, "z")).create();
 }
 
 std::shared_ptr<Geometry> ParsePolycone(SolidContext const & ctx) {
@@ -187,6 +194,12 @@ std::shared_ptr<Geometry> ParsePolyhedra(SolidContext const & ctx) {
         throw std::runtime_error("polyhedra '" + ctx.name + "' has non-monotonic z-planes");
     }
 
+    // GDML <polyhedra> rmin/rmax are tangent (apothem) distances to the flat
+    // sides (Geant4 G4Polyhedra zPlane convention). SIREN's Polyhedra uses the
+    // same apothem convention internally (see Polyhedra.cxx ComputeIntersections
+    // and GetBoundingBox, which scale by 1/cos(half-side) to reach the
+    // circumradius), so the values pass through unchanged -- matching Geant4's
+    // own G4GDMLReadSolids, which also forwards rmin/rmax without conversion.
     return Polyhedra(numSide, phi.start, planes.z, planes.rmin, planes.rmax, phi.delta).create();
 }
 
@@ -236,7 +249,9 @@ std::shared_ptr<Geometry> ParseEllipticalTube(SolidContext const & ctx) {
 std::shared_ptr<Geometry> ParseCutTube(SolidContext const & ctx) {
     double rmin = L(ctx, "rmin");
     double rmax = L(ctx, "rmax");
-    double hz = L(ctx, "z");
+    // GDML <cutTube> z is full-height; SIREN CutTube takes half-height dz.
+    // (Geant4 applies 0.5 in its GDML reader before calling G4CutTubs.)
+    double hz = 0.5 * L(ctx, "z");
     GDMLPhiRange phi = ReadPhiRange(ctx.node, ctx.ascale, ctx.data.constants);
 
     if(rmax <= 0 || hz <= 0) return nullptr;
@@ -247,9 +262,12 @@ std::shared_ptr<Geometry> ParseCutTube(SolidContext const & ctx) {
 }
 
 std::shared_ptr<Geometry> ParseTrap(SolidContext const & ctx) {
-    return Trap(L(ctx, "z"), A(ctx, "theta"), A(ctx, "phi"),
-                L(ctx, "y1"), L(ctx, "x1"), L(ctx, "x2"), A(ctx, "alpha1"),
-                L(ctx, "y2"), L(ctx, "x3"), L(ctx, "x4"), A(ctx, "alpha2")).create();
+    // GDML <trap> z,y1,x1,x2,y2,x3,x4 are full-lengths; SIREN Trap takes
+    // half-lengths. Angles (theta,phi,alpha1,alpha2) are unchanged.
+    // (Geant4 applies 0.5 to the lengths in its GDML reader before G4Trap.)
+    return Trap(0.5 * L(ctx, "z"), A(ctx, "theta"), A(ctx, "phi"),
+                0.5 * L(ctx, "y1"), 0.5 * L(ctx, "x1"), 0.5 * L(ctx, "x2"), A(ctx, "alpha1"),
+                0.5 * L(ctx, "y2"), 0.5 * L(ctx, "x3"), 0.5 * L(ctx, "x4"), A(ctx, "alpha2")).create();
 }
 
 std::shared_ptr<Geometry> ParseEllipsoid(SolidContext const & ctx) {
@@ -269,9 +287,11 @@ std::shared_ptr<Geometry> ParseEllipsoid(SolidContext const & ctx) {
 }
 
 std::shared_ptr<Geometry> ParsePara(SolidContext const & ctx) {
-    double dx = L(ctx, "x");
-    double dy = L(ctx, "y");
-    double dz = L(ctx, "z");
+    // GDML <para> x,y,z are full-lengths; SIREN Para takes half-lengths.
+    // (Geant4 applies 0.5 in its GDML reader before calling G4Para.)
+    double const dx = 0.5 * L(ctx, "x");
+    double const dy = 0.5 * L(ctx, "y");
+    double const dz = 0.5 * L(ctx, "z");
     if(dx <= 0 || dy <= 0 || dz <= 0) return nullptr;
 
     return Para(dx, dy, dz, A(ctx, "alpha"), A(ctx, "theta"), A(ctx, "phi")).create();

--- a/projects/detector/private/test/gdml/GDMLParserBooleans_TEST.inc
+++ b/projects/detector/private/test/gdml/GDMLParserBooleans_TEST.inc
@@ -143,11 +143,11 @@ TEST(GDMLParser, DuplicateSolidInstances) {
     double tol = 1e-9;
     // Both instances get __N suffixes; first is mybox__1, second is mybox__2
     auto geo1 = RequireSolid(data, "mybox__1");
-    EXPECT_NEAR(geo1->GetBoundingBox().max_corner.GetX(), 0.1, tol)
-        << "First instance is mybox__1 (100mm half-width = 0.1m)";
+    EXPECT_NEAR(geo1->GetBoundingBox().max_corner.GetX(), 0.05, tol)
+        << "First instance is mybox__1 (100mm full-width = 0.05m half-extent)";
     auto geo2 = RequireSolid(data, "mybox__2");
-    EXPECT_NEAR(geo2->GetBoundingBox().max_corner.GetX(), 0.2, tol)
-        << "Second instance is mybox__2 (200mm half-width = 0.2m)";
+    EXPECT_NEAR(geo2->GetBoundingBox().max_corner.GetX(), 0.1, tol)
+        << "Second instance is mybox__2 (200mm full-width = 0.1m half-extent)";
     // Instance count should be 2
     ASSERT_TRUE(data.solid_instance_counts.count("mybox") > 0);
     EXPECT_EQ(data.solid_instance_counts["mybox"], 2);
@@ -197,8 +197,8 @@ TEST(GDMLParser, BooleanInstanceResolution) {
     // second "base" (500mm). It should use the first definition.
     auto bb = geo->GetBoundingBox();
     double tol = 1e-6;
-    // The subtraction bounding box should be close to the first base box (100mm=0.1m half)
-    EXPECT_NEAR(bb.max_corner.GetX(), 0.1, tol)
+    // The subtraction bounding box should be close to the first base box (100mm full = 0.05m half)
+    EXPECT_NEAR(bb.max_corner.GetX(), 0.05, tol)
         << "Boolean should use first instance of 'base' (100mm), not second (500mm)";
 }
 
@@ -364,17 +364,18 @@ TEST(GDMLParser, BooleanSubtractionHollow) {
     auto geo = RequireSolid(data, "hollow_box");
     ASSERT_NE(geo, nullptr);
 
+    // outer 100mm -> 0.05m half; inner 60mm -> 0.03m half (wall in 0.03..0.05)
     // Center is inside both boxes, so subtraction should exclude it
     EXPECT_FALSE(IsInside(geo, 0, 0, 0));
-    // In the wall: x=0.08m is outside inner (half-width 0.06m) but inside outer (0.1m)
-    EXPECT_TRUE(IsInside(geo, 0.08, 0, 0));
+    // In the wall: x=0.04m is outside inner (half-width 0.03m) but inside outer (0.05m)
+    EXPECT_TRUE(IsInside(geo, 0.04, 0, 0));
     // In the wall off-axis
-    EXPECT_TRUE(IsInside(geo, 0, 0.08, 0));
-    EXPECT_TRUE(IsInside(geo, 0, 0, 0.08));
-    // Outside the outer box entirely (half-width 0.1m)
-    EXPECT_FALSE(IsInside(geo, 0.12, 0, 0));
+    EXPECT_TRUE(IsInside(geo, 0, 0.04, 0));
+    EXPECT_TRUE(IsInside(geo, 0, 0, 0.04));
+    // Outside the outer box entirely (half-width 0.05m)
+    EXPECT_FALSE(IsInside(geo, 0.06, 0, 0));
     // Inside the inner box: subtracted away
-    EXPECT_FALSE(IsInside(geo, 0.03, 0.03, 0.03));
+    EXPECT_FALSE(IsInside(geo, 0.02, 0.02, 0.02));
 }
 
 

--- a/projects/detector/private/test/gdml/GDMLParserExpressionUnits_TEST.inc
+++ b/projects/detector/private/test/gdml/GDMLParserExpressionUnits_TEST.inc
@@ -76,14 +76,15 @@ TEST(GDMLParser, ExpressionInSolidDimensions) {
     // The box should exist as a solid
     ASSERT_TRUE(data.solids.count("test_box") > 0);
     // Verify dimensions via bounding box (in meters, since lunit=mm -> *0.001)
-    // x = 50*2 = 100mm = 0.1m (full width = 0.2m since GDML x is half-width)
-    // y = 50mm = 0.05m (full width = 0.1m)
-    // z = 50/2 = 25mm = 0.025m (full width = 0.05m)
+    // GDML box x,y,z are FULL widths -> half-extent = value/2.
+    // x = 50*2 = 100mm full -> 0.05m half
+    // y = 50mm full -> 0.025m half
+    // z = 50/2 = 25mm full -> 0.0125m half
     auto bb = data.solids["test_box"]->GetBoundingBox();
     double tol = 1e-9;
-    EXPECT_NEAR(bb.max_corner.GetX(), 0.1, tol);  // half of full width 0.2
-    EXPECT_NEAR(bb.max_corner.GetY(), 0.05, tol); // half of full width 0.1
-    EXPECT_NEAR(bb.max_corner.GetZ(), 0.025, tol); // half of full width 0.05
+    EXPECT_NEAR(bb.max_corner.GetX(), 0.05, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 0.025, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 0.0125, tol);
 }
 
 
@@ -158,10 +159,10 @@ TEST(GDMLParser, LengthUnitConversion) {
     auto bb_cm = data.solids["box_cm"]->GetBoundingBox();
     auto bb_m  = data.solids["box_m"]->GetBoundingBox();
 
-    // GDML <box> x,y,z are HALF-widths. All three boxes specify the same half-width:
-    // 100mm = 10cm = 0.1m. In SIREN meters, bounding box max_corner = 0.1m.
+    // GDML <box> x,y,z are FULL widths. All three boxes specify the same full-width:
+    // 100mm = 10cm = 0.1m -> bounding box max_corner = 0.05m half-extent.
     double tol = 1e-9;
-    double expected = 0.1; // half-width in meters
+    double expected = 0.05; // half-extent in meters
 
     // All three should produce the same bounding box
     EXPECT_NEAR(bb_mm.max_corner.GetX(), expected, tol);
@@ -624,6 +625,6 @@ TEST(GDMLParser, LengthQuantityInSolid) {
 
     ASSERT_TRUE(data.solids.count("test") > 0);
     auto bb = data.solids["test"]->GetBoundingBox();
-    EXPECT_NEAR(bb.max_corner.GetX(), 0.05, 1e-9)
-        << "5cm quantity = 50mm half-width, box full-width = 100mm, AABB max = 50mm = 0.05m";
+    EXPECT_NEAR(bb.max_corner.GetX(), 0.025, 1e-9)
+        << "5cm quantity = 50mm full-width -> AABB max = half-extent = 25mm = 0.025m";
 }

--- a/projects/detector/private/test/gdml/GDMLParserMaterials_TEST.inc
+++ b/projects/detector/private/test/gdml/GDMLParserMaterials_TEST.inc
@@ -356,10 +356,10 @@ TEST(GDMLParser, NonIdenticalSolidsWithPointerSuffixes) {
     EXPECT_EQ(vol.solid_ref, "mybox__1")
         << "solidref with pointer suffix should resolve to specific instance";
     double tol = 1e-9;
-    EXPECT_NEAR(data.solids["mybox__1"]->GetBoundingBox().max_corner.GetX(), 0.1, tol)
-        << "First instance should be x=100mm -> half-width 0.1m";
-    EXPECT_NEAR(data.solids["mybox__2"]->GetBoundingBox().max_corner.GetX(), 0.2, tol)
-        << "Second instance should be x=200mm -> half-width 0.2m";
+    EXPECT_NEAR(data.solids["mybox__1"]->GetBoundingBox().max_corner.GetX(), 0.05, tol)
+        << "First instance should be x=100mm full-width -> half-extent 0.05m";
+    EXPECT_NEAR(data.solids["mybox__2"]->GetBoundingBox().max_corner.GetX(), 0.1, tol)
+        << "Second instance should be x=200mm full-width -> half-extent 0.1m";
 }
 
 // Identical materials with different pointer suffixes should collapse
@@ -512,10 +512,10 @@ TEST(GDMLParser, MixedPointerThenBareSolids) {
         auto const & vol = data.volumes.at("World");
         EXPECT_EQ(vol.solid_ref, "mybox__1");
         double tol = 1e-9;
-        EXPECT_NEAR(data.solids["mybox__1"]->GetBoundingBox().max_corner.GetX(), 0.2, tol)
-            << "First instance (from pointer-suffixed) should be the larger box";
-        EXPECT_NEAR(data.solids["mybox__2"]->GetBoundingBox().max_corner.GetX(), 0.1, tol)
-            << "Second instance (from bare) should be the smaller box";
+        EXPECT_NEAR(data.solids["mybox__1"]->GetBoundingBox().max_corner.GetX(), 0.1, tol)
+            << "First instance (from pointer-suffixed) should be the larger box (200mm->0.1m)";
+        EXPECT_NEAR(data.solids["mybox__2"]->GetBoundingBox().max_corner.GetX(), 0.05, tol)
+            << "Second instance (from bare) should be the smaller box (100mm->0.05m)";
     }
 
     // Identical: pointer-suffixed first, bare second -> dedup to one

--- a/projects/detector/private/test/gdml/GDMLParserPreprocess_TEST.inc
+++ b/projects/detector/private/test/gdml/GDMLParserPreprocess_TEST.inc
@@ -22,7 +22,8 @@ TEST(GDMLParser, FlexibleRootTag) {
     GDMLData data = ParseGDMLString(gdml);
     ASSERT_TRUE(data.solids.count("test_box") > 0);
     double tol = 1e-9;
-    EXPECT_NEAR(data.solids["test_box"]->GetBoundingBox().max_corner.GetX(), 0.1, tol);
+    // box x=100mm is a GDML full-width -> 0.05m half-extent
+    EXPECT_NEAR(data.solids["test_box"]->GetBoundingBox().max_corner.GetX(), 0.05, tol);
     ASSERT_GE(data.warnings.size(), 1u);
     bool found_root_warning = false;
     for(auto const & w : data.warnings) {

--- a/projects/detector/private/test/gdml/GDMLParserSolids_TEST.inc
+++ b/projects/detector/private/test/gdml/GDMLParserSolids_TEST.inc
@@ -46,24 +46,24 @@ TEST(GDMLParser, AllSolidTypes) {
     }
 
     double tol = 1e-6;
-    // GDML box x/y/z are half-widths: 100mm half-width = 0.1m
+    // GDML box x/y/z are full-widths: 100mm full-width -> 0.05m half-extent
     auto bb_b1 = data.solids["b1"]->GetBoundingBox();
-    EXPECT_NEAR(bb_b1.max_corner.GetX(), 0.1, tol);
-    EXPECT_NEAR(bb_b1.max_corner.GetZ(), 0.1, tol);
+    EXPECT_NEAR(bb_b1.max_corner.GetX(), 0.05, tol);
+    EXPECT_NEAR(bb_b1.max_corner.GetZ(), 0.05, tol);
 
     // sphere: rmax=50mm = 0.05m
     auto bb_s1 = data.solids["s1"]->GetBoundingBox();
     EXPECT_NEAR(bb_s1.max_corner.GetX(), 0.05, tol);
 
-    // tube: rmax=50mm=0.05m, GDML z=100mm is half-length=0.1m
+    // tube: rmax=50mm=0.05m, GDML z=100mm full-height -> 0.05m half-extent
     auto bb_t1 = data.solids["t1"]->GetBoundingBox();
     EXPECT_NEAR(bb_t1.max_corner.GetX(), 0.05, tol);
-    EXPECT_NEAR(bb_t1.max_corner.GetZ(), 0.1, tol);
+    EXPECT_NEAR(bb_t1.max_corner.GetZ(), 0.05, tol);
 
-    // trd: GDML half-widths: max(x1=60,x2=40)=60mm=0.06m, z=100mm half-height=0.1m
+    // trd: GDML full-widths halved -> max(x1=60,x2=40)/2=30mm=0.03m, z=100mm/2=0.05m
     auto bb_trd = data.solids["trd1"]->GetBoundingBox();
-    EXPECT_NEAR(bb_trd.max_corner.GetX(), 0.06, tol);
-    EXPECT_NEAR(bb_trd.max_corner.GetZ(), 0.1, tol);
+    EXPECT_NEAR(bb_trd.max_corner.GetX(), 0.03, tol);
+    EXPECT_NEAR(bb_trd.max_corner.GetZ(), 0.05, tol);
 
     // elliptical tube: dx=30mm=0.03m, dy=20mm=0.02m, dz=50mm half-z=0.05m
     auto bb_et = data.solids["et1"]->GetBoundingBox();
@@ -204,8 +204,9 @@ TEST(GDMLParser, CutTubeIntegration) {
     auto geo = RequireSolid(data, "ct");
     auto bb = geo->GetBoundingBox();
     double tol = 1e-6;
-    // rmax=50mm=0.05m, z=100mm half=50mm=0.05m (flat cuts)
+    // rmax=50mm=0.05m; GDML z=100mm is full-height -> dz=0.05m half (flat cuts)
     EXPECT_NEAR(bb.max_corner.GetX(), 0.05, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 0.05, tol);
 }
 
 
@@ -219,10 +220,10 @@ TEST(GDMLParser, TrapIntegration) {
     auto geo = RequireSolid(data, "t");
     auto bb = geo->GetBoundingBox();
     double tol = 1e-6;
-    // z=100mm = 0.1m (GDML trap z is half-height, passed directly as dz)
-    EXPECT_NEAR(bb.max_corner.GetZ(), 0.1, tol);
-    // max x = max(dx1,dx2,dx3,dx4) = 40mm = 0.04m
-    EXPECT_NEAR(bb.max_corner.GetX(), 0.04, tol);
+    // GDML trap z=100mm is a full-length -> dz=0.05m half-height
+    EXPECT_NEAR(bb.max_corner.GetZ(), 0.05, tol);
+    // max x = max(dx1..dx4) = 40mm full / 2 = 0.02m
+    EXPECT_NEAR(bb.max_corner.GetX(), 0.02, tol);
 }
 
 
@@ -247,10 +248,11 @@ TEST(GDMLParser, ParaIntegration) {
     auto geo = RequireSolid(data, "p");
     auto bb = geo->GetBoundingBox();
     double tol = 1e-6;
-    // With alpha=theta=phi=0, para = box: x=40mm=0.04m half, etc.
-    EXPECT_NEAR(bb.max_corner.GetX(), 0.04, tol);
-    EXPECT_NEAR(bb.max_corner.GetY(), 0.03, tol);
-    EXPECT_NEAR(bb.max_corner.GetZ(), 0.05, tol);
+    // With alpha=theta=phi=0, para = box. GDML x,y,z are full-lengths:
+    // x=40mm->0.02m, y=30mm->0.015m, z=50mm->0.025m half-extents.
+    EXPECT_NEAR(bb.max_corner.GetX(), 0.02, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 0.015, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 0.025, tol);
 }
 
 
@@ -706,16 +708,16 @@ TEST(GDMLParser, GenericPolyconePhiCut) {
 
 
 TEST(GDMLParser, BoxContainmentThroughParser) {
-    // box x,y,z are GDML half-widths: 50mm, 30mm, 20mm
-    // Half-extents in meters: 0.05, 0.03, 0.02
+    // box x,y,z are GDML full-widths: 50mm, 30mm, 20mm
+    // Half-extents in meters: 0.025, 0.015, 0.01
     TestContainment(
         R"(<box name="b" x="50" y="30" z="20" lunit="mm"/>)",
         "b", {
-            {0, 0, 0, true},            // Interior: center
-            {0.049, 0.029, 0.019, true}, // Interior: just inside corners
-            {0.051, 0, 0, false},       // Exterior: just past x half-width
-            {0, 0.031, 0, false},       // Exterior: just past y half-width
-            {0, 0, 0.021, false},       // Exterior: just past z half-width
+            {0, 0, 0, true},             // Interior: center
+            {0.024, 0.014, 0.009, true}, // Interior: just inside corners
+            {0.026, 0, 0, false},        // Exterior: just past x half-width
+            {0, 0.016, 0, false},        // Exterior: just past y half-width
+            {0, 0, 0.011, false},        // Exterior: just past z half-width
         });
 }
 
@@ -736,31 +738,29 @@ TEST(GDMLParser, SphereContainmentThroughParser) {
 
 TEST(GDMLParser, TubeContainmentThroughParser) {
     // Hollow tube: rmin=10mm=0.01m, rmax=50mm=0.05m
-    // z=100mm is GDML half-height; half=0.1m
+    // GDML z=100mm is full-height -> half-height=0.05m
     TestContainment(
         R"(<tube name="t" rmin="10" rmax="50" z="100" deltaphi="360" aunit="deg" lunit="mm"/>)",
         "t", {
             {0.03, 0, 0, true},         // Interior: in shell, at center height
-            {0, 0.03, 0.09, true},      // Interior: in shell, near top
+            {0, 0.03, 0.04, true},      // Interior: in shell, near top (|z|<0.05)
             {0.005, 0, 0, false},       // Exterior: inside hollow (r<rmin)
             {0.051, 0, 0, false},       // Exterior: past outer radius
-            {0.03, 0, 0.101, false},    // Exterior: past z half-height
+            {0.03, 0, 0.051, false},    // Exterior: past z half-height
         });
 }
 
 
 TEST(GDMLParser, ConeContainmentThroughParser) {
     // Solid cone: rmax1=50mm at bottom, rmax2=20mm at top
-    // z=100mm is GDML half-height, spanning z=-0.1 to z=0.1
-    // At z=0: rmax~35mm=0.035m
-    // At z=-0.09: rmax~48.5mm=0.0485m
-    // At z=+0.09: rmax~21.5mm=0.0215m
+    // GDML z=100mm is full-height -> spans z=-0.05 to z=0.05
+    // rmax(z) = 0.035 - 0.3*z. At z=0: 0.035m; z=-0.04: 0.047m; z=+0.04: 0.023m
     TestContainment(
         R"(<cone name="c" rmin1="0" rmax1="50" rmin2="0" rmax2="20" z="100" deltaphi="360" aunit="deg" lunit="mm"/>)",
         "c", {
             {0, 0, 0, true},            // Interior: center
-            {0.04, 0, -0.09, true},     // Interior: near bottom (r<rmax~0.0485)
-            {0.04, 0, 0.09, false},     // Exterior: near top (r>rmax~0.0215)
+            {0.04, 0, -0.04, true},     // Interior: near bottom (r=0.04<rmax~0.047)
+            {0.04, 0, 0.04, false},     // Exterior: near top (r=0.04>rmax~0.023)
             {0.02, 0.02, 0, true},      // Off-axis interior: r=0.0283 < 0.035
             {0.03, 0.03, 0, false},     // Off-axis exterior: r=0.0424 > 0.035
         });
@@ -768,15 +768,16 @@ TEST(GDMLParser, ConeContainmentThroughParser) {
 
 
 TEST(GDMLParser, TrdContainmentThroughParser) {
-    // Trd: x1=60, x2=30, y1=40, y2=20, z=50 (all GDML half-widths/half-height, mm)
-    // At z=0 (center): x half-width=0.045m, y half-width=0.03m
+    // Trd: GDML full-widths x1=60,x2=30,y1=40,y2=20,z=50 mm -> half-lengths
+    // dx1=0.03,dx2=0.015,dy1=0.02,dy2=0.01,dz=0.025 (spans z=-0.025..0.025)
+    // At z=0 (center): x half-width=0.0225m, y half-width=0.015m
     TestContainment(
         R"(<trd name="tr" x1="60" x2="30" y1="40" y2="20" z="50" lunit="mm"/>)",
         "tr", {
-            {0.04, 0.025, 0, true},     // Interior: center region
-            {0.046, 0, 0, false},       // Exterior: x>interpolated half-width at z=0
-            {0.055, 0, -0.045, true},   // Interior: near bottom, x<~0.057m
-            {0.055, 0, 0.045, false},   // Exterior: near top, x>~0.033m
+            {0.02, 0.012, 0, true},     // Interior: center region
+            {0.025, 0, 0, false},       // Exterior: x>interpolated half-width at z=0
+            {0.025, 0, -0.02, true},    // Interior: near bottom, x<~0.0285m
+            {0.025, 0, 0.02, false},    // Exterior: near top, x>~0.0165m
         });
 }
 
@@ -810,17 +811,17 @@ TEST(GDMLParser, TorusContainmentThroughParser) {
 
 
 TEST(GDMLParser, TrapContainmentThroughParser) {
-    // Trap: z=50mm dz=0.05m. theta=phi=0.
-    // At z=-dz: dy1=0.03m, dx1=dx2=0.02m
-    // At z=+dz: dy2=0.015m, dx3=dx4=0.01m
+    // Trap: GDML full-lengths z=50,y1=30,x1=x2=20,y2=15,x3=x4=10 mm -> half-lengths
+    // dz=0.025m, theta=phi=0. At z=-dz: dy1=0.015m, dx1=dx2=0.01m
+    // At z=+dz: dy2=0.0075m, dx3=dx4=0.005m
     TestContainment(
         R"(<trap name="trp" z="50" theta="0" phi="0" y1="30" x1="20" x2="20" alpha1="0" y2="15" x3="10" x4="10" alpha2="0" aunit="rad" lunit="mm"/>)",
         "trp", {
             {0, 0, 0, true},            // Interior: center
-            // Interior: near bottom face (z=-0.04), dx~0.019, dy~0.0285
-            {0.015, 0.02, -0.04, true},
-            // Exterior: near top face (z=+0.04), dx~0.011, x=0.015>0.011
-            {0.015, 0, 0.04, false},
+            // Interior: near bottom face (z=-0.02), x_half~0.0095, y_half~0.0143
+            {0.008, 0.012, -0.02, true},
+            // Exterior: near top face (z=+0.02), x_half~0.0055, x=0.008>0.0055
+            {0.008, 0, 0.02, false},
         });
 }
 
@@ -909,16 +910,16 @@ TEST(GDMLParser, TrapShearedContainment) {
     auto geo = RequireSolid(data, "sheared_trap");
     ASSERT_NE(geo, nullptr);
 
+    // GDML full-lengths -> dz=0.05m, dx=0.01m, dy=0.015m half-lengths.
     // Center of the solid: should be inside regardless of theta
     EXPECT_TRUE(IsInside(geo, 0, 0, 0));
 
-    // Near top face (z close to +dz=0.05m): point shifted in +x direction
-    // should be inside, while unshifted point may be outside
-    // At z=+0.049m (near top), face center ~ x=+0.0178m
-    EXPECT_TRUE(IsInside(geo, 0.03, 0, 0.049));
-    // Same x at bottom face (z=-0.049m): face center ~ x=-0.0178m
-    // x=0.03 is far from [-0.0378, 0.0022] range, so outside
-    EXPECT_FALSE(IsInside(geo, 0.03, 0, -0.049));
+    // Near top face (z close to +dz=0.05m): theta=20deg shifts the face
+    // center to x ~ +0.0178m, x half-width 0.01m -> x range [0.0078, 0.0278]
+    EXPECT_TRUE(IsInside(geo, 0.018, 0, 0.049));
+    // Same x at bottom face (z=-0.049m): face center ~ x=-0.0178m,
+    // range [-0.0278, -0.0078], so x=0.018 is outside
+    EXPECT_FALSE(IsInside(geo, 0.018, 0, -0.049));
 }
 
 
@@ -936,4 +937,94 @@ TEST(GDMLParser, PartialPolyhedraContainment) {
             {0, -0.03, 0, false},       // Exterior: negative-y half (phi~270, outside [0,180])
             {0, 0.06, 0, false},        // Exterior: beyond the solid radius
         });
+}
+
+
+TEST(GDMLParser, SolidHalfLengthConventions) {
+    // Regression guard for the GDML->SIREN dimension conventions (Geant4 ground
+    // truth). GDML box/tube/cone/para/trd/trap/cutTube linear attributes are
+    // FULL lengths, so each SIREN bounding-box half-extent must equal half the
+    // GDML value. eltube/ellipsoid attributes are semi-axes (no halving).
+    // Polyhedra rmin/rmax are apothem (tangent) distances, which SIREN stores and
+    // uses directly (pass-through); it only scales by 1/cos(pi/n) when it needs a
+    // circumradius (e.g. for vertices/AABB). All dimensions in meters for legibility.
+    GDMLData data = ParseGDMLWithSolids(R"(
+    <box name="cv_box" x="2" y="4" z="6" lunit="m"/>
+    <tube name="cv_tube" rmin="0" rmax="1" z="4" deltaphi="360" aunit="deg" lunit="m"/>
+    <cone name="cv_cone" rmin1="0" rmax1="1" rmin2="0" rmax2="1" z="4" deltaphi="360" aunit="deg" lunit="m"/>
+    <para name="cv_para" x="2" y="2" z="2" alpha="0" theta="0" phi="0" aunit="rad" lunit="m"/>
+    <trd name="cv_trd" x1="2" x2="2" y1="2" y2="2" z="2" lunit="m"/>
+    <trap name="cv_trap" z="2" theta="0" phi="0" y1="2" x1="2" x2="2" alpha1="0" y2="2" x3="2" x4="2" alpha2="0" aunit="rad" lunit="m"/>
+    <cutTube name="cv_cuttube" rmin="0" rmax="1" z="4" startphi="0" deltaphi="360" lowX="0" lowY="0" lowZ="-1" highX="0" highY="0" highZ="1" aunit="deg" lunit="m"/>
+    <eltube name="cv_eltube" dx="1" dy="2" dz="3" lunit="m"/>
+    <ellipsoid name="cv_ellipsoid" ax="1" by="2" cz="3" lunit="m"/>
+    <polyhedra name="cv_polyhedra" numsides="4" startphi="45" deltaphi="360" aunit="deg" lunit="m">
+      <zplane rmin="0" rmax="1" z="-1"/>
+      <zplane rmin="0" rmax="1" z="1"/>
+    </polyhedra>
+)", "cv_box");
+
+    double tol = 1e-6;
+
+    // box: GDML full-widths 2,4,6 m -> half-extents 1,2,3 m
+    auto bb = data.solids["cv_box"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 2.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 3.0, tol);
+
+    // tube: GDML z=4 m full-height -> half-height 2 m; rmax=1 m actual radius
+    bb = data.solids["cv_tube"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 2.0, tol);
+
+    // cone: GDML z=4 m full-height -> half-height 2 m; rmax=1 m actual radius
+    bb = data.solids["cv_cone"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 2.0, tol);
+
+    // para: GDML full-lengths 2,2,2 m (axis-aligned) -> half-extents 1,1,1 m
+    bb = data.solids["cv_para"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 1.0, tol);
+
+    // trd: GDML full-widths 2,2,2,2,2 m -> half-extents 1,1,1 m
+    bb = data.solids["cv_trd"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 1.0, tol);
+
+    // trap: GDML full-lengths (orthogonal) -> half-extents 1,1,1 m
+    bb = data.solids["cv_trap"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 1.0, tol);
+
+    // cutTube: GDML z=4 m full-height -> half-height 2 m (flat cuts); rmax=1 m
+    bb = data.solids["cv_cuttube"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 2.0, tol);
+
+    // eltube: GDML dx,dy,dz are semi-axes (half) -> bbox 1,2,3 m (no halving)
+    bb = data.solids["cv_eltube"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 2.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 3.0, tol);
+
+    // ellipsoid: GDML ax,by,cz are semi-axes (half) -> bbox 1,2,3 m (no halving)
+    bb = data.solids["cv_ellipsoid"]->GetBoundingBox();
+    EXPECT_NEAR(bb.max_corner.GetX(), 1.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetY(), 2.0, tol);
+    EXPECT_NEAR(bb.max_corner.GetZ(), 3.0, tol);
+
+    // polyhedra: 4-sided, startphi=45deg so the flat faces are axis-aligned at
+    // x,y = +/- the apothem. GDML rmax=1 m is the apothem (tangent distance to
+    // the flat face) and SIREN's Polyhedra uses the same apothem convention, so
+    // the right face sits at x=1 m: a point at x=0.9 is inside, x=1.1 is outside.
+    // This pins the rmin/rmax pass-through (no spurious apothem<->corner
+    // rescaling). Containment is checked rather than the bounding box, which is
+    // a conservative circumscribed-square bound.
+    auto poly = data.solids["cv_polyhedra"];
+    EXPECT_TRUE(IsInside(poly, 0.9, 0, 0));
+    EXPECT_FALSE(IsInside(poly, 1.1, 0, 0));
 }

--- a/projects/detector/private/test/gdml/GDMLParserStructure_TEST.inc
+++ b/projects/detector/private/test/gdml/GDMLParserStructure_TEST.inc
@@ -106,10 +106,10 @@ TEST(GDMLParser, RotationHandling) {
 
     auto dm = LoadGDMLFromString(gdml);
 
-    // The child box is 400x100x100 mm (half-widths: 0.4x0.1x0.1 m)
+    // The child box is 400x100x100 mm full-widths (half-extents 0.2x0.05x0.05 m).
     // Placed at x=200mm=0.2m with z-rotation of 90 degrees.
     // After 90-deg z-rotation, the long axis (originally x) becomes the y axis.
-    // So the child occupies roughly: x in [0.1, 0.3], y in [-0.4, 0.4]
+    // So the child occupies roughly: x in [0.15, 0.25], y in [-0.2, 0.2]
 
     // The child sector should exist
     auto const & sectors = dm->GetSectors();
@@ -120,10 +120,10 @@ TEST(GDMLParser, RotationHandling) {
     EXPECT_EQ(MaterialAt(*dm, 0.2, 0.0, 0.0), "Iron")
         << "Center of rotated child at (0.2,0,0) should be Iron";
 
-    // After rotation, the long axis is along y. A point at (0.2, 0.3, 0) should
-    // still be inside (within the rotated half-width of 0.4 along y).
-    EXPECT_EQ(MaterialAt(*dm, 0.2, 0.3, 0.0), "Iron")
-        << "Point at (0.2, 0.3, 0) should be inside the rotated child (long axis now along y)";
+    // After rotation, the long axis is along y. A point at (0.2, 0.15, 0) should
+    // still be inside (within the rotated half-extent of 0.2 along y).
+    EXPECT_EQ(MaterialAt(*dm, 0.2, 0.15, 0.0), "Iron")
+        << "Point at (0.2, 0.15, 0) should be inside the rotated child (long axis now along y)";
 
     // A point far from the child should be in Air
     EXPECT_EQ(MaterialAt(*dm, 1.0, 1.0, 0.0), "Air")
@@ -132,9 +132,11 @@ TEST(GDMLParser, RotationHandling) {
 
 
 TEST(GDMLParser, CompoundRotationGroundTruth) {
+    // child_box GDML full-widths 1.0x0.4x0.2 m -> half-extents 0.5x0.2x0.1 m,
+    // matching the local probe margins (0.1/0.2/0.1 at local (0.4,0,0)) used below.
     std::string gdml = GDMLFull("", kAirIron,
         R"(<box name="world_box" x="5" y="5" z="5" lunit="m"/>
-    <box name="child_box" x="0.5" y="0.2" z="0.1" lunit="m"/>)",
+    <box name="child_box" x="1.0" y="0.4" z="0.2" lunit="m"/>)",
         R"(<volume name="Child">
       <materialref ref="Iron"/><solidref ref="child_box"/>
     </volume>

--- a/projects/geometry/public/SIREN/geometry/Polyhedra.h
+++ b/projects/geometry/public/SIREN/geometry/Polyhedra.h
@@ -119,8 +119,8 @@ private:
     double delta_phi_;         //!< azimuthal extent (radians, default 2*pi)
     bool has_phi_cut_;         //!< true if delta_phi < 2*pi
     std::vector<double> z_planes_; //!< z-positions of each plane (ascending)
-    std::vector<double> rmin_;     //!< inner radius at each z-plane (to edge center)
-    std::vector<double> rmax_;     //!< outer radius at each z-plane (to edge center)
+    std::vector<double> rmin_;     //!< inner radius at each z-plane (apothem: perpendicular distance to edge center)
+    std::vector<double> rmax_;     //!< outer radius at each z-plane (apothem: perpendicular distance to edge center)
 
     // Precomputed cos/sin for polygon vertex angles.
     // cos_phi_[k] = cos(start_phi_ + k * dphi), k = 0..num_sides_


### PR DESCRIPTION
Part of splitting the `interface-redesign` branch into reviewable PRs (foundation tier).

**Stacked on `pr/foundational-fixes`** — its `ParseBox` fix builds on the `Box` full-width rename there (it does not apply cleanly on `main` alone). Retarget to `main` once `pr/foundational-fixes` merges.

### Delivers
GDML length conventions aligned with Geant4: box/tube/cone pass full-length through; trd/trap/cuttube/para apply x0.5 (SIREN constructors take half-lengths); Polyhedra `rmax` = apothem clarified. Updates the 6 GDML parser test `.inc` files to the corrected expectations.

**Scope:** 1 commit (parser + 6 tests + `Polyhedra.h`), extracted from the original combined "Align GDML length conventions" commit; the visualization/loader hunks of that commit ship in the `phase-space-redesign` PR.
**Verified:** build + ctest + pytest clean.
