### PR TITLE
Release v0.1.0 and enable manual Build dispatch

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   populate_cfitsio_cache:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH:$DYLD_LIBRARY_PATH delocate-wheel --requi
 
 [project]
 name = "siren"
-version = "0.0.3"
+version = "0.1.0"
 description = "Sampling and Injection for Rare EveNts: A neutrino and rare-process injection toolkit"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## Summary

Two small release-prep changes:

1. **Bump the package version `0.0.3` -> `0.1.0`.** `pyproject.toml` `[project].version` is the single source of truth: the CMake build parses it via `include(siren_pyproject)` -> `project(siren VERSION ...)`, and the Python package surfaces it through `importlib.metadata.version` (`python/__init__.py`). A repo-wide sweep confirmed `0.0.3` was hardcoded only in `pyproject.toml`, so no other files need to change and `siren.__version__` follows automatically.

2. **Add a `workflow_dispatch` trigger to the Build workflow.** The workflow was `on: [pull_request]` only, so there was no way to run wheel builds against `main` directly. This adds manual dispatch alongside the existing pull-request trigger.

## Diff

```yaml
# .github/workflows/build_wheels.yml
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
```

```toml
# pyproject.toml
-version = "0.0.3"
+version = "0.1.0"
```

## Notes for reviewers

- **`workflow_dispatch` only becomes usable after this merges.** GitHub exposes the "Run workflow" button / accepts `gh workflow run "Build"` only for workflow files present on the default branch, so manual dispatch lights up once this lands on `main`.
- **Scoped to the Build workflow** per request. `tests.yml` (Python tests) is left `pull_request`-only; happy to add the same trigger there (or a `push: [main]` trigger) in a follow-up if wanted.
- **No `push: main` on Build** by design — the wheel matrix runs ~4-6h, so auto-running it on every merge is intentionally avoided in favor of manual dispatch.
