### PR TITLE
Record time information in interaction records; fix event-flattening parentage

### DIFF
--- a/projects/dataclasses/private/InteractionRecord.cxx
+++ b/projects/dataclasses/private/InteractionRecord.cxx
@@ -1,6 +1,7 @@
 #include "SIREN/dataclasses/InteractionRecord.h"
 
 #include <cmath>
+#include <algorithm>  // for min
 #include <tuple>    // for tie, operator==, tuple
 #include <cassert>
 #include <ostream>  // for operator<<, basic_ostream, char_traits, endl, ost...
@@ -21,13 +22,15 @@ namespace {
 // Flight time for a particle with the given energy and momentum magnitude
 // that traverses a straight path of the given length. Lengths are in
 // internal units (m = 1) so the result is in internal time units
-// (second = 1e9). Degenerate configurations (zero path or zero velocity)
-// contribute no delay.
+// (second = 1e9). beta = |p|/E is the speed; a physical particle has
+// beta in (0, 1]. A non-finite or non-positive velocity (a NaN/inf record,
+// or an at-rest E <= m particle) contributes no delay, and beta is capped
+// at 1 so a spacelike |p| > E record can never yield a superluminal time.
 double FlightTime(double length, double energy, double momentum) {
-    double beta = (energy > 0) ? (momentum / energy) : 0;
-    if(length > 0 and beta > 0)
-        return length / (beta * siren::utilities::Constants::c);
-    return 0;
+    if(not (length > 0) or not (energy > 0) or not (momentum > 0))
+        return 0;
+    double beta = std::min(momentum / energy, 1.0);
+    return length / (beta * siren::utilities::Constants::c);
 }
 }
 

--- a/projects/dataclasses/private/InteractionRecord.cxx
+++ b/projects/dataclasses/private/InteractionRecord.cxx
@@ -663,25 +663,25 @@ void PrimaryDistributionRecord::FinalizeAvailable(InteractionRecord & record) co
         record.primary_momentum[1] = GetThreeMomentum().at(0);
         record.primary_momentum[2] = GetThreeMomentum().at(1);
         record.primary_momentum[3] = GetThreeMomentum().at(2);
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
     try {
         record.primary_initial_position = GetInitialPosition();
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
     try {
         record.interaction_vertex = GetInteractionVertex();
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
     try {
         record.primary_mass = GetMass();
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
     try {
         record.primary_helicity = GetHelicity();
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
     try {
         record.primary_initial_time = GetInitialTime();
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
     try {
         record.interaction_time = GetInteractionTime();
-    } catch(std::runtime_error e) {}
+    } catch(std::runtime_error const &) {}
 }
 
 void PrimaryDistributionRecord::Finalize(InteractionRecord & record) const {

--- a/projects/dataclasses/private/InteractionRecord.cxx
+++ b/projects/dataclasses/private/InteractionRecord.cxx
@@ -6,6 +6,7 @@
 #include <ostream>  // for operator<<, basic_ostream, char_traits, endl, ost...
                     //
 #include "SIREN/utilities/StringManipulation.h"  // for tab
+#include "SIREN/utilities/Constants.h"           // for c
 
 std::ostream& operator<<(std::ostream& os, siren::dataclasses::InteractionRecord const& record);
 std::ostream& operator<<(std::ostream& os, siren::dataclasses::PrimaryDistributionRecord const& record);
@@ -15,6 +16,20 @@ std::ostream& operator<<(std::ostream& os, siren::dataclasses::SecondaryDistribu
 
 namespace siren {
 namespace dataclasses {
+
+namespace {
+// Flight time for a particle with the given energy and momentum magnitude
+// that traverses a straight path of the given length. Lengths are in
+// internal units (m = 1) so the result is in internal time units
+// (second = 1e9). Degenerate configurations (zero path or zero velocity)
+// contribute no delay.
+double FlightTime(double length, double energy, double momentum) {
+    double beta = (energy > 0) ? (momentum / energy) : 0;
+    if(length > 0 and beta > 0)
+        return length / (beta * siren::utilities::Constants::c);
+    return 0;
+}
+}
 
 PrimaryDistributionRecord::PrimaryDistributionRecord(ParticleType type) :
     id(ParticleID::GenerateID()),
@@ -151,6 +166,17 @@ double const & PrimaryDistributionRecord::GetHelicity() const {
     return helicity;
 }
 
+double const & PrimaryDistributionRecord::GetInitialTime() const {
+    return initial_time;
+}
+
+double const & PrimaryDistributionRecord::GetInteractionTime() const {
+    if(not interaction_time_set) {
+        UpdateInteractionTime();
+    }
+    return interaction_time;
+}
+
 void PrimaryDistributionRecord::SetParticle(Particle const & particle) {
     if(particle.id != id) {
         throw std::runtime_error("Cannot set particle with different ID!");
@@ -243,6 +269,16 @@ void PrimaryDistributionRecord::SetInitialDistanceFromClosestApproach(double ini
 void PrimaryDistributionRecord::SetHelicity(double helicity) {
     helicity_set = true;
     this->helicity = helicity;
+}
+
+void PrimaryDistributionRecord::SetInitialTime(double initial_time) {
+    initial_time_set = true;
+    this->initial_time = initial_time;
+}
+
+void PrimaryDistributionRecord::SetInteractionTime(double interaction_time) {
+    interaction_time_set = true;
+    this->interaction_time = interaction_time;
 }
 
 void PrimaryDistributionRecord::SetInteractionParameters(std::map<std::string, double> const & parameters) {
@@ -599,6 +635,26 @@ void PrimaryDistributionRecord::UpdateInitialDistanceFromClosestApproach() const
     }
 }
 
+void PrimaryDistributionRecord::UpdateInteractionTime() const {
+    if(interaction_time_set)
+        return;
+    // Compute the path length directly from the finalized positions rather
+    // than GetLength() so the flight time is always consistent with them.
+    std::array<double, 3> const & initial = GetInitialPosition();
+    std::array<double, 3> const & vertex = GetInteractionVertex();
+    double distance = std::sqrt(
+        (vertex.at(0) - initial.at(0))*(vertex.at(0) - initial.at(0)) +
+        (vertex.at(1) - initial.at(1))*(vertex.at(1) - initial.at(1)) +
+        (vertex.at(2) - initial.at(2))*(vertex.at(2) - initial.at(2))
+    );
+    // The velocity only needs the momentum magnitude, which is available
+    // from energy and mass even when the direction is not derivable.
+    double energy = GetEnergy();
+    double mass = GetMass();
+    double momentum = (energy > mass) ? std::sqrt(energy*energy - mass*mass) : 0;
+    interaction_time = initial_time + FlightTime(distance, energy, momentum);
+}
+
 void PrimaryDistributionRecord::FinalizeAvailable(InteractionRecord & record) const {
     record.signature.primary_type = type;
     record.primary_id = GetID();
@@ -622,6 +678,12 @@ void PrimaryDistributionRecord::FinalizeAvailable(InteractionRecord & record) co
     try {
         record.primary_helicity = GetHelicity();
     } catch(std::runtime_error e) {}
+    try {
+        record.primary_initial_time = GetInitialTime();
+    } catch(std::runtime_error e) {}
+    try {
+        record.interaction_time = GetInteractionTime();
+    } catch(std::runtime_error e) {}
 }
 
 void PrimaryDistributionRecord::Finalize(InteractionRecord & record) const {
@@ -632,6 +694,8 @@ void PrimaryDistributionRecord::Finalize(InteractionRecord & record) const {
     record.primary_mass = GetMass();
     record.primary_momentum = GetFourMomentum();
     record.primary_helicity = GetHelicity();
+    record.primary_initial_time = GetInitialTime();
+    record.interaction_time = GetInteractionTime();
     for (auto const & x : interaction_parameters) {
         record.interaction_parameters[x.first] = x.second;
     }
@@ -643,7 +707,8 @@ SecondaryParticleRecord::SecondaryParticleRecord(InteractionRecord const & recor
     secondary_index(secondary_index),
     id((record.secondary_ids.size() > secondary_index and record.secondary_ids.at(secondary_index)) ? (record.secondary_ids.at(secondary_index)) : (ParticleID::GenerateID())),
     type(record.signature.secondary_types.at(secondary_index)),
-    initial_position(record.interaction_vertex)
+    initial_position(record.interaction_vertex),
+    initial_time(record.interaction_time)
 {}
 
 Particle SecondaryParticleRecord::GetParticle() const {
@@ -755,6 +820,16 @@ double const & SecondaryParticleRecord::GetHelicity() const {
     return helicity;
 }
 
+double const & SecondaryParticleRecord::GetTime() const {
+    // Secondaries are created at the interaction vertex, so their default
+    // production time is the vertex time (including any override applied
+    // through CrossSectionDistributionRecord::SetInteractionTime). A
+    // process can override this per particle to model delayed emission.
+    if(time_set)
+        return time;
+    return initial_time;
+}
+
 void SecondaryParticleRecord::SetMass(double mass) {
     mass_set = true;
     this->mass = mass;
@@ -790,6 +865,11 @@ void SecondaryParticleRecord::SetFourMomentum(std::array<double, 4> momentum) {
 void SecondaryParticleRecord::SetHelicity(double helicity) {
     helicity_set = true;
     this->helicity = helicity;
+}
+
+void SecondaryParticleRecord::SetTime(double time) {
+    time_set = true;
+    this->time = time;
 }
 
 void SecondaryParticleRecord::UpdateMass() const {
@@ -859,6 +939,7 @@ void SecondaryParticleRecord::Finalize(InteractionRecord & record) const {
     record.secondary_masses.at(secondary_index) = GetMass();
     record.secondary_momenta.at(secondary_index) = GetFourMomentum();
     record.secondary_helicities.at(secondary_index) = GetHelicity();
+    record.secondary_times.at(secondary_index) = GetTime();
 }
 
 /////////////////////////////////////////
@@ -873,6 +954,7 @@ CrossSectionDistributionRecord::CrossSectionDistributionRecord(InteractionRecord
     primary_momentum(record.primary_momentum),
     primary_helicity(record.primary_helicity),
     interaction_vertex(record.interaction_vertex),
+    interaction_time(record.interaction_time),
     target_id((record.target_id) ? (record.target_id) : (ParticleID::GenerateID())),
     target_type(record.signature.target_type),
     target_mass(record.target_mass),
@@ -916,6 +998,12 @@ std::array<double, 3> const & CrossSectionDistributionRecord::GetInteractionVert
     return interaction_vertex;
 }
 
+double const & CrossSectionDistributionRecord::GetInteractionTime() const {
+    if(interaction_time_set)
+        return overridden_interaction_time;
+    return interaction_time;
+}
+
 ParticleID const & CrossSectionDistributionRecord::GetTargetID() const {
     return target_id;
 }
@@ -942,6 +1030,17 @@ double & CrossSectionDistributionRecord::GetTargetHelicity() {
 
 std::map<std::string, double> & CrossSectionDistributionRecord::GetInteractionParameters() {
     return interaction_parameters;
+}
+
+void CrossSectionDistributionRecord::SetInteractionTime(double interaction_time) {
+    interaction_time_set = true;
+    overridden_interaction_time = interaction_time;
+    // Keep the secondaries' default production times in sync with the
+    // overridden vertex time so their getters agree with what Finalize
+    // will write.
+    for(SecondaryParticleRecord & secondary : secondary_particles) {
+        secondary.initial_time = interaction_time;
+    }
 }
 
 void CrossSectionDistributionRecord::SetTargetMass(double mass) {
@@ -981,6 +1080,12 @@ void CrossSectionDistributionRecord::Finalize(InteractionRecord & record) const 
     record.target_mass = target_mass;
     record.target_helicity = target_helicity;
 
+    // Apply a process-supplied vertex time override before the secondaries
+    // are finalized so their default production times pick it up.
+    if(interaction_time_set) {
+        record.interaction_time = overridden_interaction_time;
+    }
+
     for (auto const & x : interaction_parameters) {
         record.interaction_parameters[x.first] = x.second;
     }
@@ -989,6 +1094,7 @@ void CrossSectionDistributionRecord::Finalize(InteractionRecord & record) const 
     record.secondary_masses.resize(secondary_particles.size());
     record.secondary_momenta.resize(secondary_particles.size());
     record.secondary_helicities.resize(secondary_particles.size());
+    record.secondary_times.resize(secondary_particles.size());
 
     for(SecondaryParticleRecord const & secondary : secondary_particles) {
         secondary.Finalize(record);
@@ -1006,6 +1112,10 @@ InteractionRecord SecondaryDistributionRecord::CreateSecondaryRecord(Interaction
     record.primary_momentum = parent_record.secondary_momenta.at(secondary_index);
     record.primary_helicity = parent_record.secondary_helicities.at(secondary_index);
     record.primary_initial_position = parent_record.interaction_vertex;
+    // Parent records from version 0 archives predate secondary_times; fall
+    // back to the parent vertex time in that case.
+    record.primary_initial_time = (parent_record.secondary_times.size() > secondary_index) ?
+        parent_record.secondary_times.at(secondary_index) : parent_record.interaction_time;
     return record;
 }
 
@@ -1029,7 +1139,8 @@ SecondaryDistributionRecord::SecondaryDistributionRecord(InteractionRecord & rec
     }(record)),
     momentum(record.primary_momentum),
     helicity(record.primary_helicity),
-    initial_position(record.primary_initial_position) {}
+    initial_position(record.primary_initial_position),
+    initial_time(record.primary_initial_time) {}
 
 SecondaryDistributionRecord::SecondaryDistributionRecord(InteractionRecord const & parent_record, size_t secondary_index) :
     secondary_index(secondary_index),
@@ -1049,7 +1160,8 @@ SecondaryDistributionRecord::SecondaryDistributionRecord(InteractionRecord const
     }(record)),
     momentum(record.primary_momentum),
     helicity(record.primary_helicity),
-    initial_position(record.primary_initial_position) {}
+    initial_position(record.primary_initial_position),
+    initial_time(record.primary_initial_time) {}
 
 double const & SecondaryDistributionRecord::GetLength() const {
     if(not length_set) {
@@ -1063,10 +1175,24 @@ void SecondaryDistributionRecord::SetLength(double const & length) {
     this->length = length;
 }
 
+double const & SecondaryDistributionRecord::GetInteractionTime() const {
+    if(not interaction_time_set) {
+        double momentum_magnitude = std::sqrt(momentum.at(1)*momentum.at(1) + momentum.at(2)*momentum.at(2) + momentum.at(3)*momentum.at(3));
+        interaction_time = initial_time + FlightTime(GetLength(), momentum.at(0), momentum_magnitude);
+    }
+    return interaction_time;
+}
+
+void SecondaryDistributionRecord::SetInteractionTime(double const & interaction_time) {
+    interaction_time_set = true;
+    this->interaction_time = interaction_time;
+}
+
 void SecondaryDistributionRecord::Finalize(InteractionRecord & record) const {
     record.signature.primary_type = type;
     record.primary_id = id;
     record.primary_initial_position = initial_position;
+    record.primary_initial_time = initial_time;
     record.primary_mass = mass;
     record.primary_momentum = momentum;
     record.primary_helicity = helicity;
@@ -1074,6 +1200,7 @@ void SecondaryDistributionRecord::Finalize(InteractionRecord & record) const {
     record.interaction_vertex.at(0) += length*direction.at(0);
     record.interaction_vertex.at(1) += length*direction.at(1);
     record.interaction_vertex.at(2) += length*direction.at(2);
+    record.interaction_time = GetInteractionTime();
 }
 
 /////////////////////////////////////////
@@ -1083,6 +1210,7 @@ bool InteractionRecord::operator==(InteractionRecord const & other) const {
         signature,
         primary_id,
         primary_initial_position,
+        primary_initial_time,
         primary_mass,
         primary_momentum,
         primary_helicity,
@@ -1090,16 +1218,19 @@ bool InteractionRecord::operator==(InteractionRecord const & other) const {
         target_mass,
         target_helicity,
         interaction_vertex,
+        interaction_time,
         secondary_ids,
         secondary_masses,
         secondary_momenta,
         secondary_helicities,
+        secondary_times,
         interaction_parameters)
         ==
         std::tie(
         other.signature,
         other.primary_id,
         other.primary_initial_position,
+        other.primary_initial_time,
         other.primary_mass,
         other.primary_momentum,
         other.primary_helicity,
@@ -1107,10 +1238,12 @@ bool InteractionRecord::operator==(InteractionRecord const & other) const {
         other.target_mass,
         other.target_helicity,
         other.interaction_vertex,
+        other.interaction_time,
         other.secondary_ids,
         other.secondary_masses,
         other.secondary_momenta,
         other.secondary_helicities,
+        other.secondary_times,
         other.interaction_parameters);
 }
 
@@ -1119,6 +1252,7 @@ bool InteractionRecord::operator<(InteractionRecord const & other) const {
         signature,
         primary_id,
         primary_initial_position,
+        primary_initial_time,
         primary_mass,
         primary_momentum,
         primary_helicity,
@@ -1126,16 +1260,19 @@ bool InteractionRecord::operator<(InteractionRecord const & other) const {
         target_mass,
         target_helicity,
         interaction_vertex,
+        interaction_time,
         secondary_ids,
         secondary_masses,
         secondary_momenta,
         secondary_helicities,
+        secondary_times,
         interaction_parameters)
         <
         std::tie(
         other.signature,
         other.primary_id,
         other.primary_initial_position,
+        other.primary_initial_time,
         other.primary_mass,
         other.primary_momentum,
         other.primary_helicity,
@@ -1143,10 +1280,12 @@ bool InteractionRecord::operator<(InteractionRecord const & other) const {
         other.target_mass,
         other.target_helicity,
         other.interaction_vertex,
+        other.interaction_time,
         other.secondary_ids,
         other.secondary_masses,
         other.secondary_momenta,
         other.secondary_helicities,
+        other.secondary_times,
         other.interaction_parameters);
 }
 
@@ -1220,6 +1359,18 @@ std::string to_str(siren::dataclasses::PrimaryDistributionRecord const & record)
     else
         ss << "unset\n";
 
+    ss << tab << "InitialTime: ";
+    if(record.initial_time_set)
+        ss << record.initial_time << '\n';
+    else
+        ss << "unset\n";
+
+    ss << tab << "InteractionTime: ";
+    if(record.interaction_time_set)
+        ss << record.interaction_time << '\n';
+    else
+        ss << "unset\n";
+
     ss << "]";
 
     return ss.str();
@@ -1250,6 +1401,10 @@ std::string to_repr(siren::dataclasses::PrimaryDistributionRecord const & record
         ss << ", interaction_vertex=(" << record.interaction_vertex.at(0) << ", " << record.interaction_vertex.at(1) << ", " << record.interaction_vertex.at(2) << ")";
     if(record.helicity_set)
         ss << ", helicity=" << record.helicity;
+    if(record.initial_time_set)
+        ss << ", initial_time=" << record.initial_time;
+    if(record.interaction_time_set)
+        ss << ", interaction_time=" << record.interaction_time;
 
     ss << ")";
 
@@ -1284,6 +1439,7 @@ std::string to_str(siren::dataclasses::CrossSectionDistributionRecord const & re
        << record.interaction_vertex.at(0) << " "
        << record.interaction_vertex.at(1) << " "
        << record.interaction_vertex.at(2) << '\n';
+    ss << tab << "InteractionTime: " << record.GetInteractionTime() << '\n';
     ss << tab << "TargetID: " << to_repr(record.GetTargetID()) << '\n';
     ss << tab << "TargetType: " << record.target_type << '\n';
     ss << tab << "TargetMass: " << record.target_mass << '\n';
@@ -1328,6 +1484,7 @@ std::string to_repr(siren::dataclasses::CrossSectionDistributionRecord const& re
        << record.interaction_vertex.at(0) << ", "
        << record.interaction_vertex.at(1) << ", "
        << record.interaction_vertex.at(2) << "), ";
+    ss << "interaction_time=" << record.GetInteractionTime() << ", ";
     ss << "target_id=" << to_repr(record.GetTargetID()) << ", ";
     ss << "target_type=" << record.target_type << ", ";
     ss << "target_mass=" << record.target_mass << ", ";
@@ -1375,6 +1532,8 @@ std::string to_repr(siren::dataclasses::CrossSectionDistributionRecord const& re
                << secondary.momentum.at(2) << ")";
         if (secondary.helicity_set)
             ss << ", helicity=" << secondary.helicity;
+        if (secondary.time_set)
+            ss << ", time=" << secondary.time;
         ss << "}";
     }
     ss << "]";
@@ -1432,6 +1591,12 @@ std::string to_str(siren::dataclasses::SecondaryParticleRecord const& record) {
         ss << record.helicity << '\n';
     else
         ss << "unset\n";
+    ss << tab << "InitialTime: " << record.initial_time << '\n';
+    ss << tab << "Time: ";
+    if (record.time_set)
+        ss << record.time << '\n';
+    else
+        ss << "unset\n";
     ss << ']';
 
     return ss.str();
@@ -1465,6 +1630,8 @@ std::string to_repr(siren::dataclasses::SecondaryParticleRecord const& record) {
            << record.momentum.at(2) << ")";
     if (record.helicity_set)
         ss << ", helicity=" << record.helicity;
+    if (record.time_set)
+        ss << ", time=" << record.time;
     ss << ")";
     return ss.str();
 }
@@ -1499,10 +1666,18 @@ std::ostream& operator<<(std::ostream& os, siren::dataclasses::SecondaryDistribu
 
     os << "InitialPosition: " << record.initial_position.at(0) << " " << record.initial_position.at(1) << " " << record.initial_position.at(2) << "\n";
 
+    os << "InitialTime: " << record.initial_time << "\n";
+
     if(record.length_set) {
         os << "Length: " << record.GetLength() << "\n";
     } else {
         os << "Length: " << "None" << "\n";
+    }
+
+    if(record.length_set or record.interaction_time_set) {
+        os << "InteractionTime: " << record.GetInteractionTime() << "\n";
+    } else {
+        os << "InteractionTime: " << "None" << "\n";
     }
 
     return os;
@@ -1528,7 +1703,9 @@ std::string to_str(siren::dataclasses::InteractionRecord const & record) {
 
     ss << tab << "PrimaryID: " << to_repr(record.primary_id) << '\n';
     ss << tab << "PrimaryInitialPosition: " << record.primary_initial_position.at(0) << " " << record.primary_initial_position.at(1) << " " << record.primary_initial_position.at(2) << '\n';
+    ss << tab << "PrimaryInitialTime: " << record.primary_initial_time << '\n';
     ss << tab << "InteractionVertex: " << record.interaction_vertex.at(0) << " " << record.interaction_vertex.at(1) << " " << record.interaction_vertex.at(2) << '\n';
+    ss << tab << "InteractionTime: " << record.interaction_time << '\n';
     ss << tab << "PrimaryMass: " << record.primary_mass << '\n';
     ss << tab << "PrimaryMomentum: " << record.primary_momentum.at(0) << " " << record.primary_momentum.at(1) << " " << record.primary_momentum.at(2) << " " << record.primary_momentum.at(3) << '\n';
     ss << tab << "TargetID: " << to_repr(record.target_id) << '\n';
@@ -1543,6 +1720,10 @@ std::string to_str(siren::dataclasses::InteractionRecord const & record) {
     }
     ss << tab << "SecondaryMasses:\n";
     for(auto const & secondary: record.secondary_masses) {
+        ss << tab << tab << secondary << '\n';
+    }
+    ss << tab << "SecondaryTimes:\n";
+    for(auto const & secondary: record.secondary_times) {
         ss << tab << tab << secondary << '\n';
     }
     ss << tab << "InteractionParameters:\n";
@@ -1564,7 +1745,9 @@ std::string to_repr(siren::dataclasses::InteractionRecord const & record) {
     ss << ", ";
     ss << "primary_id=" << to_repr(record.primary_id) << ", ";
     ss << "primary_initial_position=(" << record.primary_initial_position.at(0) << ", " << record.primary_initial_position.at(1) << ", " << record.primary_initial_position.at(2) << "), ";
+    ss << "primary_initial_time=" << record.primary_initial_time << ", ";
     ss << "interaction_vertex=(" << record.interaction_vertex.at(0) << ", " << record.interaction_vertex.at(1) << ", " << record.interaction_vertex.at(2) << "), ";
+    ss << "interaction_time=" << record.interaction_time << ", ";
     ss << "primary_mass=" << record.primary_mass << ", ";
     ss << "primary_momentum=(" << record.primary_momentum.at(0) << ", " << record.primary_momentum.at(1) << ", " << record.primary_momentum.at(2) << ", " << record.primary_momentum.at(3) << "), ";
     ss << "target_id=" << to_repr(record.target_id) << ", ";
@@ -1590,6 +1773,14 @@ std::string to_repr(siren::dataclasses::InteractionRecord const & record) {
         ss << record.secondary_masses.at(0);
         for(size_t i=1; i<record.secondary_masses.size(); ++i) {
             ss << ", " << record.secondary_masses.at(i);
+        }
+    }
+    ss << "], ";
+    ss << "secondary_times=[";
+    if(record.secondary_times.size() > 0) {
+        ss << record.secondary_times.at(0);
+        for(size_t i=1; i<record.secondary_times.size(); ++i) {
+            ss << ", " << record.secondary_times.at(i);
         }
     }
     ss << "], ";

--- a/projects/dataclasses/private/InteractionRecord.cxx
+++ b/projects/dataclasses/private/InteractionRecord.cxx
@@ -20,12 +20,7 @@ namespace dataclasses {
 
 namespace {
 // Flight time for a particle with the given energy and momentum magnitude
-// that traverses a straight path of the given length. Lengths are in
-// internal units (m = 1) so the result is in internal time units
-// (second = 1e9). beta = |p|/E is the speed; a physical particle has
-// beta in (0, 1]. A non-finite or non-positive velocity (a NaN/inf record,
-// or an at-rest E <= m particle) contributes no delay, and beta is capped
-// at 1 so a spacelike |p| > E record can never yield a superluminal time.
+// that traverses a straight path of the given length.
 double FlightTime(double length, double energy, double momentum) {
     if(not (length > 0) or not (energy > 0) or not (momentum > 0))
         return 0;
@@ -825,9 +820,7 @@ double const & SecondaryParticleRecord::GetHelicity() const {
 
 double const & SecondaryParticleRecord::GetTime() const {
     // Secondaries are created at the interaction vertex, so their default
-    // production time is the vertex time (including any override applied
-    // through CrossSectionDistributionRecord::SetInteractionTime). A
-    // process can override this per particle to model delayed emission.
+    // production time is the vertex time
     if(time_set)
         return time;
     return initial_time;

--- a/projects/dataclasses/private/pybindings/dataclasses.cxx
+++ b/projects/dataclasses/private/pybindings/dataclasses.cxx
@@ -101,6 +101,8 @@ PYBIND11_MODULE(dataclasses, m) {
         .def_property("initial_position", ((std::array<double, 3> const & (PrimaryDistributionRecord::*)())(&PrimaryDistributionRecord::GetInitialPosition)), &PrimaryDistributionRecord::SetInitialPosition)
         .def_property("interaction_vertex", ((std::array<double, 3> const & (PrimaryDistributionRecord::*)())(&PrimaryDistributionRecord::GetInteractionVertex)), &PrimaryDistributionRecord::SetInteractionVertex)
         .def_property("helicity", ((double const & (PrimaryDistributionRecord::*)())(&PrimaryDistributionRecord::GetHelicity)), &PrimaryDistributionRecord::SetHelicity)
+        .def_property("initial_time", ((double const & (PrimaryDistributionRecord::*)())(&PrimaryDistributionRecord::GetInitialTime)), &PrimaryDistributionRecord::SetInitialTime)
+        .def_property("interaction_time", ((double const & (PrimaryDistributionRecord::*)())(&PrimaryDistributionRecord::GetInteractionTime)), &PrimaryDistributionRecord::SetInteractionTime)
         .def("finalize", &PrimaryDistributionRecord::Finalize);
 
     py::class_<SecondaryParticleRecord, std::shared_ptr<SecondaryParticleRecord>>(m, "SecondaryParticleRecord")
@@ -122,6 +124,7 @@ PYBIND11_MODULE(dataclasses, m) {
         .def_property("three_momentum", ((std::array<double, 3> const & (SecondaryParticleRecord::*)())(&SecondaryParticleRecord::GetThreeMomentum)), &SecondaryParticleRecord::SetThreeMomentum)
         .def_property("four_momentum", ((std::array<double, 4> (SecondaryParticleRecord::*)())(&SecondaryParticleRecord::GetFourMomentum)), &SecondaryParticleRecord::SetFourMomentum)
         .def_property("helicity", ((double const & (SecondaryParticleRecord::*)())(&SecondaryParticleRecord::GetHelicity)), &SecondaryParticleRecord::SetHelicity)
+        .def_property("time", ((double const & (SecondaryParticleRecord::*)())(&SecondaryParticleRecord::GetTime)), &SecondaryParticleRecord::SetTime)
         .def("finalize", &SecondaryParticleRecord::Finalize)
         ;
 
@@ -147,6 +150,7 @@ PYBIND11_MODULE(dataclasses, m) {
             [](siren::dataclasses::CrossSectionDistributionRecord const & cdr) {double h = cdr.primary_helicity; return h;})
         .def_property_readonly("interaction_vertex",
             [](siren::dataclasses::CrossSectionDistributionRecord const & cdr) {std::array<double, 3> iv = cdr.interaction_vertex; return iv;})
+        .def_property("interaction_time", ((double const & (siren::dataclasses::CrossSectionDistributionRecord::*)() const)(&siren::dataclasses::CrossSectionDistributionRecord::GetInteractionTime)), &siren::dataclasses::CrossSectionDistributionRecord::SetInteractionTime)
         .def_property_readonly("target_id",
             [](siren::dataclasses::CrossSectionDistributionRecord const & cdr) {siren::dataclasses::ParticleID id = cdr.target_id; return id;})
         .def_property_readonly("target_type",
@@ -174,6 +178,7 @@ PYBIND11_MODULE(dataclasses, m) {
         .def_readwrite("signature",&InteractionRecord::signature)
         .def_readwrite("primary_id",&InteractionRecord::primary_id)
         .def_readwrite("primary_initial_position",&InteractionRecord::primary_initial_position)
+        .def_readwrite("primary_initial_time",&InteractionRecord::primary_initial_time)
         .def_readwrite("primary_mass",&InteractionRecord::primary_mass)
         .def_readwrite("primary_momentum",&InteractionRecord::primary_momentum)
         .def_readwrite("primary_helicity",&InteractionRecord::primary_helicity)
@@ -181,10 +186,12 @@ PYBIND11_MODULE(dataclasses, m) {
         .def_readwrite("target_mass",&InteractionRecord::target_mass)
         .def_readwrite("target_helicity",&InteractionRecord::target_helicity)
         .def_readwrite("interaction_vertex",&InteractionRecord::interaction_vertex)
+        .def_readwrite("interaction_time",&InteractionRecord::interaction_time)
         .def_readwrite("secondary_ids",&InteractionRecord::secondary_ids)
         .def_readwrite("secondary_masses",&InteractionRecord::secondary_masses)
         .def_readwrite("secondary_momenta",&InteractionRecord::secondary_momenta)
         .def_readwrite("secondary_helicities",&InteractionRecord::secondary_helicities)
+        .def_readwrite("secondary_times",&InteractionRecord::secondary_times)
         .def_readwrite("interaction_parameters",&InteractionRecord::interaction_parameters)
         .def(pybind11::pickle(
             &(siren::serialization::pickle_save<InteractionRecord>),

--- a/projects/dataclasses/private/test/InteractionRecord_TEST.cxx
+++ b/projects/dataclasses/private/test/InteractionRecord_TEST.cxx
@@ -17,6 +17,7 @@
 #include "SIREN/dataclasses/Particle.h"
 #include "SIREN/dataclasses/ParticleID.h"
 #include "SIREN/dataclasses/ParticleType.h"
+#include "SIREN/utilities/Constants.h"
 
 using namespace siren::dataclasses;
 
@@ -39,6 +40,7 @@ InteractionRecord MakePopulatedInteractionRecord() {
 
     r.primary_id = ParticleID(1, 1);
     r.primary_initial_position = {1.0, 2.0, 3.0};
+    r.primary_initial_time = 0.5;
     r.primary_mass = 8.0;
     r.primary_momentum = {10.0, 6.0, 0.0, 0.0};
     r.primary_helicity = 0.5;
@@ -48,6 +50,7 @@ InteractionRecord MakePopulatedInteractionRecord() {
     r.target_helicity = -0.5;
 
     r.interaction_vertex = {4.0, 2.0, 3.0};
+    r.interaction_time = 17.0;
 
     r.secondary_ids = {ParticleID(3, 3), ParticleID(4, 4)};
     r.secondary_masses = {0.5, 0.25};
@@ -56,6 +59,7 @@ InteractionRecord MakePopulatedInteractionRecord() {
         std::array<double, 4>{2.0, 0.0, 0.0, 2.0},
     };
     r.secondary_helicities = {1.0, -1.0};
+    r.secondary_times = {17.0, 21.0};
 
     r.interaction_parameters = {{"alpha", 1.0}, {"beta", 2.0}};
     return r;
@@ -99,6 +103,11 @@ TEST(InteractionRecord_Comparison, Equality_CoversAllFields) {
     B.primary_initial_position = {1.0, 2.0, 3.0};
     EXPECT_TRUE(A == B);
 
+    A.primary_initial_time = 1.0;
+    EXPECT_FALSE(A == B);
+    B.primary_initial_time = 1.0;
+    EXPECT_TRUE(A == B);
+
     A.primary_mass = 1.0;
     EXPECT_FALSE(A == B);
     B.primary_mass = 1.0;
@@ -136,6 +145,11 @@ TEST(InteractionRecord_Comparison, Equality_CoversAllFields) {
     B.interaction_vertex = {1.0, 2.0, 3.0};
     EXPECT_TRUE(A == B);
 
+    A.interaction_time = 1.0;
+    EXPECT_FALSE(A == B);
+    B.interaction_time = 1.0;
+    EXPECT_TRUE(A == B);
+
     // secondaries: ids + masses + momenta + helicities
     A.secondary_ids.push_back(ParticleID(7, 7));
     EXPECT_FALSE(A == B);
@@ -155,6 +169,11 @@ TEST(InteractionRecord_Comparison, Equality_CoversAllFields) {
     A.secondary_helicities.push_back(1.0);
     EXPECT_FALSE(A == B);
     B.secondary_helicities.push_back(1.0);
+    EXPECT_TRUE(A == B);
+
+    A.secondary_times.push_back(1.0);
+    EXPECT_FALSE(A == B);
+    B.secondary_times.push_back(1.0);
     EXPECT_TRUE(A == B);
 
     // interaction parameters
@@ -239,7 +258,7 @@ TEST(InteractionRecord_Serialization, SaveUnsupportedVersionThrows) {
     std::stringstream ss;
     cereal::JSONOutputArchive oar(ss);
 
-    EXPECT_THROW(r.save(oar, 1), std::runtime_error);
+    EXPECT_THROW(r.save(oar, 2), std::runtime_error);
 }
 
 TEST(InteractionRecord_Serialization, LoadUnsupportedVersionThrows) {
@@ -249,7 +268,47 @@ TEST(InteractionRecord_Serialization, LoadUnsupportedVersionThrows) {
     ss << "{}";
     cereal::JSONInputArchive iar(ss);
 
-    EXPECT_THROW(r.load(iar, 1), std::runtime_error);
+    EXPECT_THROW(r.load(iar, 2), std::runtime_error);
+}
+
+TEST(InteractionRecord_Serialization, Version0_LoadsWithDefaultTimes) {
+    InteractionRecord in = MakePopulatedInteractionRecord();
+
+    // Write a version 0 archive (pre-time format) directly.
+    std::stringstream ss;
+    {
+        cereal::JSONOutputArchive oar(ss);
+        in.save(oar, 0);
+    }
+
+    // The version 0 format must not contain any of the new time fields.
+    std::string v0_json = ss.str();
+    EXPECT_EQ(v0_json.find("PrimaryInitialTime"), std::string::npos);
+    EXPECT_EQ(v0_json.find("InteractionTime"), std::string::npos);
+    EXPECT_EQ(v0_json.find("SecondaryTimes"), std::string::npos);
+
+    InteractionRecord out;
+    out.primary_initial_time = 123.0;
+    out.interaction_time = 456.0;
+    out.secondary_times = {789.0};
+    {
+        cereal::JSONInputArchive iar(ss);
+        out.load(iar, 0);
+    }
+
+    // All non-time fields survive; times revert to their defaults, with
+    // secondary_times sized to match the other secondary vectors.
+    EXPECT_EQ(out.signature.primary_type, in.signature.primary_type);
+    EXPECT_EQ(out.primary_id, in.primary_id);
+    ExpectArrayNear<3>(out.primary_initial_position, in.primary_initial_position);
+    ExpectArrayNear<3>(out.interaction_vertex, in.interaction_vertex);
+    EXPECT_EQ(out.secondary_ids, in.secondary_ids);
+    EXPECT_EQ(out.interaction_parameters, in.interaction_parameters);
+    EXPECT_DOUBLE_EQ(out.primary_initial_time, 0.0);
+    EXPECT_DOUBLE_EQ(out.interaction_time, 0.0);
+    ASSERT_EQ(out.secondary_times.size(), in.secondary_momenta.size());
+    EXPECT_DOUBLE_EQ(out.secondary_times.at(0), 0.0);
+    EXPECT_DOUBLE_EQ(out.secondary_times.at(1), 0.0);
 }
 
 TEST(InteractionRecord_Strings, ToStrAndToReprAreNonEmpty) {
@@ -538,12 +597,14 @@ TEST(SecondaryParticleRecord, FinalizeWritesIntoPreSizedVectors) {
     InteractionRecord parent;
     parent.signature.secondary_types = {ParticleType::EMinus};
     parent.interaction_vertex = {0.0, 0.0, 0.0};
+    parent.interaction_time = 7.0;
 
     // SecondaryParticleRecord::Finalize uses .at(), so parent must be sized.
     parent.secondary_ids.resize(1);
     parent.secondary_masses.resize(1);
     parent.secondary_momenta.resize(1);
     parent.secondary_helicities.resize(1);
+    parent.secondary_times.resize(1);
 
     SecondaryParticleRecord sr(parent, 0);
     sr.SetMass(8.0);
@@ -556,6 +617,14 @@ TEST(SecondaryParticleRecord, FinalizeWritesIntoPreSizedVectors) {
     EXPECT_NEAR(parent.secondary_masses.at(0), 8.0, 1e-12);
     ExpectArrayNear<4>(parent.secondary_momenta.at(0), {10.0, 6.0, 0.0, 0.0});
     EXPECT_NEAR(parent.secondary_helicities.at(0), 1.0, 1e-12);
+    // Default production time is the vertex time of the record being written.
+    EXPECT_NEAR(parent.secondary_times.at(0), 7.0, 1e-12);
+
+    // An explicit per-particle time overrides the default.
+    sr.SetTime(11.0);
+    EXPECT_NEAR(sr.GetTime(), 11.0, 1e-12);
+    sr.Finalize(parent);
+    EXPECT_NEAR(parent.secondary_times.at(0), 11.0, 1e-12);
 }
 
 ///////////////////////////////////////////////
@@ -764,6 +833,195 @@ TEST(RecordStrings, PrimaryAndSecondaryReprsAreNonEmpty) {
     std::stringstream sr_os;
     sr_os << sr;
     EXPECT_FALSE(sr_os.str().empty());
+}
+
+///////////////////////////////////////////////
+// Time propagation
+///////////////////////////////////////////////
+
+TEST(TimePropagation, PrimaryRecordComputesFlightTime) {
+    using siren::utilities::Constants::c;
+
+    PrimaryDistributionRecord pr(ParticleType::EMinus);
+    pr.SetMass(8.0);
+    pr.SetEnergy(10.0);  // |p| = 6 -> beta = 0.6
+    pr.SetDirection({1.0, 0.0, 0.0});
+    pr.SetInitialPosition({1.0, 2.0, 3.0});
+    pr.SetInteractionVertex({4.0, 2.0, 3.0});  // distance = 3 (internal meters)
+
+    double const flight = 3.0 / (0.6 * c);
+
+    // Automatic rule: initial time defaults to 0.
+    EXPECT_DOUBLE_EQ(pr.GetInitialTime(), 0.0);
+    EXPECT_NEAR(pr.GetInteractionTime(), flight, 1e-9);
+
+    InteractionRecord out;
+    pr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.primary_initial_time, 0.0);
+    EXPECT_NEAR(out.interaction_time, flight, 1e-9);
+}
+
+TEST(TimePropagation, PrimaryRecordInitialTimeShiftsInteractionTime) {
+    using siren::utilities::Constants::c;
+
+    PrimaryDistributionRecord pr(ParticleType::EMinus);
+    pr.SetMass(8.0);
+    pr.SetEnergy(10.0);
+    pr.SetDirection({1.0, 0.0, 0.0});
+    pr.SetInitialPosition({1.0, 2.0, 3.0});
+    pr.SetInteractionVertex({4.0, 2.0, 3.0});
+    pr.SetInitialTime(2.5);
+
+    double const flight = 3.0 / (0.6 * c);
+
+    InteractionRecord out;
+    pr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.primary_initial_time, 2.5);
+    EXPECT_NEAR(out.interaction_time, 2.5 + flight, 1e-9);
+}
+
+TEST(TimePropagation, PrimaryRecordInteractionTimeOverride) {
+    PrimaryDistributionRecord pr(ParticleType::EMinus);
+    pr.SetMass(8.0);
+    pr.SetEnergy(10.0);
+    pr.SetDirection({1.0, 0.0, 0.0});
+    pr.SetInitialPosition({1.0, 2.0, 3.0});
+    pr.SetInteractionVertex({4.0, 2.0, 3.0});
+    pr.SetInteractionTime(42.0);
+
+    InteractionRecord out;
+    pr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.interaction_time, 42.0);
+}
+
+TEST(TimePropagation, PrimaryRecordAtRestHasZeroFlightTime) {
+    PrimaryDistributionRecord pr(ParticleType::MuMinus);
+    pr.SetMass(0.105);
+    pr.SetThreeMomentum({0.0, 0.0, 0.0});
+    pr.SetInitialPosition({1.0, 2.0, 3.0});
+    pr.SetInteractionVertex({1.0, 2.0, 3.0});
+    pr.SetInitialTime(4.0);
+
+    InteractionRecord out;
+    pr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.interaction_time, 4.0);
+}
+
+TEST(TimePropagation, CrossSectionRecordFillsSecondaryTimesFromVertexTime) {
+    InteractionRecord in = MakePopulatedInteractionRecord();
+    in.interaction_time = 17.0;
+
+    CrossSectionDistributionRecord csr(in);
+    EXPECT_DOUBLE_EQ(csr.GetInteractionTime(), 17.0);
+
+    auto & s0 = csr.GetSecondaryParticleRecord(0);
+    s0.SetMass(0.5);
+    s0.SetFourMomentum({1.0, 0.0, 1.0, 0.0});
+    s0.SetHelicity(1.0);
+    auto & s1 = csr.GetSecondaryParticleRecord(1);
+    s1.SetMass(0.25);
+    s1.SetFourMomentum({2.0, 0.0, 0.0, 2.0});
+    s1.SetHelicity(-1.0);
+
+    InteractionRecord out = in;
+    csr.Finalize(out);
+    ASSERT_EQ(out.secondary_times.size(), 2u);
+    EXPECT_DOUBLE_EQ(out.secondary_times.at(0), 17.0);
+    EXPECT_DOUBLE_EQ(out.secondary_times.at(1), 17.0);
+}
+
+TEST(TimePropagation, CrossSectionRecordVertexTimeOverridePropagatesToSecondaries) {
+    InteractionRecord in = MakePopulatedInteractionRecord();
+    in.interaction_time = 17.0;
+
+    CrossSectionDistributionRecord csr(in);
+    csr.SetInteractionTime(20.0);
+    EXPECT_DOUBLE_EQ(csr.GetInteractionTime(), 20.0);
+    // The secondaries' default production times follow the override.
+    EXPECT_DOUBLE_EQ(csr.GetSecondaryParticleRecord(0).GetTime(), 20.0);
+
+    auto & s0 = csr.GetSecondaryParticleRecord(0);
+    s0.SetMass(0.5);
+    s0.SetFourMomentum({1.0, 0.0, 1.0, 0.0});
+    s0.SetHelicity(1.0);
+    auto & s1 = csr.GetSecondaryParticleRecord(1);
+    s1.SetMass(0.25);
+    s1.SetFourMomentum({2.0, 0.0, 0.0, 2.0});
+    s1.SetHelicity(-1.0);
+    // A per-particle time takes precedence over the vertex time.
+    s1.SetTime(25.0);
+
+    InteractionRecord out = in;
+    csr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.interaction_time, 20.0);
+    ASSERT_EQ(out.secondary_times.size(), 2u);
+    EXPECT_DOUBLE_EQ(out.secondary_times.at(0), 20.0);
+    EXPECT_DOUBLE_EQ(out.secondary_times.at(1), 25.0);
+}
+
+TEST(TimePropagation, SecondaryRecordThreadsProductionTimeFromParent) {
+    using siren::utilities::Constants::c;
+
+    InteractionRecord parent;
+    parent.signature.primary_type = ParticleType::EMinus;
+    parent.signature.secondary_types = {ParticleType::EMinus};
+    parent.interaction_vertex = {10.0, 0.0, 0.0};
+    parent.interaction_time = 17.0;
+    parent.secondary_ids = {ParticleID(42, 7)};
+    parent.secondary_masses = {0.0};
+    parent.secondary_momenta = {std::array<double, 4>{5.0, 3.0, 4.0, 0.0}};  // beta = 1
+    parent.secondary_helicities = {1.0};
+    parent.secondary_times = {21.0};
+
+    SecondaryDistributionRecord sdr(parent, 0);
+    EXPECT_DOUBLE_EQ(sdr.initial_time, 21.0);
+
+    // Interaction time requires the length.
+    EXPECT_THROW(sdr.GetInteractionTime(), std::runtime_error);
+    sdr.SetLength(10.0);
+    EXPECT_NEAR(sdr.GetInteractionTime(), 21.0 + 10.0 / c, 1e-9);
+
+    InteractionRecord out;
+    sdr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.primary_initial_time, 21.0);
+    EXPECT_NEAR(out.interaction_time, 21.0 + 10.0 / c, 1e-9);
+}
+
+TEST(TimePropagation, SecondaryRecordFallsBackToParentVertexTime) {
+    InteractionRecord parent;
+    parent.signature.primary_type = ParticleType::EMinus;
+    parent.signature.secondary_types = {ParticleType::EMinus};
+    parent.interaction_vertex = {10.0, 0.0, 0.0};
+    parent.interaction_time = 17.0;
+    parent.secondary_ids = {ParticleID(42, 7)};
+    parent.secondary_masses = {0.0};
+    parent.secondary_momenta = {std::array<double, 4>{5.0, 3.0, 4.0, 0.0}};
+    parent.secondary_helicities = {1.0};
+    // No secondary_times, as for records loaded from version 0 archives.
+
+    SecondaryDistributionRecord sdr(parent, 0);
+    EXPECT_DOUBLE_EQ(sdr.initial_time, 17.0);
+}
+
+TEST(TimePropagation, SecondaryRecordInteractionTimeOverride) {
+    InteractionRecord parent;
+    parent.signature.primary_type = ParticleType::EMinus;
+    parent.signature.secondary_types = {ParticleType::EMinus};
+    parent.interaction_vertex = {10.0, 0.0, 0.0};
+    parent.interaction_time = 17.0;
+    parent.secondary_ids = {ParticleID(42, 7)};
+    parent.secondary_masses = {0.0};
+    parent.secondary_momenta = {std::array<double, 4>{5.0, 3.0, 4.0, 0.0}};
+    parent.secondary_helicities = {1.0};
+    parent.secondary_times = {21.0};
+
+    SecondaryDistributionRecord sdr(parent, 0);
+    sdr.SetLength(10.0);
+    sdr.SetInteractionTime(99.0);
+
+    InteractionRecord out;
+    sdr.Finalize(out);
+    EXPECT_DOUBLE_EQ(out.interaction_time, 99.0);
 }
 
 int main(int argc, char** argv) {

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
@@ -87,9 +87,6 @@ private:
     mutable double vertex_distance_from_closest_approach;
     mutable double initial_distance_from_closest_approach;
     mutable double helicity = 0;
-    // Times default to zero rather than throwing when unset so that the
-    // automatic propagation rule works without any distribution knowing
-    // about time.
     mutable double initial_time = 0;
     mutable double interaction_time;
     std::map<std::string, double> interaction_parameters;
@@ -185,9 +182,6 @@ private:
     mutable std::array<double, 3> momentum = {0, 0, 0};
     mutable double helicity = 0;
     mutable double time = 0;
-    // Default production time: the vertex time of the parent interaction.
-    // CrossSectionDistributionRecord keeps this in sync when the vertex
-    // time is overridden.
     double initial_time = 0;
 
     friend class CrossSectionDistributionRecord;

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
@@ -72,6 +72,8 @@ private:
     bool vertex_distance_from_closest_approach_set = false;
     bool initial_distance_from_closest_approach_set = false;
     bool helicity_set = false;
+    bool initial_time_set = false;
+    bool interaction_time_set = false;
 
     mutable double mass;
     mutable double energy;
@@ -85,6 +87,11 @@ private:
     mutable double vertex_distance_from_closest_approach;
     mutable double initial_distance_from_closest_approach;
     mutable double helicity = 0;
+    // Times default to zero rather than throwing when unset so that the
+    // automatic propagation rule works without any distribution knowing
+    // about time.
+    mutable double initial_time = 0;
+    mutable double interaction_time;
     std::map<std::string, double> interaction_parameters;
 public:
     friend std::ostream& ::operator<<(std::ostream& os, siren::dataclasses::PrimaryDistributionRecord const& record);
@@ -117,6 +124,8 @@ public:
     double const & GetVertexDistanceFromClosestApproach() const;
     double const & GetInitialDistanceFromClosestApproach() const;
     double const & GetHelicity() const;
+    double const & GetInitialTime() const;
+    double const & GetInteractionTime() const;
 
     void SetMass(double mass);
     void SetEnergy(double energy);
@@ -131,6 +140,8 @@ public:
     void SetVertexDistanceFromClosestApproach(double vertex_distance_from_closest_approach);
     void SetInitialDistanceFromClosestApproach(double initial_distance_from_closest_approach);
     void SetHelicity(double helicity);
+    void SetInitialTime(double initial_time);
+    void SetInteractionTime(double interaction_time);
     void SetInteractionParameters(std::map<std::string, double> const & parameters);
     void SetInteractionParameter(std::string const & name, double value);
 
@@ -145,6 +156,7 @@ public:
     void UpdatePointOfClosestApproach() const;
     void UpdateVertexDistanceFromClosestApproach() const;
     void UpdateInitialDistanceFromClosestApproach() const;
+    void UpdateInteractionTime() const;
 
     void FinalizeAvailable(InteractionRecord & record) const;
     void Finalize(InteractionRecord & record) const;
@@ -164,6 +176,7 @@ private:
     bool direction_set = false;
     bool momentum_set = false;
     bool helicity_set = false;
+    bool time_set = false;
 
     mutable double mass = 0;
     mutable double energy = 0;
@@ -171,6 +184,13 @@ private:
     mutable std::array<double, 3> direction = {0, 0, 0};
     mutable std::array<double, 3> momentum = {0, 0, 0};
     mutable double helicity = 0;
+    mutable double time = 0;
+    // Default production time: the vertex time of the parent interaction.
+    // CrossSectionDistributionRecord keeps this in sync when the vertex
+    // time is overridden.
+    double initial_time = 0;
+
+    friend class CrossSectionDistributionRecord;
 public:
     friend std::ostream& ::operator<<(std::ostream& os, siren::dataclasses::SecondaryParticleRecord const& record);
     friend std::string (::to_str)(siren::dataclasses::SecondaryParticleRecord const & record);
@@ -201,6 +221,7 @@ public:
     std::array<double, 4> GetFourMomentum() const;
     std::array<double, 3> const & GetInitialPosition() const;
     double const & GetHelicity() const;
+    double const & GetTime() const;
 
     void SetMass(double mass);
     void SetEnergy(double energy);
@@ -209,6 +230,7 @@ public:
     void SetThreeMomentum(std::array<double, 3> momentum);
     void SetFourMomentum(std::array<double, 4> momentum);
     void SetHelicity(double helicity);
+    void SetTime(double time);
 
     void UpdateMass() const;
     void UpdateEnergy() const;
@@ -230,6 +252,7 @@ public:
     std::array<double, 4> const & primary_momentum;
     double const & primary_helicity;
     std::array<double, 3> const & interaction_vertex;
+    double const & interaction_time;
 
     ParticleID const target_id;
     ParticleType const & target_type;
@@ -239,6 +262,8 @@ public:
     std::map<std::string, double> interaction_parameters;
 private:
     std::vector<SecondaryParticleRecord> secondary_particles;
+    bool interaction_time_set = false;
+    double overridden_interaction_time = 0;
 public:
     friend std::ostream& ::operator<<(std::ostream& os, siren::dataclasses::CrossSectionDistributionRecord const& record);
     friend std::string (::to_str)(siren::dataclasses::CrossSectionDistributionRecord const & record);
@@ -260,6 +285,7 @@ public:
     double const & GetPrimaryHelicity() const;
 
     std::array<double, 3> const & GetInteractionVertex() const;
+    double const & GetInteractionTime() const;
     ParticleID const & GetTargetID() const;
     ParticleType const & GetTargetType() const;
 
@@ -269,6 +295,7 @@ public:
     double & GetTargetHelicity();
     std::map<std::string, double> & GetInteractionParameters();
 
+    void SetInteractionTime(double interaction_time);
     void SetTargetMass(double mass);
     void SetTargetHelicity(double helicity);
     void SetInteractionParameters(std::map<std::string, double> const & parameters);
@@ -287,6 +314,7 @@ public:
     InteractionSignature signature;
     ParticleID primary_id;
     std::array<double, 3> primary_initial_position = {0, 0, 0};
+    double primary_initial_time = 0;
     double primary_mass = 0;
     std::array<double, 4> primary_momentum = {0, 0, 0, 0};
     double primary_helicity = 0;
@@ -294,10 +322,12 @@ public:
     double target_mass = 0;
     double target_helicity = 0;
     std::array<double, 3> interaction_vertex = {0, 0, 0};
+    double interaction_time = 0;
     std::vector<ParticleID> secondary_ids;
     std::vector<double> secondary_masses;
     std::vector<std::array<double, 4>> secondary_momenta;
     std::vector<double> secondary_helicities;
+    std::vector<double> secondary_times;
     std::map<std::string, double> interaction_parameters;
 
     bool operator==(InteractionRecord const & other) const;
@@ -324,8 +354,27 @@ public:
             archive(::cereal::make_nvp("SecondaryMomenta", secondary_momenta));
             archive(::cereal::make_nvp("SecondaryHelicities", secondary_helicities));
             archive(::cereal::make_nvp("InteractionParameters", interaction_parameters));
+        } else if(version == 1) {
+            archive(::cereal::make_nvp("InteractionSignature", signature));
+            archive(::cereal::make_nvp("PrimaryID", primary_id));
+            archive(::cereal::make_nvp("PrimaryInitialPosition", primary_initial_position));
+            archive(::cereal::make_nvp("PrimaryInitialTime", primary_initial_time));
+            archive(::cereal::make_nvp("PrimaryMass", primary_mass));
+            archive(::cereal::make_nvp("PrimaryMomentum", primary_momentum));
+            archive(::cereal::make_nvp("PrimaryHelicity", primary_helicity));
+            archive(::cereal::make_nvp("TargetID", target_id));
+            archive(::cereal::make_nvp("TargetMass", target_mass));
+            archive(::cereal::make_nvp("TargetHelicity", target_helicity));
+            archive(::cereal::make_nvp("InteractionVertex", interaction_vertex));
+            archive(::cereal::make_nvp("InteractionTime", interaction_time));
+            archive(::cereal::make_nvp("SecondaryIDs", secondary_ids));
+            archive(::cereal::make_nvp("SecondaryMasses", secondary_masses));
+            archive(::cereal::make_nvp("SecondaryMomenta", secondary_momenta));
+            archive(::cereal::make_nvp("SecondaryHelicities", secondary_helicities));
+            archive(::cereal::make_nvp("SecondaryTimes", secondary_times));
+            archive(::cereal::make_nvp("InteractionParameters", interaction_parameters));
         } else {
-            throw std::runtime_error("InteractionRecord only supports version <= 0!");
+            throw std::runtime_error("InteractionRecord only supports version <= 1!");
         }
     }
     template<typename Archive>
@@ -346,8 +395,32 @@ public:
             archive(::cereal::make_nvp("SecondaryMomenta", secondary_momenta));
             archive(::cereal::make_nvp("SecondaryHelicities", secondary_helicities));
             archive(::cereal::make_nvp("InteractionParameters", interaction_parameters));
+            // Times are not stored in version 0 archives; default them,
+            // sizing secondary_times to match the other secondary vectors.
+            primary_initial_time = 0;
+            interaction_time = 0;
+            secondary_times.assign(secondary_momenta.size(), 0);
+        } else if(version == 1) {
+            archive(::cereal::make_nvp("InteractionSignature", signature));
+            archive(::cereal::make_nvp("PrimaryID", primary_id));
+            archive(::cereal::make_nvp("PrimaryInitialPosition", primary_initial_position));
+            archive(::cereal::make_nvp("PrimaryInitialTime", primary_initial_time));
+            archive(::cereal::make_nvp("PrimaryMass", primary_mass));
+            archive(::cereal::make_nvp("PrimaryMomentum", primary_momentum));
+            archive(::cereal::make_nvp("PrimaryHelicity", primary_helicity));
+            archive(::cereal::make_nvp("TargetID", target_id));
+            archive(::cereal::make_nvp("TargetMass", target_mass));
+            archive(::cereal::make_nvp("TargetHelicity", target_helicity));
+            archive(::cereal::make_nvp("InteractionVertex", interaction_vertex));
+            archive(::cereal::make_nvp("InteractionTime", interaction_time));
+            archive(::cereal::make_nvp("SecondaryIDs", secondary_ids));
+            archive(::cereal::make_nvp("SecondaryMasses", secondary_masses));
+            archive(::cereal::make_nvp("SecondaryMomenta", secondary_momenta));
+            archive(::cereal::make_nvp("SecondaryHelicities", secondary_helicities));
+            archive(::cereal::make_nvp("SecondaryTimes", secondary_times));
+            archive(::cereal::make_nvp("InteractionParameters", interaction_parameters));
         } else {
-            throw std::runtime_error("InteractionRecord only supports version <= 0!");
+            throw std::runtime_error("InteractionRecord only supports version <= 1!");
         }
     }
 };
@@ -364,9 +437,12 @@ public:
     std::array<double, 4> const & momentum;
     double const & helicity;
     std::array<double, 3> const & initial_position;
+    double const & initial_time;
 private:
     bool length_set = false;
     mutable double length;
+    bool interaction_time_set = false;
+    mutable double interaction_time;
 public:
     friend std::ostream& ::operator<<(std::ostream& os, SecondaryDistributionRecord const& record);
 
@@ -381,6 +457,9 @@ public:
     void SetLength(double const & length);
     double const & GetLength() const;
 
+    void SetInteractionTime(double const & interaction_time);
+    double const & GetInteractionTime() const;
+
     void Finalize(InteractionRecord & record) const;
 };
 
@@ -388,6 +467,6 @@ public:
 } // namespace dataclasses
 } // namespace siren
 
-CEREAL_CLASS_VERSION(siren::dataclasses::InteractionRecord, 0);
+CEREAL_CLASS_VERSION(siren::dataclasses::InteractionRecord, 1);
 
 #endif // SIREN_InteractionRecord_H

--- a/python/SIREN_Controller.py
+++ b/python/SIREN_Controller.py
@@ -606,7 +606,9 @@ class SIREN_Controller:
             "event_global_time":[], # global time of each event
             "num_interactions":[], # number of interactions per event
             "vertex":[], # vertex of each interaction of an event
+            "vertex_time":[], # time of each interaction vertex of an event
             "primary_initial_position":[], # initial position of primary in each interaction of an event
+            "primary_initial_time":[], # initial time of primary in each interaction of an event
             "in_fiducial":[], # whether or not each vertex is in the fiducial volume
             "primary_type":[], # primary type of each interaction
             "target_type":[], # target type of each interaction
@@ -614,6 +616,7 @@ class SIREN_Controller:
             "secondary_types":[], # secondary type of each interaction
             "primary_momentum":[], # primary momentum of each interaction
             "secondary_momenta":[], # secondary momentum of each interaction
+            "secondary_times":[], # production time of each secondary of each interaction
             "parent_idx":[], # index of the parent interaction
             "num_daughters":[], # number of daughter interactions
         }
@@ -632,7 +635,9 @@ class SIREN_Controller:
             datasets["event_global_time"].append(self.global_times[ie])
             # add empty lists for each per interaction dataset
             for k in ["vertex",
+                      "vertex_time",
                       "primary_initial_position",
+                      "primary_initial_time",
                       "in_fiducial",
                       "primary_type",
                       "target_type",
@@ -640,6 +645,7 @@ class SIREN_Controller:
                       "secondary_types",
                       "primary_momentum",
                       "secondary_momenta",
+                      "secondary_times",
                       "parent_idx",
                       "num_daughters"]:
                 datasets[k].append([])
@@ -654,7 +660,9 @@ class SIREN_Controller:
                             datasets["int_params"][-1][param_name] = []
                         datasets["int_params"][-1][param_name].append(param_value)
                 datasets["vertex"][-1].append(np.array(datum.record.interaction_vertex,dtype=float))
+                datasets["vertex_time"][-1].append(datum.record.interaction_time)
                 datasets["primary_initial_position"][-1].append(np.array(datum.record.primary_initial_position,dtype=float))
+                datasets["primary_initial_time"][-1].append(datum.record.primary_initial_time)
 
                  # primary particle stuff
                 datasets["primary_type"][-1].append(int(datum.record.signature.primary_type))
@@ -685,10 +693,18 @@ class SIREN_Controller:
                 # secondary particle stuff
                 datasets["secondary_types"][-1].append([])
                 datasets["secondary_momenta"][-1].append([])
-                for isec, (sec_type, sec_momenta) in enumerate(zip(datum.record.signature.secondary_types,
-                                                                   datum.record.secondary_momenta)):
+                datasets["secondary_times"][-1].append([])
+                # events loaded from old files predate secondary_times;
+                # fall back to the vertex time for them
+                sec_times = datum.record.secondary_times
+                if len(sec_times) != len(datum.record.secondary_momenta):
+                    sec_times = [datum.record.interaction_time] * len(datum.record.secondary_momenta)
+                for isec, (sec_type, sec_momenta, sec_time) in enumerate(zip(datum.record.signature.secondary_types,
+                                                                             datum.record.secondary_momenta,
+                                                                             sec_times)):
                     datasets["secondary_types"][-1][-1].append(int(sec_type))
                     datasets["secondary_momenta"][-1][-1].append(np.array(sec_momenta,dtype=float))
+                    datasets["secondary_times"][-1][-1].append(sec_time)
                 datasets["num_secondaries"][-1].append(isec+1)
             datasets["num_interactions"].append(id+1)
 

--- a/python/SIREN_Controller.py
+++ b/python/SIREN_Controller.py
@@ -652,6 +652,8 @@ class SIREN_Controller:
             if save_int_params:
                 datasets.setdefault("int_params", [])
                 datasets["int_params"].append({})
+            # parent index of each interaction, taken from the tree's parent edges
+            parent_indices = _util.get_parent_indices(event.tree)
             # loop over interactions
             for id, datum in enumerate(event.tree):
                 if save_int_params:
@@ -669,15 +671,8 @@ class SIREN_Controller:
                 datasets["primary_momentum"][-1].append(np.array(datum.record.primary_momentum, dtype=float))
                 datasets["num_daughters"][-1].append(len(datum.daughters))
 
-                # check parent idx; match on secondary momenta
-                if datum.depth()==0:
-                    datasets["parent_idx"][-1].append(-1)
-                else:
-                    for _id in range(len(datasets["secondary_momenta"][-1])):
-                        for secondary_momentum in datasets["secondary_momenta"][-1][_id]:
-                            if (datasets["primary_momentum"][-1][-1] == secondary_momentum).all():
-                                datasets["parent_idx"][-1].append(_id)
-                                break
+                # parent interaction index (from the tree's parent/daughter edges)
+                datasets["parent_idx"][-1].append(parent_indices[id])
 
                 if self.fid_vol is not None:
                     pos = _math.Vector3D(datasets["vertex"][-1][-1])

--- a/python/SIREN_Controller.py
+++ b/python/SIREN_Controller.py
@@ -700,7 +700,7 @@ class SIREN_Controller:
                     datasets["secondary_types"][-1][-1].append(int(sec_type))
                     datasets["secondary_momenta"][-1][-1].append(np.array(sec_momenta,dtype=float))
                     datasets["secondary_times"][-1][-1].append(sec_time)
-                datasets["num_secondaries"][-1].append(isec+1)
+                datasets["num_secondaries"][-1].append(len(datum.record.secondary_momenta))
             datasets["num_interactions"].append(id+1)
 
         # save injector and weighter (writes <filename>.siren_injector and

--- a/python/_util.py
+++ b/python/_util.py
@@ -935,6 +935,34 @@ def GenerateEvents(injector, N=None):
         count += 1
     return events,gen_times
 
+def get_parent_indices(tree):
+    """Return the parent interaction index for each datum in an InteractionTree.
+
+    ``tree`` is the ordered list of ``InteractionTreeDatum`` objects, i.e.
+    ``event.tree``. The returned list holds, for each datum, the index (within
+    ``tree``) of the interaction whose secondary particle became this datum's
+    primary, or ``-1`` for a root/primary interaction that has no parent.
+
+    Parentage is read directly from the tree's parent/daughter edges via the
+    ``InteractionTreeDatum.parent`` pointer -- the authoritative link the
+    injector records when it builds the tree. Earlier versions instead matched a
+    datum's primary four-momentum against earlier interactions' secondary
+    momenta, which is O(n^2) per tree and silently mis-links parentage whenever
+    two secondaries share identical four-momenta.
+    """
+    # Map each datum's object identity to its position in the flattened tree.
+    # pybind11 returns the same wrapper object for a given C++ shared_ptr, so a
+    # datum's ``.parent`` is identity-equal to its entry in ``tree``.
+    index_of = {id(datum): i for i, datum in enumerate(tree)}
+    parent_indices = []
+    for datum in tree:
+        parent = datum.parent
+        if parent is None:
+            parent_indices.append(-1)
+        else:
+            parent_indices.append(index_of.get(id(parent), -1))
+    return parent_indices
+
 def SaveEvents(events,
                weighter=None,
                gen_times=None,
@@ -980,6 +1008,8 @@ def SaveEvents(events,
                   "secondary_momenta",
                   "parent_idx"]:
             datasets[k].append([])
+        # parent index of each interaction, taken from the tree's parent edges
+        parent_indices = get_parent_indices(event.tree)
         # loop over interactions
         for id, datum in enumerate(event.tree):
             datasets["vertex"][-1].append(np.array(datum.record.interaction_vertex,dtype=float))
@@ -988,15 +1018,8 @@ def SaveEvents(events,
             datasets["primary_type"][-1].append(int(datum.record.signature.primary_type))
             datasets["primary_momentum"][-1].append(np.array(datum.record.primary_momentum, dtype=float))
 
-            # check parent idx; match on secondary momenta
-            if datum.depth()==0:
-                datasets["parent_idx"][-1].append(-1)
-            else:
-                for _id in range(len(datasets["secondary_momenta"][-1])):
-                    for secondary_momentum in datasets["secondary_momenta"][-1][_id]:
-                        if (datasets["primary_momentum"][-1][-1] == secondary_momentum).all():
-                            datasets["parent_idx"][-1].append(_id)
-                            break
+            # parent interaction index (from the tree's parent/daughter edges)
+            datasets["parent_idx"][-1].append(parent_indices[id])
 
             if fid_vol is not None:
                 pos = _math.Vector3D(datasets["vertex"][-1][-1])

--- a/python/_util.py
+++ b/python/_util.py
@@ -960,7 +960,7 @@ def get_parent_indices(tree):
         if parent is None:
             parent_indices.append(-1)
         else:
-            parent_indices.append(index_of.get(id(parent), -1))
+            parent_indices.append(index_of[id(parent)])
     return parent_indices
 
 def SaveEvents(events,

--- a/tests/python/test_interaction_tree_parentage.py
+++ b/tests/python/test_interaction_tree_parentage.py
@@ -1,0 +1,235 @@
+"""Regression tests for parent-interaction reconstruction in event flattening.
+
+The hdf5/parquet flattening in ``siren._util.SaveEvents`` (and its twin in
+``siren.SIREN_Controller.SIREN_Controller.SaveEvents``) records, for every
+interaction, the index of the parent interaction that produced it. This used to
+be reconstructed by comparing a datum's primary four-momentum against earlier
+interactions' secondary momenta. That is O(n^2) per tree and, more importantly,
+silently mis-links parentage whenever two secondaries share identical
+four-momenta (a common, physical situation).
+
+The fix reads parentage directly from the tree's parent/daughter edges via
+``InteractionTreeDatum.parent`` -- the authoritative link the injector records
+when it builds the tree. Both flattening functions now delegate to the shared
+``siren._util.get_parent_indices`` helper. These tests build a small tree by
+hand with two secondaries that share identical momenta and prove the new
+reconstruction links each daughter to the correct parent where the old momentum
+matching does not, end-to-end through both flattening call sites.
+"""
+import types
+
+import numpy as np
+import pytest
+
+siren = pytest.importorskip("siren")
+
+
+@pytest.fixture(scope="module")
+def dc():
+    from siren import dataclasses
+    return dataclasses
+
+
+def _make_record(dc, primary_type, primary_momentum, primary_id,
+                 secondary_types, secondary_momenta, secondary_ids):
+    record = dc.InteractionRecord()
+    sig = record.signature
+    sig.primary_type = primary_type
+    sig.secondary_types = list(secondary_types)
+    record.signature = sig
+    record.primary_momentum = list(primary_momentum)      # [E, px, py, pz]
+    record.primary_id = primary_id
+    record.secondary_momenta = [list(p) for p in secondary_momenta]
+    record.secondary_ids = list(secondary_ids)
+    return record
+
+
+def _build_degenerate_momentum_tree(dc):
+    """Build a tree in which momentum matching is provably ambiguous.
+
+    Layout (insertion order == index order, parents before children)::
+
+        idx0  root      -> secondaries B (mom M), B2 (mom M)   # identical momenta
+        idx1  primary B  (parent idx0) -> secondary C (mom M)
+        idx2  primary B2 (parent idx0) -> secondary D (mom M)
+        idx3  primary C  (parent idx1) -> secondary E (mom M)
+        idx4  primary D  (parent idx2) -> secondary F (mom X)
+
+    Almost every particle shares the same momentum ``M``, so matching a primary
+    momentum against earlier secondary momenta cannot tell the branches apart.
+    The true parentage (from the ``.parent`` edges) is ``[-1, 0, 0, 1, 2]``.
+
+    Note idx4's true parent is index 2 while its depth is 2, so ``parent index``
+    and ``depth - 1`` deliberately disagree there -- a reconstruction that merely
+    tracked depth (rather than the actual parent pointer) would get idx4 wrong.
+    """
+    PT = dc.ParticleType
+
+    M = [10.0, 0.0, 0.0, 10.0]   # degenerate momentum shared by B, B2, C, D, E
+    X = [5.0, 0.0, 0.0, 5.0]
+
+    # unique IDs for every secondary particle (2-arg ctor sets major/minor)
+    sB = dc.ParticleID(1, 1)
+    sB2 = dc.ParticleID(1, 2)
+    sC = dc.ParticleID(1, 3)
+    sD = dc.ParticleID(1, 4)
+    sE = dc.ParticleID(1, 5)
+    sF = dc.ParticleID(1, 6)
+
+    root = _make_record(
+        dc, PT.KPlus, [20.0, 0.0, 0.0, 20.0], dc.ParticleID(9, 9),
+        [PT.NuMu, PT.NuMu], [M, M], [sB, sB2])
+    # daughter B: its primary IS the root's first secondary (same id + momentum)
+    child_B = _make_record(dc, PT.NuMu, M, sB, [PT.NuMu], [M], [sC])
+    # daughter B2: its primary IS the root's second secondary (identical momentum)
+    child_B2 = _make_record(dc, PT.NuMu, M, sB2, [PT.NuMu], [M], [sD])
+    # grand-daughter C: primary IS child_B's secondary (still momentum M)
+    child_C = _make_record(dc, PT.NuMu, M, sC, [PT.NuMu], [M], [sE])
+    # grand-daughter D: primary IS child_B2's secondary (still momentum M)
+    child_D = _make_record(dc, PT.NuMu, M, sD, [PT.NuMu], [X], [sF])
+
+    tree = dc.InteractionTree()
+    d0 = tree.add_entry(root, None)     # root: single-arg overload is not bound
+    d1 = tree.add_entry(child_B, d0)
+    d2 = tree.add_entry(child_B2, d0)
+    _d3 = tree.add_entry(child_C, d1)
+    _d4 = tree.add_entry(child_D, d2)
+
+    expected_parents = [-1, 0, 0, 1, 2]
+    return tree, expected_parents
+
+
+def _momentum_parent_indices(entries):
+    """Faithful reproduction of the OLD momentum-matching reconstruction.
+
+    Mirrors the removed inline snippet from ``_util.SaveEvents`` /
+    ``SIREN_Controller.SaveEvents``: for each datum, scan every earlier
+    interaction's secondary momenta and append the index on a match, with the
+    ``break`` only exiting the inner loop (so a single datum can match -- and be
+    appended -- more than once). Kept here so the test documents exactly the
+    behavior being regressed away from.
+    """
+    secondary_momenta = []
+    parent_idx = []
+    for datum in entries:
+        primary_momentum = np.array(datum.record.primary_momentum, dtype=float)
+        if datum.depth() == 0:
+            parent_idx.append(-1)
+        else:
+            for _id in range(len(secondary_momenta)):
+                for secondary_momentum in secondary_momenta[_id]:
+                    if (primary_momentum == secondary_momentum).all():
+                        parent_idx.append(_id)
+                        break
+        secondary_momenta.append(
+            [np.array(p, dtype=float) for p in datum.record.secondary_momenta])
+    return parent_idx
+
+
+def test_ground_truth_edges(dc):
+    """Sanity: the hand-built tree has the parent/daughter edges we expect."""
+    tree, _expected = _build_degenerate_momentum_tree(dc)
+    entries = list(tree.tree)
+    assert [d.depth() for d in entries] == [0, 1, 1, 2, 2]
+    assert entries[0].parent is None
+    assert entries[1].parent is entries[0]
+    assert entries[2].parent is entries[0]
+    assert entries[3].parent is entries[1]
+    assert entries[4].parent is entries[2]
+    # the two root secondaries genuinely share identical four-momenta
+    m0, m1 = entries[0].record.secondary_momenta
+    assert list(m0) == list(m1)
+
+
+def test_get_parent_indices_uses_tree_edges(dc):
+    """The shipped helper reconstructs parentage from the tree edges."""
+    from siren._util import get_parent_indices
+    tree, expected = _build_degenerate_momentum_tree(dc)
+    result = get_parent_indices(tree.tree)
+    # one index per interaction, each pointing at the true parent
+    assert result == expected
+    assert len(result) == len(tree.tree)
+    # each entry points at the *actual* parent object, not merely a same-depth
+    # node (idx4's parent is index 2, not depth-1 == 1)
+    for i, datum in enumerate(tree.tree):
+        if datum.parent is None:
+            assert result[i] == -1
+        else:
+            assert tree.tree[result[i]] is datum.parent
+    # guard specifically against a depth-based stand-in
+    depth_minus_one = [d.depth() - 1 for d in tree.tree]
+    assert result != depth_minus_one
+
+
+def test_momentum_matching_would_mislink(dc):
+    """The old momentum-based reconstruction is wrong on this tree.
+
+    It cannot produce the correct ``[-1, 0, 0, 1, 2]``: because the secondaries
+    all carry momentum M, each deeper primary matches multiple earlier
+    interactions' secondaries, so entries are mis-linked and appended more than
+    once -- corrupting the per-event alignment.
+    """
+    from siren._util import get_parent_indices
+    tree, expected = _build_degenerate_momentum_tree(dc)
+
+    momentum_result = _momentum_parent_indices(tree.tree)
+    correct_result = get_parent_indices(tree.tree)
+
+    assert correct_result == expected
+    # the momentum reconstruction disagrees with the truth ...
+    assert momentum_result != expected
+    # ... and specifically over-counts (more entries than interactions),
+    # demonstrating the silent misalignment the fix removes.
+    assert len(momentum_result) != len(tree.tree)
+
+
+def _read_parquet_parent_idx(path):
+    import awkward as ak
+    return ak.from_parquet(path)["parent_idx"].tolist()
+
+
+def test_util_saveevents_parquet_parent_idx(dc, tmp_path):
+    """End-to-end: siren._util.SaveEvents writes the correct parent_idx column."""
+    pytest.importorskip("pyarrow")
+    from siren import _util
+
+    tree, expected = _build_degenerate_momentum_tree(dc)
+    out = str(tmp_path / "events_util")
+    _util.SaveEvents(
+        [tree],
+        weighter=None,
+        gen_times=[0.0],
+        save_hdf5=False,
+        save_parquet=True,
+        save_siren_events=False,
+        fid_vol=None,
+        output_filename=out)
+
+    assert _read_parquet_parent_idx(out + ".parquet") == [expected]
+
+
+def test_controller_saveevents_parquet_parent_idx(dc, tmp_path):
+    """End-to-end: SIREN_Controller.SaveEvents writes the correct parent_idx.
+
+    SaveEvents only duck-types a handful of ``self`` attributes, so we drive the
+    unbound method with a lightweight stand-in rather than standing up a full
+    detector/injector -- this exercises the real (modified) controller call site,
+    including its delegation to ``_util.get_parent_indices``.
+    """
+    pytest.importorskip("pyarrow")
+    from siren.SIREN_Controller import SIREN_Controller
+
+    tree, expected = _build_degenerate_momentum_tree(dc)
+    out = str(tmp_path / "events_ctrl")
+    stub_self = types.SimpleNamespace(
+        events=[tree],
+        gen_times=[0.0],
+        global_times=[0.0],
+        fid_vol=None,
+        injector=types.SimpleNamespace(SaveInjector=lambda path: None),
+    )
+    SIREN_Controller.SaveEvents(
+        stub_self, out, hdf5=False, parquet=True, siren_events=False,
+        verbose=False)
+
+    assert _read_parquet_parent_idx(out + ".parquet") == [expected]


### PR DESCRIPTION
# Summary

This PR does two unrelated things:
- adds particle timing to the `InteractionRecord`
- fixes a bug in how saved event files link each interaction to its parent

## 1. Time fields on `InteractionRecord`
This PR adds three fields to `InteractionRecord`:

- `primary_initial_time`: when the incoming particle started its flight,
- `interaction_time`: when it reached the interaction point,
- `secondary_times`: one time per produced particle, stored as a list that runs parallel to the existing list of produced-particle momenta (`secondary_momenta`), so entry `i` in one lines up with entry `i` in the other.

All times are in **ns**, the default SIREN time units.

**Times are automatically populated** as interactions occur, but can also be **overridden**.

- When an interaction vertex is finalized, the code stamps `interaction_time = start time + flight time`, where the flight time is `path length / (beta * c)` and the speed `beta` comes straight from the particle's energy and mass (`sqrt(E^2 - m^2) / E`). The path length is recomputed from the finalized start and vertex positions rather than the stored length.
- A child interaction inherits its start time from the parent's emission time for that specific produced particle. If the parent record comes from an older file that predates this feature and has no such entry, the child falls back to the parent's interaction time.
- If a time is never set, it defaults to zero instead of raising an error, so every existing distribution keeps working untouched.

The times can be overridden in three places:

- On the `InteractionRecord` itself through `SetInitialTime` / `SetInteractionTime`
- From within a CrossSection or Decay process with `CrossSectionDistributionRecord::SetInteractionTime`. This changes both the interaction time and all the secondary times, so an override made from inside `SampleFinalState` leaves the daughters consistent. (It reaches into the produced-particle record's internals through a C++ `friend` relationship)
- On an individual produced particle (`SecondaryParticleRecord::SetTime`): let's you set the creation time for a particle emitted after a delay.

The order in which these run matters and is deliberate: overrides are applied when the cross-section record is finalized, which happens **after** the automatic time is stamped and **before** any child interaction reads that time. So a sampled delay flows down the event tree exactly once.

**Old saved files still load.** The version-0 read path is unchanged except that the new times default to zero and `secondary_times` is resized to line up with the other produced-particle lists. Existing `.siren_events` files therefore still load cleanly.

**In Python and in output tables.** The sampling records gain new Python properties `initial_time`, `interaction_time`, and `time` (a 7-line addition to the pybind11 bindings), and `SaveEvents` now writes `vertex_time`, `primary_initial_time`, and `secondary_times` columns. For events loaded from older files that predate the time fields, these default to the vertex time.

## 2. Event-flattening parentage fix

When SIREN flattens an event tree into an HDF5 or Parquet table, each interaction needs to record which earlier interaction produced it i.e. `parent_idx`. This was done by matching the four-momentum between particles in the two records, which had and N^2 runtime and would fail if two particles had identical momenta.

Parentage is now read straight from the parent/child links the event tree already stores through the `_util.get_parent_indices` helper, which is used by both `_util.SaveEvents` and `SIREN_Controller.SaveEvents`.

## Test coverage

- `InteractionRecord_TEST.cxx`: field-by-field equality, a version-1 JSON round trip, a check that loading the wrong version throws, and `Version0_LoadsWithDefaultTimes` — which loads a genuine version-0 archive, asserts its JSON contains no time keys, and confirms it loads with zeroed times.
- `tests/python/test_interaction_tree_parentage.py`: the adversarial momentum-degenerate tree described above, verified both through the `get_parent_indices` helper directly and through both real `SaveEvents` call sites.

## Known issues

- **Degenerate kinematics** (`InteractionRecord.cxx`, `FlightTime`). A primary that is at rest, or has energy at or below its mass (`E <= m`), traveling over a finite path records a flight time of zero instead of raising an error. A particle with a spacelike (unphysical) four-momentum, where `E < |p|`, is clamped to `beta = 1`. We should decide whether these cases should assert, clamp to a physical value, or stay permissive by design.
- The new time columns (`vertex_time`, `primary_initial_time`, `secondary_times`) were added to `SIREN_Controller.SaveEvents` only, but **not** to the module-level `_util.SaveEvents`. This is likely bad because the controller path is the one that is supposed to be deprecated.