### PR TITLE
avoid merge issues in building both macos-14 and 15 with Apple-Silicon

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -72,14 +72,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15, macos-15-intel]
+        # Build each wheel exactly once: macos-14 (Apple Silicon) for arm64,
+        # macos-15-intel for x86_64. Building arm64 on both macos-14 and
+        # macos-15 previously produced two identically-named wheels that
+        # collided in the merge job and corrupted via torn concurrent writes.
+        os: [macos-14, macos-15-intel]
         py: [cp38, cp39, cp310, cp311, cp312]
         arch: [arm64, x86_64]
         exclude:
-          # macos-14 / macos-15 are Apple Silicon runners
+          # macos-14 is an Apple Silicon runner
           - os: macos-14
-            arch: x86_64
-          - os: macos-15
             arch: x86_64
           # macos-15-intel is an Intel runner
           - os: macos-15-intel


### PR DESCRIPTION
Small pull request to avoid a merge issue when building both macos-14 and 15 with Apple-Silicon, i.e. x86_64, which corrupts the wheels