### PR TITLE
Fix half-size boxes in the visualization GDML export

### DIFF
--- a/python/visualization.py
+++ b/python/visualization.py
@@ -188,8 +188,9 @@ def _solid_xml(geo, name):
     """Return GDML <solid> XML for *geo*, or None to fall back to a bbox."""
     cls = type(geo).__name__
     if cls == "Box":
+        # Box.X/Y/Z and GDML <box> x/y/z are both full widths.
         return ('<box name="%s" lunit="m" x="%s" y="%s" z="%s"/>'
-                % (name, _fmt(geo.X / 2), _fmt(geo.Y / 2), _fmt(geo.Z / 2)))
+                % (name, _fmt(geo.X), _fmt(geo.Y), _fmt(geo.Z)))
     if cls == "Sphere":
         return ('<sphere name="%s" lunit="m" aunit="rad" rmin="%s" rmax="%s" '
                 'startphi="%s" deltaphi="%s" starttheta="%s" deltatheta="%s"/>'

--- a/tests/python/test_visualization.py
+++ b/tests/python/test_visualization.py
@@ -29,6 +29,19 @@ def test_import_does_not_require_optional_deps():
     subprocess.run([sys.executable, "-c", code], check=True)
 
 
+def test_solid_xml_box_emits_full_widths():
+    """A Box exports its full widths (GDML <box> x == Box.X)."""
+    from siren import visualization
+    from siren.geometry import Box
+
+    box = Box(2.0, 4.0, 6.0)
+    el = ET.fromstring(visualization._solid_xml(box, "TESTBOX"))
+    assert el.tag == "box"
+    assert float(el.get("x")) == pytest.approx(2.0)
+    assert float(el.get("y")) == pytest.approx(4.0)
+    assert float(el.get("z")) == pytest.approx(6.0)
+
+
 @pytest.fixture(scope="module")
 def ccm_model(detectors_dir):
     from siren.detector import DetectorModel


### PR DESCRIPTION
## Summary

The pyg4ometry/GDML-export visualization path renders every box-shaped sector at half its true size on all three axes.

`_solid_xml()` in `python/visualization.py` emits an exact `<box>` using `geo.X / 2`, `geo.Y / 2`, `geo.Z / 2`. But `Box.X/Y/Z` return the **full** width (the C++ member is `full_width_x_`, `Box.h`), and a GDML `<box>` x/y/z is **also** a full width (Geant4 convention -- SIREN's own `ParseBox` treats it that way). So the halving shrinks every exactly-emitted box to half size.

This is inconsistent with the rest of the same file: the bounding-box path and the world box both deliberately *double* their half-extents to full widths ("GDML `<box>` x/y/z are FULL lengths, so double it"). Only the exact-Box branch halved.

## Fix

Pass the full widths through unchanged:

```python
% (name, _fmt(geo.X), _fmt(geo.Y), _fmt(geo.Z)))
```

## Provenance

This is a regression. The same fix previously existed in the pre-split `interface-redesign` branch (introduced by the initial "pyg4ometry visualization" commit, fixed by "Align GDML length conventions with Geant4"). When that work was re-split into #151-154, the "Align GDML length conventions" change was reconstructed carrying only its `sbn_loader.py` hunk (in #152); the `visualization.py` hunk was dropped and never re-added to #154, so merging #154 reintroduced the half-size boxes.

## Scope

- **Affected:** `to_gdml()`, `view(backend="pyg4ometry")` (the default backend), and the web/ROOT export.
- **Not affected:** the native pyvista backend (`_pv_box` already uses full `geo.X`), and the bounding-box/world paths (already correct).

## Test

Adds `test_solid_xml_box_emits_full_widths` to `tests/python/test_visualization.py`: builds a `Box(2, 4, 6)`, exports it via `_solid_xml`, and asserts the emitted `<box>` carries the full 2/4/6, not the halved 1/2/3. Fails on the old code, passes with the fix.
