### PR TITLE
DUNE FD + ND + LBNF beamline

### DIFF
--- a/projects/geometry/private/pybindings/geometry.cxx
+++ b/projects/geometry/private/pybindings/geometry.cxx
@@ -20,6 +20,7 @@
 #include "../../public/SIREN/geometry/Trap.h"
 #include "../../public/SIREN/geometry/Ellipsoid.h"
 #include "../../public/SIREN/geometry/Para.h"
+#include "../../public/SIREN/geometry/GeometryMesh.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
@@ -96,6 +97,18 @@ PYBIND11_MODULE(geometry,m) {
         .def_property("X",&Box::GetX, &Box::SetX)
         .def_property("Y",&Box::GetY, &Box::SetY)
         .def_property("Z",&Box::GetZ, &Box::SetZ);
+
+    // TriangularMesh
+
+    class_<TriangularMesh, std::shared_ptr<TriangularMesh>, Geometry>(m, "TriangularMesh")
+        .def(init<>())
+        .def(init<std::vector<std::array<siren::math::Vector3D, 3>> const &>())
+        .def(init<Placement const &, std::vector<std::array<siren::math::Vector3D, 3>> const &>())
+        .def(init<Placement const &>())
+        .def(init<const TriangularMesh&>())
+        .def("TriangleCount", &TriangularMesh::TriangleCount)
+        .def("GetTriangles", &TriangularMesh::GetTriangles)
+        .def("ValidateClosed", &TriangularMesh::ValidateClosed);
 
     // Cone
 

--- a/projects/geometry/public/SIREN/geometry/GeometryMesh.h
+++ b/projects/geometry/public/SIREN/geometry/GeometryMesh.h
@@ -61,6 +61,7 @@ public:
     AABB GetBoundingBox() const override;
 
     size_t TriangleCount() const { return triangles_.size(); }
+    std::vector<Triangle> const & GetTriangles() const { return triangles_; }
 
     // Validate that the mesh is a closed 2-manifold surface.
     // Returns empty string if valid, or a description of the defect.

--- a/python/earth/__init__.py
+++ b/python/earth/__init__.py
@@ -30,6 +30,7 @@ from .sectors import (
     build_earth_sectors,
     PositionedSector,
     shift_levels_up,
+    insert_sectors_above,
 )
 
 __all__ = [
@@ -38,4 +39,5 @@ __all__ = [
     "Atmosphere", "USStandard1976", "AtmosphereForm", "AtmosphereBand",
     "DEFAULT_SHELL_ALTS", "default_boundaries", "constant_shell_layers",
     "build_earth_sectors", "PositionedSector", "shift_levels_up",
+    "insert_sectors_above",
 ]

--- a/python/earth/sectors.py
+++ b/python/earth/sectors.py
@@ -52,6 +52,34 @@ def shift_levels_up(sectors, count, exempt=("UNIVERSE",)):
     return min_level
 
 
+def insert_sectors_above(model, anchor_name, new_sectors):
+    """Insert already-built DetectorSectors just above ``anchor_name``.
+
+    Uses the predict-count-and-shift-up scheme: every existing sector with a
+    higher level than the anchor is shifted up by ``len(new_sectors)`` to open a
+    gap, then the new sectors are assigned the freed levels (in ascending
+    priority: the first entry lands just above the anchor). This places
+    site-specific overburden between a background volume (e.g. "World") and the
+    detector volumes without any absolute/negative level constants.
+    """
+    sectors = model.Sectors
+    anchor = next((s for s in sectors if s.name == anchor_name), None)
+    if anchor is None:
+        raise RuntimeError(
+            "insert_sectors_above: no sector named {!r}".format(anchor_name))
+    anchor_level = anchor.level
+    n = len(new_sectors)
+    for s in sectors:
+        if s.level > anchor_level:
+            s.level = s.level + n
+    level = anchor_level + 1
+    for s in new_sectors:
+        s.level = level
+        level += 1
+        sectors.append(s)
+    model.Sectors = sorted(sectors, key=lambda s: s.level)
+
+
 def build_earth_sectors(model, *, surface_offset, prem_layers=None,
                         atmosphere=None, extra_sectors=(),
                         up_axis=(0.0, 1.0, 0.0), r_prem=6371000.0):

--- a/resources/detectors/DUNEFD/DUNEFD-v2/.gitignore
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/.gitignore
@@ -1,0 +1,8 @@
+# Generated/cached at load time -- do not commit or ship.
+# The module GDMLs live in SIREN-data (detectors/DUNEFD/v2/{HD,VD}/) and are
+# fetched on first use; the overburden DEM/materials are downloaded/derived.
+composite_*.gdml
+gdml/
+dem/
+*_homestake_materials.dat
+__pycache__/

--- a/resources/detectors/DUNEFD/DUNEFD-v2/detector.py
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/detector.py
@@ -1,0 +1,210 @@
+"""
+DUNE far-detector loader.
+
+Loads the official dunecore GDML (FD1-HD horizontal drift and/or FD2-VD vertical
+drift, nowires variants) into a single SIREN coordinate frame, optionally with the
+Homestake overburden (real topography, geological formations, PREM Earth).
+
+SITE FRAME (shared by all modules and the overburden):
+    +y = local up (vertical at SURF)
+    +z = LBNF neutrino-beam direction (downstream, traveling away from Fermilab);
+         horizontal projection, geographic azimuth ~277.15 deg at the far detector
+    +x = right-handed (horizontal transverse, ~ geographic south)
+The real beam travels +z tilted UP by ~5.71 deg (it dives under from FNAL and
+arrives going upward at the FD). This is the LArSoft DUNE convention
+(z = neutrino travel, y = up, x = right-handed).
+
+The HD GDML is already in this frame (y=up, z=beam). The VD GDML is built x=up
+(vertical drift), so it is rotated x->y (GDML rotation z=-90) to match.
+
+Usage:
+    from siren._util import load_detector
+    model = load_detector("DUNEFD", detector="VD")                 # VD only
+    model = load_detector("DUNEFD", detector="HD")                 # HD only
+    model = load_detector("DUNEFD", detector="both")               # FD1-HD + FD2-VD
+    model = load_detector("DUNEFD", detector="both", earth_model=True)  # + overburden
+
+The module GDMLs are the official DUNE/dunecore far-detector geometries, mirrored
+(sha256-verified) in SIREN-data under detectors/DUNEFD/v2/{HD,VD}/ with a README
+recording the exact upstream commit. They are fetched on first use, or via
+``siren-download --fetch DUNEFD``.
+"""
+import importlib.util
+import os
+import sys
+
+from siren.download import writable_data_dir, ensure_files, resolve_data_path
+
+_THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+# Module GDMLs are mirrored in SIREN-data (each with a provenance README) and
+# fetched, sha256-verified, on first use. _INSTALL_GDML holds any copy shipped
+# with the package; _GDML_DIR is the writable download/cache location and is
+# also where the composite stub is written.
+_ABS_DIR = writable_data_dir(_THIS_DIR)
+_INSTALL_GDML = os.path.join(_THIS_DIR, "gdml")
+_GDML_DIR = os.path.join(_ABS_DIR, "gdml")
+
+# SIREN-data mirror of the official DUNE/dunecore far-detector GDMLs. Each module
+# lives under detectors/DUNEFD/v2/<HD|VD>/ alongside a README documenting the
+# exact upstream dunecore commit it was taken from.
+_DATA_BASE = (
+    "https://raw.githubusercontent.com/SIREN-Generator/SIREN-data/"
+    "main/detectors/DUNEFD/v2"
+)
+
+# ---- site-frame / beam geometry (computed from the FNAL->SURF chord) ----
+BEAM_AZIMUTH_DEG = 277.15   # +z: beam downstream azimuth at the FD (from N toward E)
+BEAM_DIP_DEG = 5.71         # beam travels UP by this much at the FD (info only)
+# HD (north cavern) <-> VD (south cavern) transverse center-to-center spacing.
+# The N-S spacing is not published; ~75 m from cavern widths 19.8 m + CUC 19.3 m
+# + rock pillars. Transverse = +x in the site frame.
+CAVERN_SPACING_M = 75.0
+
+
+def _load_sibling(name, filename):
+    fqn = f"siren._dunefd.{name}"
+    if fqn in sys.modules:
+        return sys.modules[fqn]
+    spec = importlib.util.spec_from_file_location(fqn, os.path.join(_THIS_DIR, filename))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[fqn] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        del sys.modules[fqn]
+        raise
+    return mod
+
+
+# Per-module spec. `active_center` is the active-LAr center in the module's OWN
+# GDML frame; `rotation_deg` is the GDML <rotation> (passive) that brings the
+# module into the site frame; HD is identity, VD is x->up rotated to y->up.
+_MODULES = {
+    "HD": {
+        "name": "dune10kt_v6_refactored_1x2x6_nowires",
+        "url": f"{_DATA_BASE}/HD/dune10kt_v6_refactored_1x2x6_nowires.gdml",
+        "sha256": "b801f3eb28c5af58205cbe393039fc6f414e384fe6ee66a81ebe8c3b578b7e68",
+        "active_center": (0.0, 0.21, 5.70),    # HD already y=up, z=beam
+        "rotation_deg": (0.0, 0.0, 0.0),
+    },
+    "VD": {
+        "name": "dunevd10kt_3view_30deg_v7_refactored_1x8x14_nowires",
+        "url": f"{_DATA_BASE}/VD/dunevd10kt_3view_30deg_v7_refactored_1x8x14_nowires.gdml",
+        "sha256": "24fffafeeb17ceea3760ab378bf4ed76803a072cc9060704d7810ea9d1d85b56",
+        "active_center": (0.0, 0.0, 10.5),     # VD x=up -> rotate to y=up
+        "rotation_deg": (0.0, 0.0, -90.0),
+    },
+}
+
+
+def _ensure_gdml(spec):
+    """Resolve a module GDML, fetching it from SIREN-data if absent.
+
+    Prefers a copy shipped in the package's gdml/ directory; otherwise downloads
+    the sha256-verified file from SIREN-data into a writable mirror. The files
+    originate from DUNE/dunecore -- see the per-module README under
+    detectors/DUNEFD/v2/<HD|VD>/ in SIREN-data for the exact upstream commit.
+    Returns the absolute path to the resolved file.
+    """
+    fn = spec["name"] + ".gdml"
+    path = resolve_data_path(_INSTALL_GDML, _GDML_DIR, fn)
+    if not os.path.isfile(path):
+        ensure_files([{"path": path, "url": spec["url"], "sha256": spec["sha256"]}])
+    return path
+
+
+def fetch_data():
+    """Pre-fetch the FD module GDMLs from SIREN-data.
+
+    Entry point for ``siren-download --fetch DUNEFD``; downloads both modules so
+    later ``load_detector`` calls run offline.
+    """
+    for spec in _MODULES.values():
+        _ensure_gdml(spec)
+
+
+def _write_composite(placements, out_path, world_half=400.0):
+    """Write a stub GDML referencing each module's GDML with a position+rotation.
+
+    placements: list of (gdml_path, (rx,ry,rz) deg, (tx,ty,tz) m). gdml_path is
+    an absolute path so the composite need not be co-located with the modules
+    (they may be resolved from the package dir or a writable download mirror).
+    """
+    os.makedirs(os.path.dirname(out_path) or ".", exist_ok=True)
+    physvols = []
+    for i, (fn, rot, off) in enumerate(placements):
+        # as_assembly="true" unwraps the sub-geometry into this frame so the
+        # position/rotation propagates to containment (not just the bounding box).
+        pv = [f'      <physvol name="pv_module_{i}">',
+              f'        <file name="{fn}" as_assembly="true"/>',
+              f'        <position unit="m" x="{off[0]:.6f}" y="{off[1]:.6f}" z="{off[2]:.6f}"/>']
+        if any(abs(a) > 1e-9 for a in rot):
+            pv.append(f'        <rotation unit="deg" x="{rot[0]:.6f}" y="{rot[1]:.6f}" z="{rot[2]:.6f}"/>')
+        pv.append("      </physvol>")
+        physvols.append("\n".join(pv))
+    stub = (
+        '<?xml version="1.0"?>\n<gdml>\n  <define/>\n  <materials>\n'
+        '    <material name="WorldVacuum" Z="1"><D value="1e-25" unit="g/cm3"/>'
+        '<atom value="1.008"/></material>\n  </materials>\n  <solids>\n'
+        f'    <box name="sol_world" lunit="m" x="{2*world_half}" y="{2*world_half}" '
+        f'z="{2*world_half}"/>\n  </solids>\n  <structure>\n'
+        '    <volume name="World">\n      <materialref ref="WorldVacuum"/>\n'
+        '      <solidref ref="sol_world"/>\n'
+        + "\n".join(physvols)
+        + '\n    </volume>\n  </structure>\n'
+        '  <setup name="Default" version="1.0"><world ref="World"/></setup>\n</gdml>\n')
+    with open(out_path, "w") as f:
+        f.write(stub)
+    return out_path
+
+
+def load_detector(detector=None, earth_model=False):
+    """Load a DUNE far-detector model in the site frame (+y up, +z beam).
+
+    detector : "HD", "VD", or "both" (FD1-HD + FD2-VD).
+    earth_model : if True, overlay the Homestake overburden (real topography,
+        formations, PREM). DEM tiles download on first use. Default False.
+    """
+    if detector is None:
+        raise TypeError('"detector" is required: "HD", "VD", or "both".')
+    key = str(detector).lower()
+    if key in ("hd", "vd"):
+        modules = [key.upper()]
+    elif key == "both":
+        modules = ["HD", "VD"]
+    else:
+        raise ValueError(f'Unknown detector "{detector}". Choose "HD", "VD", or "both".')
+
+    # transverse offsets: single module at origin; for "both", HD at -spacing/2,
+    # VD at +spacing/2 along +x (north cavern / south cavern).
+    offsets = {m: (0.0, 0.0, 0.0) for m in modules}
+    if modules == ["HD", "VD"]:
+        offsets["HD"] = (-CAVERN_SPACING_M / 2.0, 0.0, 0.0)
+        offsets["VD"] = (+CAVERN_SPACING_M / 2.0, 0.0, 0.0)
+
+    placements = []
+    for m in modules:
+        spec = _MODULES[m]
+        gdml = _ensure_gdml(spec)
+        placements.append((gdml, spec["rotation_deg"], offsets[m]))
+
+    from siren.detector import DetectorModel, GeometryPosition
+    from siren.math import Vector3D
+
+    composite = os.path.join(_GDML_DIR, f"composite_{key}.gdml")
+    _write_composite(placements, composite)
+    model = DetectorModel()
+    model.LoadGDML(composite)
+
+    if earth_model:
+        earth = _load_sibling("earth_model", "earth_model.py")
+        earth.add_earth_model(model)
+
+    # DetectorOrigin = active-LAr center of the primary module (HD for "both"),
+    # mapped into the site frame (rotation of HD/VD primary is about the long
+    # axis, so the on-axis active center only shifts by the transverse offset).
+    primary = modules[0]
+    ac = _MODULES[primary]["active_center"]
+    off = offsets[primary]
+    model.DetectorOrigin = GeometryPosition(Vector3D(ac[0] + off[0], ac[1] + off[1], ac[2] + off[2]))
+    return model

--- a/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
@@ -1,0 +1,425 @@
+"""
+Homestake/SURF overburden + PREM Earth model for the DUNE far detector.
+
+Adds real topography (graded, anti-aliased DEM mesh), Homestake geological
+formations (Poorman/Yates/rhyolite), and a full PREM Earth to a DetectorModel
+that was loaded from the DUNE FD GDML. The GDML volumes always take priority
+over these sectors wherever both exist (same pattern as SBN earth_model.py).
+
+Site frame (shared with detector.py): +y = up, +z = LBNF beam downstream
+(geographic azimuth ~277.15 deg), +x = right-handed. The overburden is built in
+a local ENU frame (z = up) then rotated by the ENU->site placement so ENU-up
+maps to +y and the ENU horizontal plane carries +z along the beam azimuth.
+
+Call ``add_earth_model(model)`` after ``model.LoadGDML(path)``.
+"""
+from __future__ import annotations
+
+import math
+import os
+import importlib.util
+import sys
+import numpy as np
+
+_THIS_DIR = os.path.dirname(os.path.realpath(__file__))
+
+# SURF/Homestake 4850L site
+SITE_LAT = 44.352
+SITE_LON = -103.751
+DEPTH = 1478.0          # vertical depth (m) to 4850L
+R_PREM = 6371000.0
+
+
+def _load_sibling(name, filename):
+    fqn = f"siren._dunefd.{name}"
+    if fqn in sys.modules:
+        return sys.modules[fqn]
+    spec = importlib.util.spec_from_file_location(
+        fqn, os.path.join(_THIS_DIR, filename))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[fqn] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        del sys.modules[fqn]
+        raise
+    return mod
+
+
+# ---- DEM access (Copernicus GLO-30) ----
+_DEM_DIR = os.path.join(_THIS_DIR, "dem")
+_TILES = {}
+_SAT = {}
+
+_phi = math.radians(SITE_LAT)
+M_LAT = 111132.954 - 559.822 * math.cos(2 * _phi) + 1.175 * math.cos(4 * _phi)
+M_LON = (math.pi / 180.0) * 6378137.0 * math.cos(_phi) / math.sqrt(
+    1 - 0.00669437999014 * math.sin(_phi) ** 2)
+
+
+def _ensure_dem():
+    """Download Copernicus GLO-30 tiles if not cached."""
+    if _TILES:
+        return
+    os.makedirs(_DEM_DIR, exist_ok=True)
+    import tifffile
+    for ul_lon, fn in [(-104.0, "cop30_N44_W104.tif"), (-105.0, "cop30_N44_W105.tif")]:
+        path = os.path.join(_DEM_DIR, fn)
+        if not os.path.isfile(path):
+            import urllib.request
+            url = (f"https://copernicus-dem-30m.s3.amazonaws.com/"
+                   f"Copernicus_DSM_COG_10_N44_00_W{abs(int(ul_lon)):03d}_00_DEM/"
+                   f"Copernicus_DSM_COG_10_N44_00_W{abs(int(ul_lon)):03d}_00_DEM.tif")
+            urllib.request.urlretrieve(url, path)
+        arr = tifffile.imread(path).astype(np.float64)
+        _TILES[ul_lon] = (arr, 45.0, 1.0 / 3600.0)
+        sat = np.pad(arr.cumsum(0).cumsum(1), ((1, 0), (1, 0)))
+        _SAT[ul_lon] = (sat, 45.0, 1.0 / 3600.0)
+
+
+def _sample_dem(lat, lon):
+    _ensure_dem()
+    lat = np.atleast_1d(np.asarray(lat, float))
+    lon = np.atleast_1d(np.asarray(lon, float))
+    out = np.full(lat.shape, np.nan)
+    for ul_lon, (arr, ul_lat, dx) in _TILES.items():
+        m = (lon >= ul_lon) & (lon < ul_lon + 1.0)
+        if not m.any():
+            continue
+        nr, nc = arr.shape
+        col = (lon[m] - ul_lon) / dx; row = (ul_lat - lat[m]) / dx
+        c0 = np.clip(np.floor(col).astype(int), 0, nc - 2)
+        r0 = np.clip(np.floor(row).astype(int), 0, nr - 2)
+        fc = np.clip(col - c0, 0, 1); fr = np.clip(row - r0, 0, 1)
+        out[m] = (arr[r0, c0] * (1-fc) * (1-fr) + arr[r0, c0+1] * fc * (1-fr)
+                  + arr[r0+1, c0] * (1-fc) * fr + arr[r0+1, c0+1] * fc * fr)
+    return out
+
+
+Z_SURF_SITE = None
+Z_DET_ASL = None
+
+def _init_site():
+    global Z_SURF_SITE, Z_DET_ASL
+    if Z_SURF_SITE is not None:
+        return
+    _ensure_dem()
+    Z_SURF_SITE = float(_sample_dem(SITE_LAT, SITE_LON)[0])
+    Z_DET_ASL = Z_SURF_SITE - DEPTH
+
+
+_M_PER_PIX_LAT = (1.0 / 3600.0) * M_LAT
+_M_PER_PIX_LON = (1.0 / 3600.0) * M_LON
+
+
+def _avg_elev_asl(x, y, window):
+    _ensure_dem()
+    x = np.atleast_1d(np.asarray(x, float)); y = np.atleast_1d(np.asarray(y, float))
+    window = np.broadcast_to(np.atleast_1d(np.asarray(window, float)), x.shape)
+    lat = SITE_LAT + y / M_LAT; lon = SITE_LON + x / M_LON
+    out = np.full(x.shape, np.nan)
+    for ul_lon, (sat, ul_lat, dx) in _SAT.items():
+        m = (lon >= ul_lon) & (lon < ul_lon + 1.0)
+        if not m.any():
+            continue
+        nr, nc = sat.shape[0] - 1, sat.shape[1] - 1
+        col = (lon[m] - ul_lon) / dx; row = (ul_lat - lat[m]) / dx
+        hr = np.maximum(window[m] / 2 / _M_PER_PIX_LAT, 0.5)
+        hc = np.maximum(window[m] / 2 / _M_PER_PIX_LON, 0.5)
+        r0 = np.clip(np.floor(row - hr).astype(int), 0, nr - 1)
+        r1 = np.clip(np.ceil(row + hr).astype(int), 1, nr)
+        c0 = np.clip(np.floor(col - hc).astype(int), 0, nc - 1)
+        c1 = np.clip(np.ceil(col + hc).astype(int), 1, nc)
+        S = sat[r1, c1] - sat[r0, c1] - sat[r1, c0] + sat[r0, c0]
+        area = ((r1 - r0) * (c1 - c0)).astype(float)
+        out[m] = S / area
+    return out
+
+
+# ---- graded mesh builder (ENU frame, z=up, origin at detector) ----
+H_MIN = 80.0
+L_HALF = 20480.0
+BASE_Z = -3000.0
+C_Z_ENU = -(R_PREM - DEPTH)  # Earth center in ENU
+TAPER_START = 15000.0
+_BANDS = [(2560, 80.0), (5120, 160.0), (10240, 320.0), (15360, 640.0), (1e9, 1280.0)]
+
+
+def _target_cell(xc, yc):
+    r = max(abs(xc), abs(yc))
+    for rmax, c in _BANDS:
+        if r < rmax:
+            return c
+    return _BANDS[-1][1]
+
+
+def _surface_sphere_z(x, y):
+    return C_Z_ENU + math.sqrt(max(R_PREM * R_PREM - x * x - y * y, 0.0))
+
+
+def _elev(x, y, window):
+    """Terrain surface elevation (ENU z above the detector), with curvature correction.
+
+    The curvature drop d^2/(2R) accounts for the Earth curving away from the
+    tangent plane. The surface is the real DEM terrain everywhere we have data;
+    no blending to the PREM sphere (which would add fake rock where the terrain
+    is lower than the sphere). The mesh BASE tapers to the PREM sphere instead
+    (see _base_z), so leaving the mesh laterally falls through the bottom into
+    PREM crust -- physically correct.
+    """
+    _init_site()
+    z = float(_avg_elev_asl(x, y, window)[0]) - Z_DET_ASL
+    z -= (x * x + y * y) / (2.0 * R_PREM)   # Earth-curvature drop
+    return z
+
+
+def _base_z(x, y):
+    """Mesh base elevation (ENU z): flat at BASE_Z so the mesh is a filled rock
+    volume from the terrain surface down to BASE_Z. (A graded spherical-cap base
+    is the planned refinement.) The local_crust box continues the rock below."""
+    return BASE_Z
+
+
+_vcache = {}
+U = H_MIN
+ROOT = int(round(L_HALF / U))
+
+
+def _v(ix, iy, V3):
+    key = (ix, iy)
+    if key not in _vcache:
+        x, y = ix * U, iy * U
+        _vcache[key] = V3(x, y, _elev(x, y, _target_cell(x, y)))
+    return _vcache[key]
+
+
+def _build_graded_mesh(V3):
+    _vcache.clear()
+    _init_site()
+    leaves = set()
+
+    def subdivide(x0, y0, s):
+        cx, cy = (x0 + s / 2) * U, (y0 + s / 2) * U
+        if s > 1 and s * U > _target_cell(cx, cy):
+            h = s // 2
+            for dx in (0, h):
+                for dy in (0, h):
+                    subdivide(x0 + dx, y0 + dy, h)
+        else:
+            leaves.add((x0, y0, s))
+
+    subdivide(-ROOT, -ROOT, 2 * ROOT)
+    # 2:1 balance
+    changed = True
+    while changed:
+        changed = False
+        for cell in list(leaves):
+            x0, y0, s = cell
+            if s == 1:
+                continue
+            pts = []
+            for t in (0.25, 0.75):
+                pts += [(x0 + s + 0.01, y0 + s * t), (x0 - 0.01, y0 + s * t),
+                        (x0 + s * t, y0 + s + 0.01), (x0 + s * t, y0 - 0.01)]
+            def _lsz(px, py):
+                sz = 1
+                while sz <= 2 * ROOT:
+                    lx = int(np.floor(px / sz)) * sz
+                    ly = int(np.floor(py / sz)) * sz
+                    if (lx, ly, sz) in leaves:
+                        return sz
+                    sz *= 2
+                return None
+            if any((sz := _lsz(px, py)) is not None and sz < s / 2 for px, py in pts):
+                leaves.discard(cell)
+                h = s // 2
+                for dx in (0, h):
+                    for dy in (0, h):
+                        leaves.add((x0 + dx, y0 + dy, h))
+                changed = True
+
+    def _has_mid(x0, y0, s, side):
+        if side == "R":   px, py = x0 + s + 0.01, y0 + s * 0.5
+        elif side == "L": px, py = x0 - 0.01,     y0 + s * 0.5
+        elif side == "T": px, py = x0 + s * 0.5,  y0 + s + 0.01
+        else:             px, py = x0 + s * 0.5,  y0 - 0.01
+        sz = 1
+        while sz <= 2 * ROOT:
+            lx = int(np.floor(px / sz)) * sz
+            ly = int(np.floor(py / sz)) * sz
+            if (lx, ly, sz) in leaves:
+                return sz == s // 2
+            sz *= 2
+        return False
+
+    tris = []
+    for (x0, y0, s) in leaves:
+        h = s // 2
+        cx, cy = (x0 + h) * U, (y0 + h) * U
+        cz = _elev(cx, cy, s * U)
+        C = V3(cx, cy, cz)
+        corners = {"B": [(x0, y0), (x0 + s, y0)],
+                   "R": [(x0 + s, y0), (x0 + s, y0 + s)],
+                   "T": [(x0 + s, y0 + s), (x0, y0 + s)],
+                   "L": [(x0, y0 + s), (x0, y0)]}
+        mids = {"B": (x0 + h, y0), "R": (x0 + s, y0 + h),
+                "T": (x0 + h, y0 + s), "L": (x0, y0 + h)}
+        for side in ("B", "R", "T", "L"):
+            (a, b) = corners[side]
+            if _has_mid(x0, y0, s, side):
+                mx, my = mids[side]
+                tris.append([C, _v(*a, V3), _v(mx, my, V3)])
+                tris.append([C, _v(mx, my, V3), _v(*b, V3)])
+            else:
+                tris.append([C, _v(*a, V3), _v(*b, V3)])
+
+    step = int(round(_BANDS[-1][1] / U))
+    n = (2 * ROOT) // step
+    ring = ([(-ROOT + k * step, -ROOT) for k in range(n)]
+            + [(ROOT, -ROOT + k * step) for k in range(n)]
+            + [(ROOT - k * step, ROOT) for k in range(n)]
+            + [(-ROOT, ROOT - k * step) for k in range(n)])
+    def Bv(ix, iy):
+        return V3(ix * U, iy * U, _base_z(ix * U, iy * U))
+    for k in range(len(ring)):
+        a = ring[k]; b = ring[(k + 1) % len(ring)]
+        tris.append([_v(*a, V3), Bv(*a), Bv(*b)])
+        tris.append([_v(*a, V3), Bv(*b), _v(*b, V3)])
+    for k in range(1, len(ring) - 1):
+        tris.append([Bv(*ring[0]), Bv(*ring[k + 1]), Bv(*ring[k])])
+    return tris, leaves
+
+
+# ---- PREM shells ----
+_PREM = [
+    ("innercore",    1221500, "INNERCORE", 13.0),
+    ("outercore",    3480000, "OUTERCORE", 11.0),
+    ("lower_mantle", 5701000, "MANTLE",     4.9),
+    ("upper_mantle", 6336000, "MANTLE",     3.4),
+    ("inner_crust",  6356000, "ROCK",       2.9),
+    ("upper_crust",  6371000, "ROCK",       2.65),
+]
+_ATMO = [
+    ("atmo_low",  6371000 + 12000,  "AIR", 4.0e-4),
+    ("atmo_mid",  6371000 + 50000,  "AIR", 6.0e-5),
+    ("atmo_top",  6371000 + 200000, "AIR", 1.0e-6),
+]
+
+# ---- schematic geology ----
+CONTACT_Z = -150.0    # Poorman/Yates contact (ENU z rel. detector)
+CONTACT_DIP = 55.0
+CONTACT_DIPDIR = 45.0
+DIKES = [(-400.0, 200.0, 315.0, 40.0, 30000.0),
+         (1200.0, -800.0, 300.0, 25.0, 30000.0)]
+
+
+# Beam downstream azimuth at the FD (from the FNAL->SURF chord). Must match
+# detector.py BEAM_AZIMUTH_DEG: +z (geometry) points along this geographic bearing.
+BEAM_AZIMUTH_DEG = 277.15
+
+
+def add_earth_model(model):
+    """Add the Homestake overburden + PREM Earth to a DUNE FD DetectorModel.
+
+    Must be called after the detector GDML is loaded. The model is in the SITE
+    FRAME: +y = up, +z = LBNF beam downstream (geographic azimuth ~277.15 deg),
+    +x = right-handed. The overburden is built in a local ENU frame (z = up) and
+    rotated into the site frame, so the real Black Hills topography is oriented
+    correctly relative to the beam.
+    """
+    from siren.math import Vector3D, Quaternion, Matrix3D
+    from siren.geometry import Box, Sphere, Placement, TriangularMesh, BooleanGeometry, BooleanOperation
+    from siren.detector import DetectorSector, ConstantDensityDistribution
+    V3 = Vector3D
+
+    # ---- load materials (supplements the GDML's own) ----
+    geo_mod = _load_sibling("homestake_geology", "homestake_geology.py")
+    mat_path = os.path.join(_THIS_DIR, "DUNEFD_homestake_materials.dat")
+    if not os.path.isfile(mat_path):
+        geo_mod.write_materials_dat(mat_path)
+    model.LoadMaterialModel(mat_path)
+    mats = model.GetMaterials()
+
+    # ---- ENU -> site rotation -------------------------------------------
+    # ENU: x=East, y=North, z=Up.  Site: x=right-handed, y=Up, z=beam azimuth.
+    # R maps ENU vectors to site coords (rows = site axes expressed in ENU):
+    #   site_z (beam) = (sin az, cos az, 0);  site_y (up) = (0,0,1);
+    #   site_x = site_y x site_z = (-cos az, sin az, 0).
+    az = math.radians(BEAM_AZIMUTH_DEG)
+    ca, sa = math.cos(az), math.sin(az)
+    R = (-ca, sa, 0.0,    0.0, 0.0, 1.0,    sa, ca, 0.0)
+    q_enu_site = Quaternion()
+    q_enu_site.SetMatrix(Matrix3D(*R))
+    enu_placement = Placement(V3(0.0, 0.0, 0.0), q_enu_site)
+
+    # Earth center is DEPTH below the surface; the detector (geometry origin,
+    # y~0) is the 4850L, so the center sits at y = -(R_PREM - DEPTH) (straight
+    # down). The PREM surface sphere (R_PREM) then passes through y = +DEPTH.
+    earth_place = Placement(V3(0.0, -(R_PREM - DEPTH), 0.0))
+
+    def sector(name, material, level, geo, rho):
+        s = DetectorSector()
+        s.name = name
+        s.material_id = mats.GetMaterialId(material)
+        s.level = level
+        s.geo = geo
+        s.density = ConstantDensityDistribution(float(rho))
+        model.AddSector(s)
+
+    # ---- level strategy -------------------------------------------------
+    # The composite has the vacuum "World" box at level 0 and all detector
+    # volumes above it (the DUSEL_Rock world boxes are unwrapped away by
+    # as_assembly). We want:
+    #   PREM (<0) < World(0) < local_crust/air < overburden < detector volumes.
+    # Shift every detector volume up to open a gap for the overburden.
+    sectors = model.Sectors
+    dup = {"local_crust", "local_air", "Poorman_bulk", "Yates_lens", "dike_0", "dike_1"}
+    dup |= set(n for n, *_ in (_PREM + _ATMO))
+    if any(s.name in dup for s in sectors):
+        raise RuntimeError("add_earth_model already applied to this model")
+    SHIFT = 100000
+    for s in sectors:
+        if s.name not in ("UNIVERSE", "World"):
+            s.level += SHIFT
+    model.Sectors = sorted(sectors, key=lambda s: s.level)
+
+    # ---- PREM background (far negative levels; innermost = highest wins) --
+    shells = _PREM + _ATMO                        # innermost first
+    n_sh = len(shells)
+    for i, (name, Rsh, material, rho) in enumerate(shells):
+        sector(name, material, -200 + (n_sh - 1 - i), Sphere(earth_place, float(Rsh), 0.0), rho)
+
+    # ---- local crust bridge + air (built in ENU, placed into site frame) --
+    deep = -15000.0
+    sky = 5000.0
+    sector("local_crust", "ROCK", 1,
+           Box(Placement(V3(0, (BASE_Z + deep) / 2, 0), q_enu_site),
+               2 * L_HALF, 2 * L_HALF, BASE_Z - deep), 2.75)
+    sector("local_air", "AIR", 2,
+           Box(Placement(V3(0, (BASE_Z + sky) / 2, 0), q_enu_site),
+               2 * L_HALF, 2 * L_HALF, sky - BASE_Z), 1.205e-3)
+
+    # ---- graded terrain mesh + formations -------------------------------
+    tris_enu, leaves = _build_graded_mesh(V3)
+    mesh = TriangularMesh(enu_placement, tris_enu)
+    sector("Poorman_bulk", "Poorman_phyllite", 3, mesh, 2.80)
+
+    dd = math.radians(CONTACT_DIP); cz = math.radians(CONTACT_DIPDIR)
+    nx, ny, nz = -math.sin(dd)*math.sin(cz), -math.sin(dd)*math.cos(cz), math.cos(dd)
+    Hz = 8000.0
+    rot_cont = Quaternion.rotation_between(V3(0, 0, 1), V3(nx, ny, nz))
+    cen_enu = V3(-nx*Hz/2, -ny*Hz/2, CONTACT_Z - nz*Hz/2)
+    yates_slab = Box(Placement(cen_enu, rot_cont), 120000.0, 120000.0, Hz)
+    yates_bool = BooleanGeometry(enu_placement, BooleanOperation.INTERSECTION,
+                                 TriangularMesh(tris_enu), yates_slab)
+    sector("Yates_lens", "Yates_amphibolite", 4, yates_bool, 2.95)
+
+    ceiling = DEPTH + 700
+    for i, (x0, y0, strike_az, t, L) in enumerate(DIKES):
+        a = math.radians(strike_az)
+        rotd = Quaternion.rotation_between(V3(1, 0, 0), V3(math.cos(a), -math.sin(a), 0.0))
+        dike = Box(Placement(V3(x0, y0, 0.5*(BASE_Z + ceiling)), rotd),
+                   t, L, ceiling - BASE_Z)
+        dike_bool = BooleanGeometry(enu_placement, BooleanOperation.INTERSECTION,
+                                    TriangularMesh(tris_enu), dike)
+        sector(f"dike_{i}", "Rhyolite_dike", 5 + i, dike_bool, 2.62)

--- a/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
@@ -299,11 +299,9 @@ _PREM = [
     ("inner_crust",  6356000, "ROCK",       2.9),
     ("upper_crust",  6371000, "ROCK",       2.65),
 ]
-_ATMO = [
-    ("atmo_low",  6371000 + 12000,  "AIR", 4.0e-4),
-    ("atmo_mid",  6371000 + 50000,  "AIR", 6.0e-5),
-    ("atmo_top",  6371000 + 200000, "AIR", 1.0e-6),
-]
+# Atmosphere shells are generated at load time from a pluggable air-density model
+# (default US Standard Atmosphere 1976; see atmosphere.py) as mass-conserving
+# spherical shells, replacing the old 3 hand-set AIR shells. See add_earth_model.
 
 # ---- schematic geology ----
 CONTACT_Z = -150.0    # Poorman/Yates contact (ENU z rel. detector)
@@ -318,7 +316,7 @@ DIKES = [(-400.0, 200.0, 315.0, 40.0, 30000.0),
 BEAM_AZIMUTH_DEG = 277.15
 
 
-def add_earth_model(model):
+def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
     """Add the Homestake overburden + PREM Earth to a DUNE FD DetectorModel.
 
     Must be called after the detector GDML is loaded. The model is in the SITE
@@ -326,6 +324,13 @@ def add_earth_model(model):
     +x = right-handed. The overburden is built in a local ENU frame (z = up) and
     rotated into the site frame, so the real Black Hills topography is oriented
     correctly relative to the beam.
+
+    The atmosphere is built as mass-conserving spherical shells from a pluggable
+    air-density model (``atmosphere``; default ``atmosphere.USStandard1976``) out
+    to ``atmo_top_km`` km ASL, and the near-surface ``local_air`` box is set from
+    the same model. Pass a custom ``atmosphere.Atmosphere`` subclass (e.g. an
+    NRLMSIS / GDAS / CORSIKA-Linsley profile) for atmospheric-neutrino production
+    studies where a specific or seasonal air column matters.
     """
     from siren.math import Vector3D, Quaternion, Matrix3D
     from siren.geometry import Box, Sphere, Placement, TriangularMesh, BooleanGeometry, BooleanOperation
@@ -374,8 +379,8 @@ def add_earth_model(model):
     # Shift every detector volume up to open a gap for the overburden.
     sectors = model.Sectors
     dup = {"local_crust", "local_air", "Poorman_bulk", "Yates_lens", "dike_0", "dike_1"}
-    dup |= set(n for n, *_ in (_PREM + _ATMO))
-    if any(s.name in dup for s in sectors):
+    dup |= set(n for n, *_ in _PREM)
+    if any(s.name in dup or s.name.startswith("atmo_") for s in sectors):
         raise RuntimeError("add_earth_model already applied to this model")
     SHIFT = 100000
     for s in sectors:
@@ -383,8 +388,21 @@ def add_earth_model(model):
             s.level += SHIFT
     model.Sectors = sorted(sectors, key=lambda s: s.level)
 
-    # ---- PREM background (far negative levels; innermost = highest wins) --
-    shells = _PREM + _ATMO                        # innermost first
+    # ---- atmosphere shells from the air-density model (mass-conserving) ---
+    # Built as spheres above R_PREM; R_PREM <-> the site surface (Z_SURF_SITE
+    # ASL), so a shell whose outer edge is at altitude h (ASL) has radius
+    # R_PREM + (h - Z_SURF_SITE). Each density is the mass-conserving (column-
+    # preserving) mean over its band -- the value that matters for slant depth.
+    atm_mod = _load_sibling("atmosphere", "atmosphere.py")
+    if atmosphere is None:
+        atmosphere = atm_mod.USStandard1976()
+    _init_site()                                   # sets Z_SURF_SITE, Z_DET_ASL
+    bnds = atm_mod.default_boundaries(Z_SURF_SITE, atmo_top_km * 1000.0)
+    atmo_shells = [(f"atmo_{k}", R_PREM + (asl_top - Z_SURF_SITE), "AIR", rho)
+                   for k, (asl_top, rho) in enumerate(atmosphere.shells(bnds))]
+
+    # ---- PREM + atmosphere (far negative levels; innermost = highest wins) -
+    shells = _PREM + atmo_shells                   # innermost first (ascending R)
     n_sh = len(shells)
     for i, (name, Rsh, material, rho) in enumerate(shells):
         sector(name, material, -200 + (n_sh - 1 - i), Sphere(earth_place, float(Rsh), 0.0), rho)
@@ -395,9 +413,12 @@ def add_earth_model(model):
     sector("local_crust", "ROCK", 1,
            Box(Placement(V3(0, (BASE_Z + deep) / 2, 0), q_enu_site),
                2 * L_HALF, 2 * L_HALF, BASE_Z - deep), 2.75)
+    # local_air density from the same atmosphere model: mass-conserving over the
+    # box's air column (site surface up to the box top; ENU sky -> ASL via Z_DET_ASL).
+    air_rho = atmosphere.shell_density_gcc(Z_SURF_SITE, Z_DET_ASL + sky)
     sector("local_air", "AIR", 2,
            Box(Placement(V3(0, (BASE_Z + sky) / 2, 0), q_enu_site),
-               2 * L_HALF, 2 * L_HALF, sky - BASE_Z), 1.205e-3)
+               2 * L_HALF, 2 * L_HALF, sky - BASE_Z), air_rho)
 
     # ---- graded terrain mesh + formations -------------------------------
     tris_enu, leaves = _build_graded_mesh(V3)

--- a/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
@@ -290,18 +290,9 @@ def _build_graded_mesh(V3):
     return tris, leaves
 
 
-# ---- PREM shells ----
-_PREM = [
-    ("innercore",    1221500, "INNERCORE", 13.0),
-    ("outercore",    3480000, "OUTERCORE", 11.0),
-    ("lower_mantle", 5701000, "MANTLE",     4.9),
-    ("upper_mantle", 6336000, "MANTLE",     3.4),
-    ("inner_crust",  6356000, "ROCK",       2.9),
-    ("upper_crust",  6371000, "ROCK",       2.65),
-]
-# Atmosphere shells are generated at load time from a pluggable air-density model
-# (default US Standard Atmosphere 1976; see atmosphere.py) as mass-conserving
-# spherical shells, replacing the old 3 hand-set AIR shells. See add_earth_model.
+# The PREM shells and the atmosphere are the canonical, shared ones from
+# siren.earth (see add_earth_model); this module supplies only the DUNE-specific
+# Homestake overburden (DEM terrain, formations, dikes) built on top of them.
 
 # ---- schematic geology ----
 CONTACT_Z = -150.0    # Poorman/Yates contact (ENU z rel. detector)
@@ -333,8 +324,15 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
     studies where a specific or seasonal air column matters.
     """
     from siren.math import Vector3D, Quaternion, Matrix3D
-    from siren.geometry import Box, Sphere, Placement, TriangularMesh, BooleanGeometry, BooleanOperation
+    from siren.geometry import Box, Placement, TriangularMesh, BooleanGeometry, BooleanOperation
     from siren.detector import DetectorSector, ConstantDensityDistribution
+    from siren.earth import (
+        CANONICAL_PREM_LAYERS,
+        USStandard1976,
+        AtmosphereForm,
+        build_earth_sectors,
+        insert_sectors_above,
+    )
     V3 = Vector3D
 
     # ---- load materials (supplements the GDML's own) ----
@@ -357,73 +355,59 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
     q_enu_site.SetMatrix(Matrix3D(*R))
     enu_placement = Placement(V3(0.0, 0.0, 0.0), q_enu_site)
 
-    # Earth center is DEPTH below the surface; the detector (geometry origin,
-    # y~0) is the 4850L, so the center sits at y = -(R_PREM - DEPTH) (straight
-    # down). The PREM surface sphere (R_PREM) then passes through y = +DEPTH.
-    earth_place = Placement(V3(0.0, -(R_PREM - DEPTH), 0.0))
+    # ---- canonical PREM + exponential atmosphere via the shared builder ----
+    # siren.earth places PREM/atmosphere below every existing volume using the
+    # predict-count-and-shift-up level scheme (World and the detector volumes
+    # shift up to make room). The site surface sits at radius R_PREM because the
+    # Earth center is DEPTH below the detector origin (y ~ 0 == 4850L).
+    if atmosphere is None:
+        atmosphere = USStandard1976()
+    _init_site()                                   # sets Z_SURF_SITE, Z_DET_ASL
 
-    def sector(name, material, level, geo, rho):
+    build_earth_sectors(
+        model,
+        surface_offset=DEPTH,
+        prem_layers=CANONICAL_PREM_LAYERS,
+        atmosphere=AtmosphereForm(model=atmosphere, mode="exponential",
+                                  top_m=atmo_top_km * 1000.0),
+        up_axis=(0.0, 1.0, 0.0),
+        r_prem=R_PREM,
+    )
+
+    # ---- site overburden: built in ENU, inserted just above "World" --------
+    # The local crust/air and Homestake formations must override the vacuum
+    # World box but stay below the detector volumes. insert_sectors_above shifts
+    # the detector volumes up and gives the overburden the freed levels
+    # (ascending priority: local_crust lowest, dikes highest) -- no absolute or
+    # negative level constants.
+    def _geo(name, material, geo, rho):
         s = DetectorSector()
         s.name = name
         s.material_id = mats.GetMaterialId(material)
-        s.level = level
         s.geo = geo
         s.density = ConstantDensityDistribution(float(rho))
-        model.AddSector(s)
+        return s
 
-    # ---- level strategy -------------------------------------------------
-    # The composite has the vacuum "World" box at level 0 and all detector
-    # volumes above it (the DUSEL_Rock world boxes are unwrapped away by
-    # as_assembly). We want:
-    #   PREM (<0) < World(0) < local_crust/air < overburden < detector volumes.
-    # Shift every detector volume up to open a gap for the overburden.
-    sectors = model.Sectors
-    dup = {"local_crust", "local_air", "Poorman_bulk", "Yates_lens", "dike_0", "dike_1"}
-    dup |= set(n for n, *_ in _PREM)
-    if any(s.name in dup or s.name.startswith("atmo_") for s in sectors):
-        raise RuntimeError("add_earth_model already applied to this model")
-    SHIFT = 100000
-    for s in sectors:
-        if s.name not in ("UNIVERSE", "World"):
-            s.level += SHIFT
-    model.Sectors = sorted(sectors, key=lambda s: s.level)
-
-    # ---- atmosphere shells from the air-density model (mass-conserving) ---
-    # Built as spheres above R_PREM; R_PREM <-> the site surface (Z_SURF_SITE
-    # ASL), so a shell whose outer edge is at altitude h (ASL) has radius
-    # R_PREM + (h - Z_SURF_SITE). Each density is the mass-conserving (column-
-    # preserving) mean over its band -- the value that matters for slant depth.
-    atm_mod = _load_sibling("atmosphere", "atmosphere.py")
-    if atmosphere is None:
-        atmosphere = atm_mod.USStandard1976()
-    _init_site()                                   # sets Z_SURF_SITE, Z_DET_ASL
-    bnds = atm_mod.default_boundaries(Z_SURF_SITE, atmo_top_km * 1000.0)
-    atmo_shells = [(f"atmo_{k}", R_PREM + (asl_top - Z_SURF_SITE), "AIR", rho)
-                   for k, (asl_top, rho) in enumerate(atmosphere.shells(bnds))]
-
-    # ---- PREM + atmosphere (far negative levels; innermost = highest wins) -
-    shells = _PREM + atmo_shells                   # innermost first (ascending R)
-    n_sh = len(shells)
-    for i, (name, Rsh, material, rho) in enumerate(shells):
-        sector(name, material, -200 + (n_sh - 1 - i), Sphere(earth_place, float(Rsh), 0.0), rho)
+    overburden = []
 
     # ---- local crust bridge + air (built in ENU, placed into site frame) --
     deep = -15000.0
     sky = 5000.0
-    sector("local_crust", "ROCK", 1,
+    overburden.append(_geo("local_crust", "ROCK",
            Box(Placement(V3(0, (BASE_Z + deep) / 2, 0), q_enu_site),
-               2 * L_HALF, 2 * L_HALF, BASE_Z - deep), 2.75)
-    # local_air density from the same atmosphere model: mass-conserving over the
-    # box's air column (site surface up to the box top; ENU sky -> ASL via Z_DET_ASL).
-    air_rho = atmosphere.shell_density_gcc(Z_SURF_SITE, Z_DET_ASL + sky)
-    sector("local_air", "AIR", 2,
+               2 * L_HALF, 2 * L_HALF, BASE_Z - deep), 2.75))
+    # local_air density from the same atmosphere model: mass-conserving mean of
+    # the air column from the site surface up to the box top (altitudes measured
+    # above the site surface, ASL top = Z_DET_ASL + sky).
+    air_rho = atmosphere.shell_mean_density(0.0, max(1.0, (Z_DET_ASL + sky) - Z_SURF_SITE))
+    overburden.append(_geo("local_air", "AIR",
            Box(Placement(V3(0, (BASE_Z + sky) / 2, 0), q_enu_site),
-               2 * L_HALF, 2 * L_HALF, sky - BASE_Z), air_rho)
+               2 * L_HALF, 2 * L_HALF, sky - BASE_Z), air_rho))
 
     # ---- graded terrain mesh + formations -------------------------------
     tris_enu, leaves = _build_graded_mesh(V3)
     mesh = TriangularMesh(enu_placement, tris_enu)
-    sector("Poorman_bulk", "Poorman_phyllite", 3, mesh, 2.80)
+    overburden.append(_geo("Poorman_bulk", "Poorman_phyllite", mesh, 2.80))
 
     dd = math.radians(CONTACT_DIP); cz = math.radians(CONTACT_DIPDIR)
     nx, ny, nz = -math.sin(dd)*math.sin(cz), -math.sin(dd)*math.cos(cz), math.cos(dd)
@@ -433,7 +417,7 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
     yates_slab = Box(Placement(cen_enu, rot_cont), 120000.0, 120000.0, Hz)
     yates_bool = BooleanGeometry(enu_placement, BooleanOperation.INTERSECTION,
                                  TriangularMesh(tris_enu), yates_slab)
-    sector("Yates_lens", "Yates_amphibolite", 4, yates_bool, 2.95)
+    overburden.append(_geo("Yates_lens", "Yates_amphibolite", yates_bool, 2.95))
 
     ceiling = DEPTH + 700
     for i, (x0, y0, strike_az, t, L) in enumerate(DIKES):
@@ -443,4 +427,6 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
                    t, L, ceiling - BASE_Z)
         dike_bool = BooleanGeometry(enu_placement, BooleanOperation.INTERSECTION,
                                     TriangularMesh(tris_enu), dike)
-        sector(f"dike_{i}", "Rhyolite_dike", 5 + i, dike_bool, 2.62)
+        overburden.append(_geo(f"dike_{i}", "Rhyolite_dike", dike_bool, 2.62))
+
+    insert_sectors_above(model, "World", overburden)

--- a/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/earth_model.py
@@ -23,6 +23,12 @@ import numpy as np
 
 _THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
+# Generated/downloaded data (DEM tiles, materials .dat) goes in the writable
+# mirror of this resource directory: _THIS_DIR itself may be a read-only
+# site-packages install. Sibling .py sources are still read from _THIS_DIR.
+from siren.download import writable_data_dir
+_ABS_DIR = writable_data_dir(_THIS_DIR)
+
 # SURF/Homestake 4850L site
 SITE_LAT = 44.352
 SITE_LON = -103.751
@@ -47,7 +53,7 @@ def _load_sibling(name, filename):
 
 
 # ---- DEM access (Copernicus GLO-30) ----
-_DEM_DIR = os.path.join(_THIS_DIR, "dem")
+_DEM_DIR = os.path.join(_ABS_DIR, "dem")
 _TILES = {}
 _SAT = {}
 
@@ -62,7 +68,13 @@ def _ensure_dem():
     if _TILES:
         return
     os.makedirs(_DEM_DIR, exist_ok=True)
-    import tifffile
+    try:
+        import tifffile
+    except ImportError as e:
+        raise ImportError(
+            "The DUNE FD terrain model reads Copernicus GLO-30 DEM tiles, "
+            "which requires the optional 'tifffile' package. Install it with "
+            "'pip install tifffile' to use earth_model=True.") from e
     for ul_lon, fn in [(-104.0, "cop30_N44_W104.tif"), (-105.0, "cop30_N44_W105.tif")]:
         path = os.path.join(_DEM_DIR, fn)
         if not os.path.isfile(path):
@@ -337,7 +349,7 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
 
     # ---- load materials (supplements the GDML's own) ----
     geo_mod = _load_sibling("homestake_geology", "homestake_geology.py")
-    mat_path = os.path.join(_THIS_DIR, "DUNEFD_homestake_materials.dat")
+    mat_path = os.path.join(_ABS_DIR, "DUNEFD_homestake_materials.dat")
     if not os.path.isfile(mat_path):
         geo_mod.write_materials_dat(mat_path)
     model.LoadMaterialModel(mat_path)
@@ -405,8 +417,15 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
                2 * L_HALF, 2 * L_HALF, sky - BASE_Z), air_rho))
 
     # ---- graded terrain mesh + formations -------------------------------
+    # Build the DEM mesh (and its BVH) once in each frame it is needed:
+    # `mesh` carries the ENU->site placement and is the Poorman_bulk sector
+    # geometry; `terrain_enu` is the same triangles with identity placement,
+    # shared by the boolean intersections below, whose components live in the
+    # boolean's local (ENU) frame -- the enclosing BooleanGeometry applies the
+    # ENU->site placement, so a placed mesh there would rotate twice.
     tris_enu, leaves = _build_graded_mesh(V3)
     mesh = TriangularMesh(enu_placement, tris_enu)
+    terrain_enu = TriangularMesh(tris_enu)
     overburden.append(_geo("Poorman_bulk", "Poorman_phyllite", mesh, 2.80))
 
     dd = math.radians(CONTACT_DIP); cz = math.radians(CONTACT_DIPDIR)
@@ -416,7 +435,7 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
     cen_enu = V3(-nx*Hz/2, -ny*Hz/2, CONTACT_Z - nz*Hz/2)
     yates_slab = Box(Placement(cen_enu, rot_cont), 120000.0, 120000.0, Hz)
     yates_bool = BooleanGeometry(enu_placement, BooleanOperation.INTERSECTION,
-                                 TriangularMesh(tris_enu), yates_slab)
+                                 terrain_enu, yates_slab)
     overburden.append(_geo("Yates_lens", "Yates_amphibolite", yates_bool, 2.95))
 
     ceiling = DEPTH + 700
@@ -426,7 +445,7 @@ def add_earth_model(model, atmosphere=None, atmo_top_km=100.0):
         dike = Box(Placement(V3(x0, y0, 0.5*(BASE_Z + ceiling)), rotd),
                    t, L, ceiling - BASE_Z)
         dike_bool = BooleanGeometry(enu_placement, BooleanOperation.INTERSECTION,
-                                    TriangularMesh(tris_enu), dike)
+                                    terrain_enu, dike)
         overburden.append(_geo(f"dike_{i}", "Rhyolite_dike", dike_bool, 2.62))
 
     insert_sectors_above(model, "World", overburden)

--- a/resources/detectors/DUNEFD/DUNEFD-v2/homestake_geology.py
+++ b/resources/detectors/DUNEFD/DUNEFD-v2/homestake_geology.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Homestake / SURF 4850L geology: schematic rock units with density + isotopic
+composition, for the DUNE FD 3D overburden model.
+
+Provides, per rock unit, a SIREN material (PDG isotope -> mass fraction) built by
+expanding a representative major-oxide chemistry into natural isotopes, with the
+measured U/Th/K assays folded in. Writes a SIREN materials.dat.
+
+SCHEMATIC: the major-oxide chemistries are representative literature values for
+the rock TYPES (mafic amphibolite, pelitic/carbonate phyllite, felsic rhyolite);
+the U/Th/K are the measured SURF assays. Bulk densities are representative.
+Stratigraphy/structure at SURF is multiply-deformed (Lead anticlinorium), so the
+unit GEOMETRY (handled separately) is schematic too.
+
+Sources: USGS Geolex (Poorman/Homestake/Yates/Ellison); SURF radioassays
+(amphibolite 0.22/0.33 ppm U/Th, 0.96% K; Poorman 2.58/10.48 ppm, 2.12% K;
+rhyolite 8.75/10.86 ppm, 4.17% K); DUNE DUSEL_Rock (duneggd) for the average.
+"""
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Standard atomic weights (for oxide -> element mass conversion)
+# ---------------------------------------------------------------------------
+AW = dict(H=1.008, C=12.011, N=14.007, O=15.999, Na=22.990, Mg=24.305,
+          Al=26.982, Si=28.085, P=30.974, S=32.06, K=39.098, Ca=40.078,
+          Ti=47.867, Mn=54.938, Fe=55.845, U=238.029, Th=232.038, Ar=39.948)
+Z = dict(H=1, C=6, N=7, O=8, Na=11, Mg=12, Al=13, Si=14, P=15, S=16, K=19,
+         Ca=20, Ti=22, Mn=25, Fe=26, U=92, Th=90, Ar=18)
+
+# Natural isotopes: symbol -> [(A, atomic_mass_amu, mole_abundance_fraction), ...]
+ISO = {
+    "H":  [(1, 1.007825, 0.999885), (2, 2.014102, 0.000115)],
+    "C":  [(12, 12.000000, 0.9893), (13, 13.003355, 0.0107)],
+    "N":  [(14, 14.003074, 0.99636), (15, 15.000109, 0.00364)],
+    "O":  [(16, 15.994915, 0.99757), (17, 16.999132, 0.00038), (18, 17.999160, 0.00205)],
+    "Na": [(23, 22.989769, 1.0)],
+    "Mg": [(24, 23.985042, 0.7899), (25, 24.985837, 0.1000), (26, 25.982593, 0.1101)],
+    "Al": [(27, 26.981539, 1.0)],
+    "Si": [(28, 27.976927, 0.92223), (29, 28.976495, 0.04685), (30, 29.973770, 0.03092)],
+    "P":  [(31, 30.973762, 1.0)],
+    "S":  [(32, 31.972071, 0.9499), (33, 32.971459, 0.0075), (34, 33.967867, 0.0425), (36, 35.967081, 0.0001)],
+    "K":  [(39, 38.963707, 0.932581), (40, 39.963998, 0.000117), (41, 40.961825, 0.067302)],
+    "Ca": [(40, 39.962591, 0.96941), (42, 41.958618, 0.00647), (43, 42.958766, 0.00135),
+           (44, 43.955481, 0.02086), (46, 45.953693, 0.00004), (48, 47.952534, 0.00187)],
+    "Ti": [(46, 45.952628, 0.0825), (47, 46.951759, 0.0744), (48, 47.947942, 0.7372),
+           (49, 48.947866, 0.0541), (50, 49.944787, 0.0518)],
+    "Mn": [(55, 54.938044, 1.0)],
+    "Fe": [(54, 53.939609, 0.05845), (56, 55.934936, 0.91754), (57, 56.935393, 0.02119), (58, 57.933274, 0.00282)],
+    "U":  [(234, 234.040952, 0.000054), (235, 235.043930, 0.007204), (238, 238.050788, 0.992742)],
+    "Th": [(232, 232.038056, 1.0)],
+    "Ar": [(36, 35.967545, 0.003336), (38, 37.962732, 0.000629), (40, 39.962383, 0.996035)],
+}
+
+# Oxide -> {element: count}
+OXIDE = dict(SiO2={"Si":1,"O":2}, Al2O3={"Al":2,"O":3}, FeO={"Fe":1,"O":1},
+            Fe2O3={"Fe":2,"O":3}, MgO={"Mg":1,"O":1}, CaO={"Ca":1,"O":1},
+            Na2O={"Na":2,"O":1}, K2O={"K":2,"O":1}, TiO2={"Ti":1,"O":2},
+            MnO={"Mn":1,"O":1}, P2O5={"P":2,"O":5}, CO2={"C":1,"O":2}, H2O={"H":2,"O":1})
+
+
+def pdg(zz: int, aa: int) -> int:
+    return 1000000000 + zz * 10000 + aa * 10
+
+
+def _k2o_from_pct_K(pct_K: float) -> float:
+    """wt% K2O that contains pct_K wt% elemental K."""
+    return pct_K * (2 * AW["K"] + AW["O"]) / (2 * AW["K"])
+
+
+# ---------------------------------------------------------------------------
+# Rock units. Composition in wt% of components (oxides or free elements).
+# trace: ppm by mass for U/Th. K given as elemental wt% -> converted to K2O.
+# ---------------------------------------------------------------------------
+def _poorman():
+    K2O = _k2o_from_pct_K(2.12)
+    comp = dict(SiO2=58.0, Al2O3=17.0, FeO=7.0, MgO=3.0, CaO=3.5, Na2O=1.5,
+                K2O=K2O, TiO2=0.8, MnO=0.1, P2O5=0.2, CO2=4.5, H2O=1.0, C=0.3)
+    return dict(name="Poorman_phyllite", density=2.80, comp=comp,
+                trace_ppm=dict(U=2.58, Th=10.48),
+                desc="Poorman Fm: carbonate/sericite/graphitic phyllite (bulk overburden)")
+
+
+def _yates():
+    K2O = _k2o_from_pct_K(0.96)
+    comp = dict(SiO2=49.0, Al2O3=14.0, FeO=12.0, MgO=7.0, CaO=10.0, Na2O=2.5,
+                K2O=K2O, TiO2=1.5, MnO=0.2, P2O5=0.2)
+    return dict(name="Yates_amphibolite", density=2.95, comp=comp,
+                trace_ppm=dict(U=0.22, Th=0.33),
+                desc="Yates amphibolite: mafic metavolcanic (dense, radio-clean, hosts 4850L)")
+
+
+def _rhyolite():
+    K2O = _k2o_from_pct_K(4.17)
+    comp = dict(SiO2=72.0, Al2O3=13.0, FeO=2.0, MgO=0.4, CaO=1.2, Na2O=3.2,
+                K2O=K2O, TiO2=0.3)
+    return dict(name="Rhyolite_dike", density=2.62, comp=comp,
+                trace_ppm=dict(U=8.75, Th=10.86),
+                desc="Tertiary rhyolite dike (felsic, high U/Th/K)")
+
+
+def _dusel_avg():
+    # DUNE-official average rock (duneggd), already element/oxide mix
+    comp = dict(SiO2=52.67, FeO=11.74, Al2O3=10.25, MgO=4.73, CO2=4.22,
+                CaO=3.82, C=2.40, S=1.86, Na2O=0.53, P2O5=0.07, O=7.71)
+    return dict(name="DUSEL_Rock", density=2.82, comp=comp, trace_ppm={},
+                desc="DUNE-official average cavern rock (fallback / generic)")
+
+
+def _air():
+    # dry air element mass fractions
+    comp = dict(N=75.52, O=23.14, Ar=1.288, C=0.012)
+    return dict(name="AIR", density=1.205e-3, comp=comp, trace_ppm={},
+                desc="dry air")
+
+
+def _lar():
+    return dict(name="LAr", density=1.396, comp=dict(Ar=100.0), trace_ppm={},
+                desc="liquid argon (detector placeholder)")
+
+
+# --- PREM background materials (for the Earth shells the local model embeds in) ---
+def _crust():   # generic upper/inner crust
+    return dict(name="ROCK", density=2.65, comp=dict(SiO2=66.0, Al2O3=15.0, FeO=5.0,
+                CaO=4.0, Na2O=3.5, K2O=3.0, MgO=2.5), trace_ppm={}, desc="generic crust (PREM)")
+
+
+def _mantle():
+    return dict(name="MANTLE", density=3.3, comp=dict(SiO2=45.0, MgO=38.0, FeO=8.0,
+                Al2O3=4.5, CaO=3.5), trace_ppm={}, desc="pyrolite mantle (PREM)")
+
+
+def _innercore():
+    return dict(name="INNERCORE", density=13.0, comp=dict(Fe=100.0), trace_ppm={}, desc="Fe inner core")
+
+
+def _outercore():
+    return dict(name="OUTERCORE", density=11.0, comp=dict(Fe=100.0), trace_ppm={}, desc="Fe outer core")
+
+
+UNITS = [_air(), _lar(), _dusel_avg(), _poorman(), _yates(), _rhyolite(),
+         _crust(), _mantle(), _innercore(), _outercore()]
+
+
+# ---------------------------------------------------------------------------
+# Composition -> element mass fractions -> isotope (PDG) mass fractions
+# ---------------------------------------------------------------------------
+def element_mass_fractions(unit: dict) -> dict:
+    em: dict[str, float] = {}
+    for comp, wt in unit["comp"].items():
+        if comp in OXIDE:
+            fw = sum(n * AW[el] for el, n in OXIDE[comp].items())
+            for el, n in OXIDE[comp].items():
+                em[el] = em.get(el, 0.0) + wt * n * AW[el] / fw
+        else:  # free element symbol
+            em[comp] = em.get(comp, 0.0) + wt
+    for el, ppm in unit.get("trace_ppm", {}).items():
+        em[el] = em.get(el, 0.0) + ppm * 1e-4  # ppm -> wt%
+    tot = sum(em.values())
+    return {el: w / tot for el, w in em.items()}
+
+
+def isotope_mass_fractions(unit: dict) -> dict:
+    """PDG code -> mass fraction (sums to 1)."""
+    em = element_mass_fractions(unit)
+    out: dict[int, float] = {}
+    for el, w in em.items():
+        isos = ISO[el]
+        denom = sum(ab * m for _, m, ab in isos)
+        for A, m, ab in isos:
+            out[pdg(Z[el], A)] = out.get(pdg(Z[el], A), 0.0) + w * ab * m / denom
+    tot = sum(out.values())
+    return {k: v / tot for k, v in out.items()}
+
+
+def zoverA(unit: dict) -> tuple[float, float, float]:
+    """Return (<Z>_mass, <A>_mass, Z/A) for sanity checks."""
+    em = element_mass_fractions(unit)
+    ZA = sum(w * Z[el] / AW[el] for el, w in em.items())          # electron fraction
+    meanZ = sum(w * Z[el] for el, w in em.items())
+    meanA = sum(w * AW[el] for el, w in em.items())
+    return meanZ, meanA, ZA
+
+
+def write_materials_dat(path: str) -> None:
+    lines = ["# DUNE FD Homestake 3D overburden materials",
+             "# PDG isotope -> mass fraction. See homestake_geology.py for provenance.",
+             ""]
+    for u in UNITS:
+        iso = isotope_mass_fractions(u)
+        iso = {k: v for k, v in iso.items() if v > 1e-12}
+        lines.append(f"{u['name']} {len(iso)}")
+        for code in sorted(iso):
+            lines.append(f"{code} {iso[code]:.10f}")
+        lines.append("")
+    with open(path, "w") as fh:
+        fh.write("\n".join(lines))
+
+
+if __name__ == "__main__":
+    import os
+    out = os.path.join(os.path.dirname(__file__), "DUNEFD_homestake_materials.dat")
+    write_materials_dat(out)
+    print("wrote", out)
+    print(f"\n{'unit':22s} {'rho':>5s} {'<Z>':>6s} {'<A>':>6s} {'Z/A':>6s}  niso")
+    for u in UNITS:
+        mz, ma, za = zoverA(u)
+        n = len([v for v in isotope_mass_fractions(u).values() if v > 1e-12])
+        print(f"{u['name']:22s} {u['density']:5.2f} {mz:6.2f} {ma:6.2f} {za:6.4f}  {n}")

--- a/resources/detectors/SBN/SBN-v1/detector.py
+++ b/resources/detectors/SBN/SBN-v1/detector.py
@@ -54,14 +54,17 @@ _DATA_BASE = (
 )
 
 
-def _beamline_sources():
+def _beamline_sources(lbnf=False):
+    """Beamline GDML sources placed in the BNB world.
+
+    Always includes the BNB and NuMI beamlines. The DUNE LBNF beam (g4lbnf)
+    is appended only when ``lbnf=True`` -- it is the DUNE beamline (~700 KB /
+    911 volumes), off by default so SBN-only loads stay lean.
+    """
     T_numi = geo.transform("NuMI", "BNB")
     numi_origin_bnb = T_numi.apply([0.0, 0.0, 0.0])
     numi_rx, numi_ry, numi_rz = geo.gdml_rotation_angles(T_numi.R.T)
-    T_lbnf = geo.transform("LBNF", "BNB")
-    lbnf_origin_bnb = T_lbnf.apply([0.0, 0.0, 0.0])
-    lbnf_rx, lbnf_ry, lbnf_rz = geo.gdml_rotation_angles(T_lbnf.R.T)
-    return [
+    sources = [
         {
             "file": "gdml/BooNE_50m.gdml",
             "prefix": "bnb",
@@ -80,23 +83,26 @@ def _beamline_sources():
             "url": f"{_DATA_BASE}/NuMI/numi_g4export_2026-05-19.gdml",
             "sha256": "39670d52a6181352a8ae7c798387a9c58de950462c634e57da7d39fb23abe30a",
         },
-        {
-            # DUNE LBNF beamline (g4lbnf export, OptEngDesignJul2020). Placed via
-            # the LBNF->BNB edge in sbn_geometry (MI-10/MI-60 FSCS survey bridged
-            # through NuMI; horizontal ~10-15 m, vertical y_up=8.369 m -- LBNF
-            # MCZero at site grade = MiniBooNE room floor). Staged in gdml/ --
-            # no remote
-            # URL yet. NOTE: this is the DUNE beam, included in every SBN load;
-            # gate it behind a flag if SBN-only loads should stay lean.
+    ]
+    if lbnf:
+        # DUNE LBNF beamline (g4lbnf export, OptEngDesignJul2020). Placed via
+        # the LBNF->BNB edge in sbn_geometry (MI-10/MI-60 FSCS survey bridged
+        # through NuMI; horizontal ~10-15 m; vertical y_up=8.369 m, MCZero at
+        # site grade = MiniBooNE room floor). Provenance: the LBNF/ README in
+        # SIREN-data.
+        T_lbnf = geo.transform("LBNF", "BNB")
+        lbnf_origin_bnb = T_lbnf.apply([0.0, 0.0, 0.0])
+        lbnf_rx, lbnf_ry, lbnf_rz = geo.gdml_rotation_angles(T_lbnf.R.T)
+        sources.append({
             "file": "gdml/g4lbnf.gdml",
             "prefix": "lbnf",
             "position": tuple(lbnf_origin_bnb),
             "rotation": (lbnf_rx, lbnf_ry, lbnf_rz),
             "unwrap": False,
-            "url": None,
-            "sha256": "",
-        },
-    ]
+            "url": f"{_DATA_BASE}/LBNF/g4lbnf.gdml",
+            "sha256": "f0e0f32cc3cf45fb1a783d84d470a5d2caa06b7ba667648482f8e4137d507cdc",
+        })
+    return sources
 
 _DETECTOR_SPECS = {
     "ICARUS": {
@@ -135,14 +141,14 @@ def fetch_data():
     # MiniBooNE's tank GDML has no remote URL; generate it locally first so
     # _ensure_gdml_files finds it present rather than failing to download.
     sbn_loader.ensure_miniboone_gdml(_ABS_DIR)
-    all_sources = list(_beamline_sources())
+    all_sources = list(_beamline_sources(lbnf=True))
     for spec in _DETECTOR_SPECS.values():
         if spec.get("file"):
             all_sources.append(spec)
     sbn_loader._ensure_gdml_files(_ABS_DIR, all_sources)
 
 
-def load_detector(detector=None, earth_model=False):
+def load_detector(detector=None, earth_model=False, lbnf=False):
     """Load an SBN detector model.
 
     Parameters
@@ -160,6 +166,11 @@ def load_detector(detector=None, earth_model=False):
         correction for the Midwest crust.  Use this for atmospheric
         neutrino studies or BSM searches where interactions can occur
         far from the detector.
+    lbnf : bool, optional
+        If *True*, also place the DUNE LBNF beamline (g4lbnf) in the
+        BNB world via the LBNF->BNB transform (MCZero at site grade,
+        ~263 m west of the BNB target).  Off by default: it is the DUNE
+        beam (~700 KB / 911 volumes), not part of an SBN-only model.
 
     Returns
     -------
@@ -207,7 +218,7 @@ def load_detector(detector=None, earth_model=False):
         rx, ry, rz = geo.gdml_rotation_angles(T_det_to_bnb.R.T)
         det_rotation = (rx, ry, rz)
 
-    sources = list(_beamline_sources())
+    sources = list(_beamline_sources(lbnf=lbnf))
     if spec["file"] is not None:
         sources.append({
             "file": spec["file"],

--- a/resources/detectors/SBN/SBN-v1/detector.py
+++ b/resources/detectors/SBN/SBN-v1/detector.py
@@ -58,6 +58,9 @@ def _beamline_sources():
     T_numi = geo.transform("NuMI", "BNB")
     numi_origin_bnb = T_numi.apply([0.0, 0.0, 0.0])
     numi_rx, numi_ry, numi_rz = geo.gdml_rotation_angles(T_numi.R.T)
+    T_lbnf = geo.transform("LBNF", "BNB")
+    lbnf_origin_bnb = T_lbnf.apply([0.0, 0.0, 0.0])
+    lbnf_rx, lbnf_ry, lbnf_rz = geo.gdml_rotation_angles(T_lbnf.R.T)
     return [
         {
             "file": "gdml/BooNE_50m.gdml",
@@ -76,6 +79,22 @@ def _beamline_sources():
             "unwrap": False,
             "url": f"{_DATA_BASE}/NuMI/numi_g4export_2026-05-19.gdml",
             "sha256": "39670d52a6181352a8ae7c798387a9c58de950462c634e57da7d39fb23abe30a",
+        },
+        {
+            # DUNE LBNF beamline (g4lbnf export, OptEngDesignJul2020). Placed via
+            # the LBNF->BNB edge in sbn_geometry (MI-10/MI-60 FSCS survey bridged
+            # through NuMI; horizontal ~10-15 m, vertical y_up=8.369 m -- LBNF
+            # MCZero at site grade = MiniBooNE room floor). Staged in gdml/ --
+            # no remote
+            # URL yet. NOTE: this is the DUNE beam, included in every SBN load;
+            # gate it behind a flag if SBN-only loads should stay lean.
+            "file": "gdml/g4lbnf.gdml",
+            "prefix": "lbnf",
+            "position": tuple(lbnf_origin_bnb),
+            "rotation": (lbnf_rx, lbnf_ry, lbnf_rz),
+            "unwrap": False,
+            "url": None,
+            "sha256": "",
         },
     ]
 

--- a/resources/detectors/SBN/SBN-v1/detector.py
+++ b/resources/detectors/SBN/SBN-v1/detector.py
@@ -133,6 +133,20 @@ _DETECTOR_SPECS = {
         "url": None,
         "sha256": "",
     },
+    # DUNE near-detector hall (ND-LAr + TMS + SAND), material-aggregated from
+    # dunendggd @ TDR_Production_geometry_v_1.2.0 with DUNENDGGD_AGGREGATE=1
+    # (fine readout/straws/slabs collapsed to homogenized blocks; active LAr
+    # volTPCActive preserved). Placed via the DUNE_ND -> LBNF -> BNB edges in
+    # sbn_geometry (~555 m downstream of the LBNF target, on the beam axis).
+    # unwrap=True: place the hall+rock contents, not the dunendggd world box.
+    # Provenance: the DUNE_ND/ README in SIREN-data.
+    "DUNE_ND": {
+        "file": "gdml/nd_hall_with_lar_tms_sand.gdml",
+        "prefix": "dune_nd",
+        "unwrap": True,
+        "url": f"{_DATA_BASE}/DUNE_ND/nd_hall_with_lar_tms_sand.gdml",
+        "sha256": "b277cb887dba1dae1a3d6358eccdd7338e4e07c51b022b519eb70491d36ba243",
+    },
 }
 
 
@@ -154,7 +168,10 @@ def load_detector(detector=None, earth_model=False, lbnf=False):
     Parameters
     ----------
     detector : str
-        Which detector to load ("ICARUS" or "SBND").
+        Which detector to load: "ICARUS", "SBND", "MiniBooNE", or "DUNE_ND"
+        (the aggregated DUNE near-detector hall, placed on the LBNF beam axis
+        ~555 m downstream of the LBNF target; pair with lbnf=True to also place
+        the LBNF beamline).
     earth_model : bool, optional
         If *False* (default), only load the GDML site-geology volume
         (beamlines, detector, local stratigraphy within ~500 m).

--- a/resources/detectors/SBN/SBN-v1/sbn_geometry.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_geometry.py
@@ -216,6 +216,105 @@ def _build_graph() -> FrameGraph:
         "MiniBooNE_local", "BNB", T_MiniBooNE_local,
         "G4BNB MiniBooNE bsim::Location (0, 189.614, 54134) cm; NuBeamOutput.cc:136"))
 
+    # ==================================================================
+    # DUNE / LBNF beamline + near detectors
+    #
+    # Authoritative beam<->detector transforms from the DUNE GNuMIFlux
+    # configs -- the same kind of dk2nu/GENIE flux-driver artifact as the
+    # icaruscode GNuMIFlux.xml used for NuMI above. GNuMIFlux <beampos>
+    # "( user ) = ( beam )" gives one physical point in both frames;
+    # <beamdir> is the user->beam rotation (here a single rotation about x
+    # = the beam declination). So r_beam = Rx(theta) @ r_user + t.
+    #
+    # NOTE: these anchor the DUNE detectors to their *beams*. The 2x2
+    # (ProtoDUNE-ND) is in the NuMI beam (MINOS/MINERvA hall) -> reaches
+    # BNB via the existing NuMI edge. The full DUNE_ND is in the LBNF beam;
+    # since no single flux artifact crosses experiments, the LBNF->BNB site
+    # tie (LBNF vs BNB/NuMI target offset + azimuth) is instead derived below
+    # from the Fermilab MI-10/MI-60 survey bridged through NuMI.
+    # ==================================================================
+    def _Rx(theta):
+        c, s = math.cos(theta), math.sin(theta)
+        return np.array([[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]])
+
+    # LBNF beam frame: MCZERO at the target / Horn 1, +z along the
+    # (horizontal-built) beam axis, +y up. Matches the g4lbnf Tunnel world.
+    g.add_frame(Frame("LBNF",
+        "LBNF beam frame (g4lbnf Tunnel world; MCZERO at target).",
+        "LBNF target / Horn 1 (MCZERO)",
+        "horizontal", "up", "along LBNF beam axis (downstream, built horizontal)"))
+
+    # DUNE ND geometry frame (edep-sim / dunendggd world); level hall, the
+    # beam enters dipping 101 mrad.
+    g.add_frame(Frame("DUNE_ND",
+        "DUNE near detector geometry frame (edep-sim / dunendggd world).",
+        "DUNE ND hall reference", "beam-left", "up", "downstream (level)"))
+
+    # DUNE_ND -> LBNF. GNuMIFlux DUNEND: beamdir Rx(-0.101); beampos
+    # user(0, 0.05387, 6.66) m = beam(0, 0, 562.1179) m. Places the ND on
+    # the beam axis ~555 m downstream (~0.73 m below); the target sits
+    # ~552.6 m upstream and ~56.7 m above the ND (562 * 0.101 = 56.8 m check).
+    _R_nd_lbnf = _Rx(-0.101)
+    _t_nd_lbnf = (np.array([0.0, 0.0, 562.1179])
+                  - _R_nd_lbnf @ np.array([0.0, 0.05387, 6.66]))
+    g.add_transform(Transform(
+        "DUNE_ND", "LBNF", _R_nd_lbnf, _t_nd_lbnf,
+        "DUNE/ND_Production toolbox/generator/GNuMIFlux.xml param_set DUNEND "
+        "(beamdir rotation x -0.101 rad; beampos (0,0.05387,6.66)=(0,0,562.1179) m)"))
+
+    # 2x2 ProtoDUNE-ND: in the NuMI beam in the MINOS/MINERvA near hall
+    # (NOT LBNF). Ties to NuMI -> BNB (existing), so the 2x2 prototype is
+    # placeable in the BNB world. GNuMIFlux ProtoDUNE-ND: beamdir
+    # Rx(-0.0582977560) (= NuMI 58.3 mrad declination); beampos
+    # (0,0,0)=(0,0,1036.48837) m (2x2 origin on the NuMI axis, 1036.49 m
+    # downstream of the NuMI target; matches g4lbne zdetNear[1]=1036.49).
+    g.add_frame(Frame("ProtoDUNE_ND_2x2",
+        "DUNE 2x2 ArgonCube prototype frame (MINOS/MINERvA near hall, NuMI beam).",
+        "2x2 detector center", "beam-left", "up", "downstream (level)"))
+    g.add_transform(Transform(
+        "ProtoDUNE_ND_2x2", "NuMI", _Rx(-0.0582977560),
+        np.array([0.0, 0.0, 1036.48837]),
+        "DUNE/2x2_sim run-genie/flux/GNuMIFlux.xml param_set ProtoDUNE-ND "
+        "(beamdir rotation x -0.0582977560 rad; beampos (0,0,0)=(0,0,1036.48837) m)"))
+
+    # LBNF -> BNB: closes the DUNE system into the SBN/BNB world.
+    #
+    # Rotation: the LBNF beam frame (g4lbnf Tunnel world -- +z = beam axis,
+    # built horizontal; +y up; +x = up x beam) pointed along the real LBNF
+    # beam: true azimuth 287.79 deg (toward SURF) and 101 mrad downward.
+    # Columns of R are the LBNF axes expressed in BNB (x=west, y=up, z=north).
+    #
+    # Translation: the LBNF target (MCZero = g4lbnf origin) in BNB. Solved from
+    # the Fermilab-survey MI-10 / MI-60 straight-section centers (FSCS, ft):
+    #   MI-10 = (E 99673.5943, N 97303.9630),  MI-60 = (E 101513.8611, N 97129.4878).
+    # Projected to ENU (FSCS Y-axis geodetic azimuth alpha = 38 16 48.0143") and
+    # bridged into BNB through NuMI: MI-60 + 350 m lands on the graph's NuMI
+    # point; MI-10 + 328 m -> the LBNF target. Validated -- MI-10 tangent + 7.2
+    # deg extraction = 288.1 deg ~ 287.79; the survey->BNB chain reproduces the
+    # NuMI matrix to ~1 deg. Horizontal good to ~10-15 m. VERTICAL: the LBNF
+    # MCZero is at grade. The SBN model takes the Fermilab site grade (minus
+    # berm/overburden) to be the MiniBooNE computer-room floor, already encoded
+    # in sbn_loader: _FNAL_SITE_GRADE_Y (6.4733 m, tank-center frame) + the
+    # tank-center->BNB shift _MB_Y_BNB (1.89614 m) = 8.369 m in the BNB frame
+    # (so the BNB beam axis is ~8.4 m below grade). Hence y_up = 8.369 m.
+    # (Uniform-grade approximation; the actual LBNF-site grade is ~757.5 ft
+    # DUSAF = MI-10 + ~42 ft per CDR Vol3 p107, but we use the model grade.)
+    # Hardcoded -- keep in sync with sbn_loader._FNAL_SITE_GRADE_Y.
+    _lb_b, _lb_d = math.radians(287.79), 0.101
+    _cb, _sb = math.cos(_lb_b), math.sin(_lb_b)
+    _cd, _sd = math.cos(_lb_d), math.sin(_lb_d)
+    _z_lbnf = np.array([-_cd * _sb, -_sd, _cd * _cb])   # LBNF +z (dipping beam) in BNB
+    _x_lbnf = np.array([_cb, 0.0, _sb])                 # LBNF +x (horiz perp = up x beam)
+    _y_lbnf = np.cross(_z_lbnf, _x_lbnf)                # LBNF +y (tilted up)
+    g.add_transform(Transform(
+        "LBNF", "BNB",
+        np.column_stack([_x_lbnf, _y_lbnf, _z_lbnf]),
+        np.array([261.5, 8.369, 35.8]),                 # (x_west, y_up=site grade, z_north) m
+        "LBNF beam (az 287.79 deg, 101 mrad down) placed in BNB via the Fermilab "
+        "MI-10/MI-60 FSCS survey centers bridged through NuMI; horizontal ~10-15 m, "
+        "y_up=8.369 m: LBNF MCZero at site grade (MiniBooNE room floor; "
+        "sbn_loader _FNAL_SITE_GRADE_Y + _MB_Y_BNB)"))
+
     return g
 
 

--- a/resources/detectors/SBN/SBN-v1/sbn_geometry.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_geometry.py
@@ -400,6 +400,17 @@ def _build_detectors() -> dict[str, Detector]:
         np.array([-_mb_tank_r, -_mb_tank_r, -_mb_tank_r]),
         np.array([+_mb_tank_r, +_mb_tank_r, +_mb_tank_r]))
 
+    # DUNE near-detector hall. Native frame == the dunendggd/edep-sim hall
+    # "world" frame, which is exactly the DUNE_ND frame already in the graph, so
+    # placement in BNB (DUNE_ND -> LBNF -> BNB) is exact. center_native is the
+    # hall-world origin and the active box is a nominal ND-LAr extent, not the
+    # exact per-detector active-LAr center/extent.
+    detectors["DUNE_ND"] = Detector(
+        "DUNE_ND", "DUNE_ND",
+        np.array([0.0, 0.0, 0.0]),
+        np.array([-3.5, -1.7, -2.5]),
+        np.array([+3.5, +1.7, +2.5]))
+
     return detectors
 
 

--- a/tests/python/test_earth_factorization.py
+++ b/tests/python/test_earth_factorization.py
@@ -1,0 +1,125 @@
+"""
+Unit tests for the shared siren.earth factorization.
+
+These exercise the pure logic that both the SBN and DUNE earth models rely on --
+the predict-count-and-shift-up level scheme, the mass-conserving PREM collapse,
+and the exponential-atmosphere band parameters -- without needing a real
+DetectorModel, materials, or (for DUNE) DEM/network access.
+"""
+
+import math
+import pytest
+
+import siren.earth as earth
+
+
+# --- lightweight duck-typed stand-ins for DetectorModel / DetectorSector ----
+
+class _FakeSector:
+    def __init__(self, name, level):
+        self.name = name
+        self.level = level
+
+
+class _FakeModel:
+    """Mimics the DetectorModel.Sectors get/set contract used by siren.earth."""
+    def __init__(self, sectors):
+        self._sectors = list(sectors)
+
+    @property
+    def Sectors(self):
+        # The real getter yields a fresh list of the sector objects; callers
+        # mutate .level then reassign via the setter.
+        return list(self._sectors)
+
+    @Sectors.setter
+    def Sectors(self, value):
+        self._sectors = list(value)
+
+    def levels(self):
+        return {s.name: s.level for s in self._sectors}
+
+
+def test_shift_levels_up_normalizes_and_exempts_universe():
+    sectors = [_FakeSector("UNIVERSE", -1), _FakeSector("World", 0),
+               _FakeSector("det", 1), _FakeSector("det2", 2)]
+    min_level = earth.shift_levels_up(sectors, 5)
+    assert min_level == 0
+    lv = {s.name: s.level for s in sectors}
+    assert lv["UNIVERSE"] == -1          # exempt, untouched
+    assert lv["World"] == 5              # 0 - 0 + 5
+    assert lv["det"] == 6                # 1 - 0 + 5
+    assert lv["det2"] == 7               # 2 - 0 + 5
+
+
+def test_insert_sectors_above_places_between_anchor_and_higher():
+    m = _FakeModel([_FakeSector("UNIVERSE", -1), _FakeSector("World", 0),
+                    _FakeSector("det", 1), _FakeSector("det2", 2)])
+    overburden = [_FakeSector("ob_low", None), _FakeSector("ob_high", None)]
+    earth.insert_sectors_above(m, "World", overburden)
+    lv = m.levels()
+    # anchor unchanged; below-anchor (UNIVERSE) unchanged
+    assert lv["World"] == 0
+    assert lv["UNIVERSE"] == -1
+    # overburden fills the freed levels just above the anchor, in order
+    assert lv["ob_low"] == 1
+    assert lv["ob_high"] == 2
+    # everything that was above the anchor shifts up by len(overburden)
+    assert lv["det"] == 3
+    assert lv["det2"] == 4
+    # strict ordering: PREM/background < World < overburden < detectors
+    assert lv["World"] < lv["ob_low"] < lv["ob_high"] < lv["det"] < lv["det2"]
+
+
+def test_insert_sectors_above_unknown_anchor_raises():
+    m = _FakeModel([_FakeSector("World", 0)])
+    with pytest.raises(RuntimeError):
+        earth.insert_sectors_above(m, "NoSuchSector", [_FakeSector("x", None)])
+
+
+def test_collapse_to_constant_is_mass_conserving_and_matches_crust():
+    layers = earth.CANONICAL_PREM_LAYERS
+    collapsed = earth.collapse_to_constant(layers)
+    assert len(collapsed) == len(layers)
+    # constant layers pass through unchanged (upper crust = 2.600)
+    assert abs(collapsed[-1][4] - 2.600) < 1e-9
+    assert collapsed[-2][4] == pytest.approx(2.900)  # inner_crust constant
+    # inner core mean is close to the central PREM value ~13.09 g/cm^3
+    assert 12.5 < collapsed[0][4] < 13.1
+    # every collapsed shell is a positive constant
+    for name, r, mat, dtype, rho in collapsed:
+        assert dtype == "constant"
+        assert rho > 0.0
+
+
+def test_atmosphere_exponential_band_params():
+    atm = earth.USStandard1976()
+    form = earth.AtmosphereForm(model=atm, mode="exponential")
+    bands = form.resolve(earth.R_PREM)
+    assert len(bands) == len(earth.DEFAULT_SHELL_ALTS)
+    H = atm.scale_height
+    for band, (h1, h2) in zip(bands, earth.DEFAULT_SHELL_ALTS):
+        assert band.mode == "exponential"
+        assert band.material == "AIR"
+        # base radius = surface + h1; density at base = rho0*exp(-h1/H)
+        assert band.r_base == pytest.approx(earth.R_PREM + h1)
+        assert band.r_top == pytest.approx(earth.R_PREM + h2)
+        assert band.rho_base == pytest.approx(atm.rho0 * math.exp(-h1 / H))
+        # densities strictly decrease with altitude, and never underflow to 0
+        assert band.rho_base > 0.0
+
+
+def test_atmosphere_column_depth_exponential_matches_analytic():
+    """The exact exponential column integral is ~1030 g/cm^2, and agrees with
+    the mass-conserving shell sum the loaders still expose (both integrate the
+    same barometric profile)."""
+    atm = earth.USStandard1976()
+    H = atm.scale_height
+    # analytic column from surface to top of the modeled atmosphere
+    top = earth.DEFAULT_SHELL_ALTS[-1][1]
+    analytic = atm.rho0 * H * (1.0 - math.exp(-top / H)) * 100.0  # g/cm^2
+    shell_sum = 0.0
+    for (h1, h2) in earth.DEFAULT_SHELL_ALTS:
+        shell_sum += atm.shell_mean_density(h1, h2) * (h2 - h1) * 100.0
+    assert analytic == pytest.approx(shell_sum, rel=1e-6)
+    assert 980 < analytic < 1080

--- a/tests/python/test_sbn_loader_offline.py
+++ b/tests/python/test_sbn_loader_offline.py
@@ -158,11 +158,17 @@ def offline_sbn_cache(tmp_path):
         tmp_path, "gdml/numi_g4export_2026-05-19.gdml",
         _beamline_fixture_gdml("numi_fixture", "NuMIFixtureAir"))
     _write_fixture_file(
+        tmp_path, "gdml/g4lbnf.gdml",
+        _beamline_fixture_gdml("lbnf_fixture", "LBNFFixtureAir"))
+    _write_fixture_file(
         tmp_path, "gdml/icarus_refactored_nounderscore_20230918_nowires.gdml",
         _detector_fixture_gdml("icarus_fixture"))
     _write_fixture_file(
         tmp_path, "gdml/sbnd_v02_06.gdml",
         _detector_fixture_gdml("sbnd_fixture"))
+    _write_fixture_file(
+        tmp_path, "gdml/nd_hall_with_lar_tms_sand.gdml",
+        _detector_fixture_gdml("dune_nd_fixture"))
     return tmp_path
 
 


### PR DESCRIPTION
Third of the detector/viz PRs. Stacks on `pr/miniboone-geometry` (DUNE geometry was built on top of the MiniBooNE composite edits, so this is a linear child, not a sibling).

### Delivers
- **DUNEFD-v2** far-detector model (self-contained), **DUNE ND**, and the **LBNF beamline** transforms into the SBN composite frames.
- Homestake geology (DEM terrain mesh, Poorman/Yates formations, dikes) + DUNE atmosphere for the far-detector Earth model.
- **DUNE earth model ported onto `siren.earth`** (introduced in `pr/sbn-geometry`): the private constant-shell PREM table and the dependency on an uncommitted `atmosphere.py` sibling are gone -- DUNE now uses the canonical polynomial PREM, the shared exponential atmosphere, and a new `insert_sectors_above` helper that places the overburden above the World volume via the predict-count-and-shift-up scheme (no absolute -200/+100000 level constants). This also fixes a latent crash: `add_earth_model` previously loaded an `atmosphere.py` file that was never committed.
- Offline test fixture preseeds LBNF (`g4lbnf.gdml`) + DUNE ND GDML so `fetch_data()` does not hit the network; unit tests cover the shared level bookkeeping, the mass-conserving PREM collapse, and the exponential-atmosphere bands.

**Note:** DUNE's PREM densities change deliberately from hand-picked constants (e.g. upper crust 2.65) to the canonical Dziewonski-Anderson values (2.600) -- the coarse table was an unsourced approximation.

**Verified:** full pytest 316 passed at this tip; ctest density suite 21/21.

**Shared commit:** "Expose TriangularMesh to Python" also appears in #154 (the visualization PR) -- the DUNE terrain mesh here and the meshing backend there both need the binding, and the two PRs are otherwise independent. Whichever merges second drops it as patch-equivalent on rebase.