### PR TITLE
Harden InteractionTree with integer node references

### DIFF
--- a/projects/dataclasses/private/InteractionRecord.cxx
+++ b/projects/dataclasses/private/InteractionRecord.cxx
@@ -1166,6 +1166,10 @@ SecondaryDistributionRecord::SecondaryDistributionRecord(InteractionRecord const
     initial_position(record.primary_initial_position),
     initial_time(record.primary_initial_time) {}
 
+size_t SecondaryDistributionRecord::GetSecondaryIndex() const {
+    return secondary_index;
+}
+
 double const & SecondaryDistributionRecord::GetLength() const {
     if(not length_set) {
         throw std::runtime_error("Length not set!");

--- a/projects/dataclasses/private/InteractionTree.cxx
+++ b/projects/dataclasses/private/InteractionTree.cxx
@@ -1,52 +1,107 @@
 #include "SIREN/dataclasses/InteractionTree.h"
 
+#include <map>
 #include <memory>
+#include <string>
+#include <sstream>
+#include <cassert>
+#include <ostream>
+#include <unordered_map>
 
 namespace siren {
 namespace dataclasses {
 
-int InteractionTreeDatum::depth() const {
+int InteractionTreeDatum::depth(InteractionTree const & owner) const {
     int depth = 0;
-    if(parent==NULL) return depth;
-    std::shared_ptr<InteractionTreeDatum> test = std::make_shared<InteractionTreeDatum>(*parent);
-    while(true) {
+    std::uint32_t p = parent_index;
+    while(p != kNoParent) {
         ++depth;
-        if(test->parent==NULL) return depth;
-        test = std::make_shared<InteractionTreeDatum>(*(test->parent));
+        p = owner.tree.at(p)->parent_index;
     }
-    return -1;
+    return depth;
+}
+
+bool InteractionTreeDatum::operator==(InteractionTreeDatum const & other) const {
+    return node_id == other.node_id
+        and parent_index == other.parent_index
+        and daughter_indices == other.daughter_indices
+        and record == other.record;
+}
+
+bool InteractionTreeHeader::operator==(InteractionTreeHeader const & other) const {
+    return event_number == other.event_number
+        and weights == other.weights
+        and provenance == other.provenance;
+}
+
+bool InteractionTree::operator==(InteractionTree const & other) const {
+    if(not (header == other.header)) return false;
+    if(tree.size() != other.tree.size()) return false;
+    for(std::size_t i=0; i<tree.size(); ++i) {
+        bool const lhs = bool(tree[i]);
+        bool const rhs = bool(other.tree[i]);
+        if(lhs != rhs) return false;
+        if(lhs and not (*tree[i] == *other.tree[i])) return false;
+    }
+    return true;
 }
 
 std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(std::shared_ptr<InteractionTreeDatum> datum,
         std::shared_ptr<InteractionTreeDatum> parent) {
+    datum->node_id = static_cast<std::uint32_t>(tree.size());
     if (parent) {
-        datum->parent = parent;
-        parent->daughters.push_back(datum);
+        datum->parent_index = parent->node_id;
+        parent->daughter_indices.push_back(datum->node_id);
+    } else {
+        datum->parent_index = kNoParent;
     }
     tree.push_back(datum);
+    // Enforced invariant: node_id is exactly the position in tree.
+    assert(tree.back()->node_id == tree.size() - 1);
     return datum;
 }
 
 std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(InteractionTreeDatum& datum,
         std::shared_ptr<InteractionTreeDatum> parent) {
     std::shared_ptr<InteractionTreeDatum> _datum = std::make_shared<InteractionTreeDatum>(datum);
-    if (parent) {
-        _datum->parent = parent;
-        parent->daughters.push_back(_datum);
-    }
-    tree.push_back(_datum);
-    return _datum;
+    return add_entry(_datum, parent);
 }
 
 std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(InteractionRecord& record,
         std::shared_ptr<InteractionTreeDatum> parent) {
     std::shared_ptr<InteractionTreeDatum> datum = std::make_shared<InteractionTreeDatum>(record);
-    if (parent) {
-        datum->parent = parent;
-        parent->daughters.push_back(datum);
+    return add_entry(datum, parent);
+}
+
+void InteractionTree::rebuild_indices_from_legacy() {
+    // tree is already populated in parent-before-daughter order by the legacy
+    // writer. Map each node's shared_ptr identity to its position, then derive
+    // node_id/parent_index/daughter_indices from the legacy pointer edges.
+    std::unordered_map<InteractionTreeDatum const *, std::uint32_t> index_of;
+    index_of.reserve(tree.size());
+    for(std::size_t i=0; i<tree.size(); ++i) {
+        index_of[tree[i].get()] = static_cast<std::uint32_t>(i);
     }
-    tree.push_back(datum);
-    return datum;
+    for(std::size_t i=0; i<tree.size(); ++i) {
+        std::shared_ptr<InteractionTreeDatum> & datum = tree[i];
+        datum->node_id = static_cast<std::uint32_t>(i);
+        if(datum->legacy_parent) {
+            auto it = index_of.find(datum->legacy_parent.get());
+            datum->parent_index = (it != index_of.end()) ? it->second : kNoParent;
+        } else {
+            datum->parent_index = kNoParent;
+        }
+        datum->daughter_indices.clear();
+        for(auto const & d : datum->legacy_daughters) {
+            auto it = index_of.find(d.get());
+            if(it != index_of.end()) datum->daughter_indices.push_back(it->second);
+        }
+    }
+    // Break the legacy shared_ptr cycle so nothing leaks into the running process.
+    for(std::shared_ptr<InteractionTreeDatum> & datum : tree) {
+        datum->legacy_parent = nullptr;
+        datum->legacy_daughters.clear();
+    }
 }
 
 void SaveInteractionTrees(std::vector<std::shared_ptr<InteractionTree>>& trees, std::string const & filename) {
@@ -65,3 +120,80 @@ std::vector<std::shared_ptr<InteractionTree>> LoadInteractionTrees(std::string c
 
 } // namespace dataclasses
 } // namespace siren
+
+std::string to_str(siren::dataclasses::InteractionTreeDatum const & datum) {
+    using siren::dataclasses::kNoParent;
+    std::stringstream ss;
+    ss << "[ InteractionTreeDatum (" << &datum << ")\n";
+    ss << "  node_id: " << datum.node_id << '\n';
+    if(datum.parent_index == kNoParent) ss << "  parent_index: (root)\n";
+    else ss << "  parent_index: " << datum.parent_index << '\n';
+    ss << "  daughter_indices: [";
+    for(std::size_t i=0; i<datum.daughter_indices.size(); ++i) {
+        ss << (i ? ", " : "") << datum.daughter_indices[i];
+    }
+    ss << "]\n";
+    ss << "  record: " << to_str(datum.record) << '\n';
+    ss << ']';
+    return ss.str();
+}
+
+std::string to_str(siren::dataclasses::InteractionTreeHeader const & header) {
+    std::stringstream ss;
+    ss << "[ InteractionTreeHeader (" << &header << ")\n";
+    ss << "  event_number: " << header.event_number << '\n';
+    ss << "  weights: [";
+    for(std::size_t i=0; i<header.weights.size(); ++i) ss << (i ? ", " : "") << header.weights[i];
+    ss << "]\n";
+    ss << "  provenance: {";
+    bool first = true;
+    for(auto const & kv : header.provenance) {
+        ss << (first ? "" : ", ") << kv.first << ": " << kv.second;
+        first = false;
+    }
+    ss << "}\n]";
+    return ss.str();
+}
+
+std::string to_str(siren::dataclasses::InteractionTree const & tree) {
+    std::stringstream ss;
+    ss << "[ InteractionTree (" << &tree << ")\n";
+    ss << "  " << to_str(tree.header) << '\n';
+    ss << "  nodes: " << tree.tree.size() << '\n';
+    ss << ']';
+    return ss.str();
+}
+
+std::string to_repr(siren::dataclasses::InteractionTreeDatum const & datum) {
+    using siren::dataclasses::kNoParent;
+    std::stringstream ss;
+    ss << "InteractionTreeDatum(node_id=" << datum.node_id << ", parent_index=";
+    if(datum.parent_index == kNoParent) ss << "None"; else ss << datum.parent_index;
+    ss << ", daughters=" << datum.daughter_indices.size() << ")";
+    return ss.str();
+}
+
+std::string to_repr(siren::dataclasses::InteractionTreeHeader const & header) {
+    std::stringstream ss;
+    ss << "InteractionTreeHeader(event_number=" << header.event_number
+       << ", weights=" << header.weights.size()
+       << ", provenance=" << header.provenance.size() << ")";
+    return ss.str();
+}
+
+std::string to_repr(siren::dataclasses::InteractionTree const & tree) {
+    std::stringstream ss;
+    ss << "InteractionTree(nodes=" << tree.tree.size()
+       << ", event_number=" << tree.header.event_number << ")";
+    return ss.str();
+}
+
+std::ostream & operator<<(std::ostream & os, siren::dataclasses::InteractionTreeDatum const & datum) {
+    os << to_str(datum); return os;
+}
+std::ostream & operator<<(std::ostream & os, siren::dataclasses::InteractionTreeHeader const & header) {
+    os << to_str(header); return os;
+}
+std::ostream & operator<<(std::ostream & os, siren::dataclasses::InteractionTree const & tree) {
+    os << to_str(tree); return os;
+}

--- a/projects/dataclasses/private/InteractionTree.cxx
+++ b/projects/dataclasses/private/InteractionTree.cxx
@@ -14,8 +14,13 @@ namespace dataclasses {
 int InteractionTreeDatum::depth(InteractionTree const & owner) const {
     int depth = 0;
     std::uint32_t p = parent_index;
+    // An acyclic parent chain visits at most tree.size() nodes; exceeding that
+    // means the indices form a cycle (a corrupt archive), so stop rather than
+    // spin forever.
     while(p != kNoParent) {
         ++depth;
+        if(static_cast<std::size_t>(depth) > owner.tree.size())
+            throw std::runtime_error("InteractionTreeDatum::depth: parent_index chain exceeds tree size");
         p = owner.tree.at(p)->parent_index;
     }
     return depth;
@@ -49,6 +54,10 @@ bool InteractionTree::operator==(InteractionTree const & other) const {
 std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(std::shared_ptr<InteractionTreeDatum> datum,
         std::shared_ptr<InteractionTreeDatum> parent) {
     datum->node_id = static_cast<std::uint32_t>(tree.size());
+    // A node is a leaf at insertion; its daughters are recorded as they are
+    // added. Drop any indices carried over from a datum copied out of another
+    // tree, which would otherwise dangle into this one.
+    datum->daughter_indices.clear();
     if (parent) {
         datum->parent_index = parent->node_id;
         parent->daughter_indices.push_back(datum->node_id);
@@ -101,6 +110,22 @@ void InteractionTree::rebuild_indices_from_legacy() {
     for(std::shared_ptr<InteractionTreeDatum> & datum : tree) {
         datum->legacy_parent = nullptr;
         datum->legacy_daughters.clear();
+    }
+    validate_indices();
+}
+
+void InteractionTree::validate_indices() const {
+    std::uint32_t const n = static_cast<std::uint32_t>(tree.size());
+    for(std::uint32_t i = 0; i < n; ++i) {
+        std::shared_ptr<InteractionTreeDatum> const & datum = tree[i];
+        if(not datum) continue;
+        if(datum->node_id != i)
+            throw std::runtime_error("InteractionTree: node_id does not equal its position");
+        if(datum->parent_index != kNoParent and datum->parent_index >= n)
+            throw std::runtime_error("InteractionTree: parent_index out of range");
+        for(std::uint32_t d : datum->daughter_indices)
+            if(d >= n)
+                throw std::runtime_error("InteractionTree: daughter_index out of range");
     }
 }
 

--- a/projects/dataclasses/private/InteractionTree.cxx
+++ b/projects/dataclasses/private/InteractionTree.cxx
@@ -54,9 +54,6 @@ bool InteractionTree::operator==(InteractionTree const & other) const {
 std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(std::shared_ptr<InteractionTreeDatum> datum,
         std::shared_ptr<InteractionTreeDatum> parent) {
     datum->node_id = static_cast<std::uint32_t>(tree.size());
-    // A node is a leaf at insertion; its daughters are recorded as they are
-    // added. Drop any indices carried over from a datum copied out of another
-    // tree, which would otherwise dangle into this one.
     datum->daughter_indices.clear();
     if (parent) {
         datum->parent_index = parent->node_id;

--- a/projects/dataclasses/private/InteractionTree.cxx
+++ b/projects/dataclasses/private/InteractionTree.cxx
@@ -115,14 +115,22 @@ void InteractionTree::validate_indices() const {
     std::uint32_t const n = static_cast<std::uint32_t>(tree.size());
     for(std::uint32_t i = 0; i < n; ++i) {
         std::shared_ptr<InteractionTreeDatum> const & datum = tree[i];
-        if(not datum) continue;
+        if(not datum)
+            throw std::runtime_error("InteractionTree: null datum in tree vector");
         if(datum->node_id != i)
             throw std::runtime_error("InteractionTree: node_id does not equal its position");
-        if(datum->parent_index != kNoParent and datum->parent_index >= n)
-            throw std::runtime_error("InteractionTree: parent_index out of range");
-        for(std::uint32_t d : datum->daughter_indices)
+        if(datum->parent_index != kNoParent) {
+            if(datum->parent_index >= n)
+                throw std::runtime_error("InteractionTree: parent_index out of range");
+            if(not tree[datum->parent_index])
+                throw std::runtime_error("InteractionTree: parent_index points to null datum");
+        }
+        for(std::uint32_t d : datum->daughter_indices) {
             if(d >= n)
                 throw std::runtime_error("InteractionTree: daughter_index out of range");
+            if(not tree[d])
+                throw std::runtime_error("InteractionTree: daughter_index points to null datum");
+        }
     }
 }
 

--- a/projects/dataclasses/private/pybindings/dataclasses.cxx
+++ b/projects/dataclasses/private/pybindings/dataclasses.cxx
@@ -202,20 +202,38 @@ PYBIND11_MODULE(dataclasses, m) {
     py::class_<InteractionTreeDatum, std::shared_ptr<InteractionTreeDatum>>(m, "InteractionTreeDatum")
         .def(py::init<InteractionRecord&>())
         .def_readwrite("record",&InteractionTreeDatum::record)
-        .def_readwrite("parent",&InteractionTreeDatum::parent)
-        .def_readwrite("daughters",&InteractionTreeDatum::daughters)
-        .def("depth",&InteractionTreeDatum::depth)
+        .def_readonly("node_id",&InteractionTreeDatum::node_id)
+        .def_readonly("parent_index",&InteractionTreeDatum::parent_index)
+        .def_readwrite("daughter_indices",&InteractionTreeDatum::daughter_indices)
+        .def("is_root",&InteractionTreeDatum::is_root)
+        .def("depth",&InteractionTreeDatum::depth, pybind11::arg("tree"))
+        .def("__str__", [](InteractionTreeDatum const & d){ return to_str(d); })
+        .def("__repr__", [](InteractionTreeDatum const & d){ return to_repr(d); })
         .def(pybind11::pickle(
             &(siren::serialization::pickle_save<InteractionTreeDatum>),
             &(siren::serialization::pickle_load<InteractionTreeDatum>)
         ))
         ;
 
+    py::class_<InteractionTreeHeader, std::shared_ptr<InteractionTreeHeader>>(m, "InteractionTreeHeader")
+        .def(py::init<>())
+        .def_readwrite("event_number", &InteractionTreeHeader::event_number)
+        .def_readwrite("weights", &InteractionTreeHeader::weights)
+        .def_readwrite("provenance", &InteractionTreeHeader::provenance)
+        .def("__str__", [](InteractionTreeHeader const & h){ return to_str(h); })
+        .def("__repr__", [](InteractionTreeHeader const & h){ return to_repr(h); })
+        ;
+
     py::class_<InteractionTree, std::shared_ptr<InteractionTree>>(m, "InteractionTree")
         .def(py::init<>())
         .def_readwrite("tree",&InteractionTree::tree)
+        .def_readwrite("header", &InteractionTree::header)
+        .def("at", &InteractionTree::at, pybind11::arg("node_id"))
+        .def("depth", &InteractionTree::depth, pybind11::arg("node_id"))
         .def("add_entry",static_cast<std::shared_ptr<InteractionTreeDatum> (InteractionTree::*)(InteractionTreeDatum&,std::shared_ptr<InteractionTreeDatum>)>(&InteractionTree::add_entry))
         .def("add_entry",static_cast<std::shared_ptr<InteractionTreeDatum> (InteractionTree::*)(InteractionRecord&,std::shared_ptr<InteractionTreeDatum>)>(&InteractionTree::add_entry))
+        .def("__str__", [](InteractionTree const & t){ return to_str(t); })
+        .def("__repr__", [](InteractionTree const & t){ return to_repr(t); })
         .def(pybind11::pickle(
             &(siren::serialization::pickle_save<InteractionTree>),
             &(siren::serialization::pickle_load<InteractionTree>)
@@ -223,7 +241,8 @@ PYBIND11_MODULE(dataclasses, m) {
         ;
 
     m.def("SaveInteractionTrees",&SaveInteractionTrees);
-    m.def("LoadInteractionTrees",&LoadInteractionTrees, py::return_value_policy::reference);
+    m.def("LoadInteractionTrees",&LoadInteractionTrees);
+    m.attr("kNoParent") = pybind11::int_(siren::dataclasses::kNoParent);
 
     m.def("GetParticleMass", &GetParticleMass, py::arg("particle_type"));
 

--- a/projects/dataclasses/private/test/InteractionTree_TEST.cxx
+++ b/projects/dataclasses/private/test/InteractionTree_TEST.cxx
@@ -2,10 +2,15 @@
 #include <math.h>
 #include <cmath>
 #include <random>
+#include <sstream>
 #include <iostream>
 #include <gtest/gtest.h>
 
+#include <cstdio>
+#include <fstream>
 #include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/memory.hpp>
 #include <cereal/types/vector.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/map.hpp>
@@ -17,6 +22,42 @@
 
 using namespace siren::dataclasses;
 
+// Legacy (version-0) mirror of the pointer-edge container layout: parent/daughters are
+// shared_ptr edges. Used only to write a genuine version-0 ".siren_events"
+// archive so the real (version-1) LoadInteractionTrees can be exercised on its
+// backward-compatibility branch (rebuild_indices_from_legacy).
+namespace legacy_v0 {
+struct LegacyDatum {
+    siren::dataclasses::InteractionRecord record;
+    std::shared_ptr<LegacyDatum> parent = nullptr;
+    std::vector<std::shared_ptr<LegacyDatum>> daughters;
+    template<class Archive>
+    void serialize(Archive & archive, std::uint32_t const version) {
+        if(version == 0) {
+            archive(::cereal::make_nvp("Record", record));
+            archive(::cereal::make_nvp("Parent", parent));
+            archive(::cereal::make_nvp("Daughters", daughters));
+        } else {
+            throw std::runtime_error("legacy_v0::LegacyDatum only writes version 0!");
+        }
+    }
+};
+struct LegacyTree {
+    std::vector<std::shared_ptr<LegacyDatum>> tree;
+    template<class Archive>
+    void serialize(Archive & archive, std::uint32_t const version) {
+        if(version == 0) {
+            archive(::cereal::make_nvp("Tree", tree));
+        } else {
+            throw std::runtime_error("legacy_v0::LegacyTree only writes version 0!");
+        }
+    }
+};
+} // namespace legacy_v0
+
+CEREAL_CLASS_VERSION(legacy_v0::LegacyDatum, 0);
+CEREAL_CLASS_VERSION(legacy_v0::LegacyTree, 0);
+
 std::mt19937 rng_;
 std::uniform_real_distribution<double> uniform_distribution(0.0, 1.0);
 
@@ -24,48 +65,15 @@ double RandomDouble() {
     return uniform_distribution(rng_);
 }
 
-int InteractionTreeDatum::depth() const {
-    int depth = 0;
-    if(parent==NULL) return depth;
-    std::shared_ptr<InteractionTreeDatum> test = std::make_shared<InteractionTreeDatum>(*parent);
-    while(true) {
-        ++depth;
-        if(test->parent==NULL) return depth;
-        test = std::make_shared<InteractionTreeDatum>(*(test->parent));
-    }
-    return -1;
-}
-
-std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(std::shared_ptr<InteractionTreeDatum> datum,
-        std::shared_ptr<InteractionTreeDatum> parent) {
-    if (parent) {
-        datum->parent = parent;
-        parent->daughters.push_back(datum);
-    }
-    tree.push_back(datum);
-    return datum;
-}
-
-std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(InteractionTreeDatum& datum,
-        std::shared_ptr<InteractionTreeDatum> parent) {
-    std::shared_ptr<InteractionTreeDatum> _datum = std::make_shared<InteractionTreeDatum>(datum);
-    if (parent) {
-        _datum->parent = parent;
-        parent->daughters.push_back(_datum);
-    }
-    tree.push_back(_datum);
-    return _datum;
-}
-
-std::shared_ptr<InteractionTreeDatum> InteractionTree::add_entry(InteractionRecord& record,
-        std::shared_ptr<InteractionTreeDatum> parent) {
-    std::shared_ptr<InteractionTreeDatum> datum = std::make_shared<InteractionTreeDatum>(record);
-    if (parent) {
-        datum->parent = parent;
-        parent->daughters.push_back(datum);
-    }
-    tree.push_back(datum);
-    return datum;
+// Helper: build an InteractionRecord with a fixed EPlus/EMinus signature so the
+// tests below can populate node records without repeating the boilerplate.
+InteractionRecord MakeRecord() {
+    InteractionRecord record;
+    record.signature.primary_type = siren::dataclasses::ParticleType::EPlus;
+    record.signature.target_type = siren::dataclasses::ParticleType::EPlus;
+    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EPlus);
+    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EMinus);
+    return record;
 }
 
 TEST(DatumConstructor, InteractionRecord)
@@ -83,6 +91,17 @@ TEST(DatumConstructor, InteractionRecord)
     EXPECT_EQ(datum.record.signature.secondary_types[1], siren::dataclasses::ParticleType::EMinus);
 }
 
+TEST(DatumConstructor, DefaultsAreRoot)
+{
+    // A freshly constructed datum has no owning tree yet; node_id and
+    // parent_index both default to the kNoParent sentinel and it reads as root.
+    InteractionTreeDatum datum;
+    EXPECT_EQ(datum.node_id, kNoParent);
+    EXPECT_EQ(datum.parent_index, kNoParent);
+    EXPECT_TRUE(datum.daughter_indices.empty());
+    EXPECT_TRUE(datum.is_root());
+}
+
 TEST(TreeConstructor, Default)
 {
     InteractionTree tree;
@@ -92,11 +111,7 @@ TEST(TreeConstructor, Default)
 TEST(TreeAddEntry, Record)
 {
     InteractionTree tree;
-    InteractionRecord record;
-    record.signature.primary_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.target_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EPlus);
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EMinus);
+    InteractionRecord record = MakeRecord();
 
     std::shared_ptr<InteractionTreeDatum> datum = tree.add_entry(record);
     EXPECT_EQ(tree.tree.size(), 1);
@@ -104,16 +119,16 @@ TEST(TreeAddEntry, Record)
     EXPECT_EQ(datum->record.signature.target_type, siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum->record.signature.secondary_types[0], siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum->record.signature.secondary_types[1], siren::dataclasses::ParticleType::EMinus);
+    // The first entry is a root at position 0.
+    EXPECT_EQ(datum->node_id, 0u);
+    EXPECT_EQ(datum->parent_index, kNoParent);
+    EXPECT_TRUE(datum->is_root());
 }
 
 TEST(TreeAddEntry, DatumReference)
 {
     InteractionTree tree;
-    InteractionRecord record;
-    record.signature.primary_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.target_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EPlus);
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EMinus);
+    InteractionRecord record = MakeRecord();
 
     InteractionTreeDatum datum = InteractionTreeDatum(record);
     std::shared_ptr<InteractionTreeDatum> datum2 = tree.add_entry(datum);
@@ -122,16 +137,13 @@ TEST(TreeAddEntry, DatumReference)
     EXPECT_EQ(datum2->record.signature.target_type, siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum2->record.signature.secondary_types[0], siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum2->record.signature.secondary_types[1], siren::dataclasses::ParticleType::EMinus);
+    EXPECT_EQ(datum2->node_id, 0u);
 }
 
 TEST(TreeAddEntry, DatumPointer)
 {
     InteractionTree tree;
-    InteractionRecord record;
-    record.signature.primary_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.target_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EPlus);
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EMinus);
+    InteractionRecord record = MakeRecord();
 
     std::shared_ptr<InteractionTreeDatum> datum = std::make_shared<InteractionTreeDatum>(record);
     std::shared_ptr<InteractionTreeDatum> datum2 = tree.add_entry(datum);
@@ -140,16 +152,15 @@ TEST(TreeAddEntry, DatumPointer)
     EXPECT_EQ(datum2->record.signature.target_type, siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum2->record.signature.secondary_types[0], siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum2->record.signature.secondary_types[1], siren::dataclasses::ParticleType::EMinus);
+    // add_entry with a shared_ptr stores that very object and assigns its node_id.
+    EXPECT_EQ(datum2, datum);
+    EXPECT_EQ(datum->node_id, 0u);
 }
 
 TEST(TreeAddEntry, Parent)
 {
     InteractionTree tree;
-    InteractionRecord record;
-    record.signature.primary_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.target_type = siren::dataclasses::ParticleType::EPlus;
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EPlus);
-    record.signature.secondary_types.push_back(siren::dataclasses::ParticleType::EMinus);
+    InteractionRecord record = MakeRecord();
 
     auto datum = tree.add_entry(record);
     auto datum2 = tree.add_entry(record, datum);
@@ -158,7 +169,320 @@ TEST(TreeAddEntry, Parent)
     EXPECT_EQ(datum2->record.signature.target_type, siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum2->record.signature.secondary_types[0], siren::dataclasses::ParticleType::EPlus);
     EXPECT_EQ(datum2->record.signature.secondary_types[1], siren::dataclasses::ParticleType::EMinus);
-    EXPECT_EQ(datum2->parent, datum);
+
+    // New integer-edge API: the child points back at the parent by node_id, and
+    // the parent lists the child among its daughter_indices.
+    EXPECT_EQ(datum2->parent_index, datum->node_id);
+    EXPECT_EQ(datum2->node_id, 1u);
+    EXPECT_FALSE(datum2->is_root());
+    EXPECT_TRUE(datum->is_root());
+    EXPECT_EQ(datum->daughter_indices.size(), 1u);
+    EXPECT_EQ(datum->daughter_indices[0], datum2->node_id);
+}
+
+TEST(TreeInvariant, NodeIdEqualsPosition)
+{
+    // Build a small multi-node tree and assert every datum's node_id matches its
+    // position in the flat tree vector.
+    InteractionTree tree;
+    InteractionRecord record = MakeRecord();
+
+    auto root = tree.add_entry(record);
+    auto childA = tree.add_entry(record, root);
+    auto childB = tree.add_entry(record, root);
+    auto grandchild = tree.add_entry(record, childA);
+    (void)childB;
+    (void)grandchild;
+
+    EXPECT_EQ(tree.tree.size(), 4u);
+    for(std::uint32_t k=0; k<tree.tree.size(); ++k) {
+        EXPECT_EQ(tree.tree[k]->node_id, k);
+    }
+}
+
+TEST(TreeStructure, ParentIndexAndDaughters)
+{
+    // Root + two children + one grandchild under the first child.
+    InteractionTree tree;
+    InteractionRecord record = MakeRecord();
+
+    auto root = tree.add_entry(record);
+    auto childA = tree.add_entry(record, root);
+    auto childB = tree.add_entry(record, root);
+    auto grandchild = tree.add_entry(record, childA);
+
+    // Positions / node_ids.
+    EXPECT_EQ(root->node_id, 0u);
+    EXPECT_EQ(childA->node_id, 1u);
+    EXPECT_EQ(childB->node_id, 2u);
+    EXPECT_EQ(grandchild->node_id, 3u);
+
+    // Root: no parent, is_root, both children recorded as daughters.
+    EXPECT_EQ(root->parent_index, kNoParent);
+    EXPECT_TRUE(root->is_root());
+    ASSERT_EQ(root->daughter_indices.size(), 2u);
+    EXPECT_EQ(root->daughter_indices[0], childA->node_id);
+    EXPECT_EQ(root->daughter_indices[1], childB->node_id);
+
+    // Children point back at the root.
+    EXPECT_EQ(childA->parent_index, root->node_id);
+    EXPECT_FALSE(childA->is_root());
+    EXPECT_EQ(childB->parent_index, root->node_id);
+    EXPECT_FALSE(childB->is_root());
+
+    // childA owns the grandchild; childB has none.
+    ASSERT_EQ(childA->daughter_indices.size(), 1u);
+    EXPECT_EQ(childA->daughter_indices[0], grandchild->node_id);
+    EXPECT_TRUE(childB->daughter_indices.empty());
+
+    // Grandchild points back at childA.
+    EXPECT_EQ(grandchild->parent_index, childA->node_id);
+    EXPECT_FALSE(grandchild->is_root());
+    EXPECT_TRUE(grandchild->daughter_indices.empty());
+}
+
+TEST(TreeDepth, DatumAndTreeAgree)
+{
+    // Root(0) -> childA(1) -> grandchild(3); childB(2) is a sibling of childA.
+    InteractionTree tree;
+    InteractionRecord record = MakeRecord();
+
+    auto root = tree.add_entry(record);
+    auto childA = tree.add_entry(record, root);
+    auto childB = tree.add_entry(record, root);
+    auto grandchild = tree.add_entry(record, childA);
+
+    // Depth via the datum (resolving against its owner).
+    EXPECT_EQ(root->depth(tree), 0);
+    EXPECT_EQ(childA->depth(tree), 1);
+    EXPECT_EQ(childB->depth(tree), 1);
+    EXPECT_EQ(grandchild->depth(tree), 2);
+
+    // Depth via the tree convenience wrapper keyed by node_id.
+    EXPECT_EQ(tree.depth(root->node_id), 0);
+    EXPECT_EQ(tree.depth(childA->node_id), 1);
+    EXPECT_EQ(tree.depth(childB->node_id), 1);
+    EXPECT_EQ(tree.depth(grandchild->node_id), 2);
+
+    // at() returns the same handles that add_entry produced.
+    EXPECT_EQ(tree.at(grandchild->node_id), grandchild);
+}
+
+// Build a fixed 2-level tree (root + two children) for equality tests.
+static InteractionTree BuildSampleTree() {
+    InteractionTree tree;
+    InteractionRecord record = MakeRecord();
+    auto root = tree.add_entry(record);
+    tree.add_entry(record, root);
+    tree.add_entry(record, root);
+    tree.header.event_number = 42;
+    tree.header.weights.push_back(1.5);
+    tree.header.provenance["generator"] = "siren-test";
+    return tree;
+}
+
+TEST(DatumEquality, IdenticalAndMutations)
+{
+    InteractionTree a = BuildSampleTree();
+    InteractionTree b = BuildSampleTree();
+
+    // Independently built identical data compare equal.
+    ASSERT_EQ(a.tree.size(), b.tree.size());
+    EXPECT_TRUE(*a.tree[1] == *b.tree[1]);
+
+    // Mutating node_id breaks equality.
+    {
+        InteractionTreeDatum mutated = *b.tree[1];
+        mutated.node_id = 99u;
+        EXPECT_FALSE(*a.tree[1] == mutated);
+    }
+    // Mutating parent_index breaks equality.
+    {
+        InteractionTreeDatum mutated = *b.tree[1];
+        mutated.parent_index = kNoParent;
+        EXPECT_FALSE(*a.tree[1] == mutated);
+    }
+    // Mutating daughter_indices breaks equality.
+    {
+        InteractionTreeDatum mutated = *b.tree[0];
+        mutated.daughter_indices.push_back(123u);
+        EXPECT_FALSE(*a.tree[0] == mutated);
+    }
+    // Mutating the record breaks equality.
+    {
+        InteractionTreeDatum mutated = *b.tree[1];
+        mutated.record.signature.primary_type = siren::dataclasses::ParticleType::EMinus;
+        EXPECT_FALSE(*a.tree[1] == mutated);
+    }
+}
+
+TEST(HeaderEquality, IdenticalAndMutations)
+{
+    InteractionTreeHeader h1;
+    h1.event_number = 7;
+    h1.weights = {1.0, 2.0};
+    h1.provenance["gen"] = "v1";
+
+    InteractionTreeHeader h2 = h1;
+    EXPECT_TRUE(h1 == h2);
+
+    h2.event_number = 8;
+    EXPECT_FALSE(h1 == h2);
+
+    h2 = h1;
+    h2.weights.push_back(3.0);
+    EXPECT_FALSE(h1 == h2);
+
+    h2 = h1;
+    h2.provenance["gen"] = "v2";
+    EXPECT_FALSE(h1 == h2);
+}
+
+TEST(TreeEquality, IdenticalAndMutations)
+{
+    InteractionTree a = BuildSampleTree();
+    InteractionTree b = BuildSampleTree();
+
+    // Two independently-built identical trees compare equal.
+    EXPECT_TRUE(a == b);
+
+    // Mutating one node's node_id makes them unequal.
+    {
+        InteractionTree c = BuildSampleTree();
+        c.tree[1]->node_id = 99u;
+        EXPECT_FALSE(a == c);
+    }
+    // Mutating a node's parent_index makes them unequal.
+    {
+        InteractionTree c = BuildSampleTree();
+        c.tree[1]->parent_index = kNoParent;
+        EXPECT_FALSE(a == c);
+    }
+    // Mutating a node's daughter_indices makes them unequal.
+    {
+        InteractionTree c = BuildSampleTree();
+        c.tree[0]->daughter_indices.push_back(123u);
+        EXPECT_FALSE(a == c);
+    }
+    // Mutating a node's record makes them unequal.
+    {
+        InteractionTree c = BuildSampleTree();
+        c.tree[1]->record.signature.primary_type = siren::dataclasses::ParticleType::EMinus;
+        EXPECT_FALSE(a == c);
+    }
+    // Mutating the header makes them unequal.
+    {
+        InteractionTree c = BuildSampleTree();
+        c.header.event_number = 43;
+        EXPECT_FALSE(a == c);
+    }
+}
+
+TEST(TreeSerialization, JSONRoundTripV1)
+{
+    // Populate a header (event_number, one weight, one provenance entry) and a
+    // 2-level tree, then round-trip through a cereal JSON archive.
+    InteractionTree original;
+    InteractionRecord record = MakeRecord();
+    auto root = original.add_entry(record);
+    original.add_entry(record, root);
+    original.add_entry(record, root);
+    original.header.event_number = 12345;
+    original.header.weights.push_back(0.75);
+    original.header.provenance["generator"] = "siren-serialization-test";
+
+    std::stringstream ss;
+    {
+        cereal::JSONOutputArchive oarchive(ss);
+        oarchive(original);
+    }
+
+    InteractionTree loaded;
+    {
+        cereal::JSONInputArchive iarchive(ss);
+        iarchive(loaded);
+    }
+
+    // Records, integer edges, and header all survive the round-trip.
+    EXPECT_TRUE(loaded == original);
+    EXPECT_EQ(loaded.tree.size(), original.tree.size());
+    EXPECT_EQ(loaded.header.event_number, original.header.event_number);
+    ASSERT_EQ(loaded.header.weights.size(), 1u);
+    EXPECT_EQ(loaded.header.weights[0], 0.75);
+    EXPECT_EQ(loaded.header.provenance.at("generator"), "siren-serialization-test");
+
+    // The reconstructed node_id == position invariant still holds after load.
+    for(std::uint32_t k=0; k<loaded.tree.size(); ++k) {
+        EXPECT_EQ(loaded.tree[k]->node_id, k);
+    }
+}
+
+TEST(LegacyLoad, V0FileRebuildsIndices)
+{
+    // Build a version-0 tree with shared_ptr edges:
+    //   root -> {child0, child1};  child0 -> {grandchild}
+    using legacy_v0::LegacyDatum;
+    using legacy_v0::LegacyTree;
+    auto root = std::make_shared<LegacyDatum>(); root->record = MakeRecord();
+    auto child0 = std::make_shared<LegacyDatum>(); child0->record = MakeRecord();
+    auto child1 = std::make_shared<LegacyDatum>(); child1->record = MakeRecord();
+    auto grandchild = std::make_shared<LegacyDatum>(); grandchild->record = MakeRecord();
+    child0->parent = root; child1->parent = root; grandchild->parent = child0;
+    root->daughters = {child0, child1};
+    child0->daughters = {grandchild};
+
+    auto ltree = std::make_shared<LegacyTree>();
+    ltree->tree = {root, child0, child1, grandchild}; // parent-before-daughter order
+    std::vector<std::shared_ptr<LegacyTree>> ltrees = {ltree};
+
+    // Write it exactly like SaveInteractionTrees does (binary, ".siren_events").
+    std::string base = std::string(::testing::TempDir()) + "siren_v0_fixture";
+    {
+        std::ofstream os(base + ".siren_events", std::ios::binary);
+        ::cereal::BinaryOutputArchive archive(os);
+        archive(ltrees);
+    }
+
+    // Load with the real version-1 loader; it must take the version-0 branch.
+    std::vector<std::shared_ptr<InteractionTree>> loaded = LoadInteractionTrees(base);
+    std::remove((base + ".siren_events").c_str());
+
+    ASSERT_EQ(loaded.size(), 1u);
+    InteractionTree & t = *loaded[0];
+    ASSERT_EQ(t.tree.size(), 4u);
+
+    // node_id == position invariant reconstructed
+    for(std::uint32_t k=0; k<t.tree.size(); ++k) EXPECT_EQ(t.tree[k]->node_id, k);
+
+    // parent_index topology reconstructed from the legacy pointer edges
+    EXPECT_TRUE(t.tree[0]->is_root());
+    EXPECT_EQ(t.tree[0]->parent_index, kNoParent);
+    EXPECT_EQ(t.tree[1]->parent_index, 0u);
+    EXPECT_EQ(t.tree[2]->parent_index, 0u);
+    EXPECT_EQ(t.tree[3]->parent_index, 1u);
+
+    // daughter_indices reconstructed
+    ASSERT_EQ(t.tree[0]->daughter_indices.size(), 2u);
+    EXPECT_EQ(t.tree[0]->daughter_indices[0], 1u);
+    EXPECT_EQ(t.tree[0]->daughter_indices[1], 2u);
+    ASSERT_EQ(t.tree[1]->daughter_indices.size(), 1u);
+    EXPECT_EQ(t.tree[1]->daughter_indices[0], 3u);
+    EXPECT_TRUE(t.tree[2]->daughter_indices.empty());
+    EXPECT_TRUE(t.tree[3]->daughter_indices.empty());
+
+    // depth resolves through the rebuilt indices
+    EXPECT_EQ(t.tree[3]->depth(t), 2);
+    EXPECT_EQ(t.depth(3), 2);
+
+    // legacy shared_ptr edges cleared: no reference cycle survives the load
+    for(auto const & d : t.tree) {
+        EXPECT_EQ(d->legacy_parent, nullptr);
+        EXPECT_TRUE(d->legacy_daughters.empty());
+    }
+
+    // default header for an upgraded file
+    EXPECT_EQ(t.header.event_number, 0u);
+    EXPECT_TRUE(t.header.weights.empty());
 }
 
 int main(int argc, char** argv)
@@ -166,4 +490,3 @@ int main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionRecord.h
@@ -454,6 +454,8 @@ public:
     SecondaryDistributionRecord(InteractionRecord & record);
     SecondaryDistributionRecord(InteractionRecord const & parent_record, size_t secondary_index);
 
+    size_t GetSecondaryIndex() const;
+
     void SetLength(double const & length);
     double const & GetLength() const;
 

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionTree.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionTree.h
@@ -48,8 +48,7 @@ namespace siren {
 namespace dataclasses {
 
 // Sentinel value for InteractionTreeDatum::parent_index / node_id meaning "no
-// parent" (i.e. a root/primary interaction). Chosen as the max uint32_t so that
-// a valid index is never confused with "unset".
+// parent" (i.e. a root/primary interaction).
 static constexpr std::uint32_t kNoParent = std::numeric_limits<std::uint32_t>::max();
 
 struct InteractionTreeDatum {
@@ -58,29 +57,19 @@ struct InteractionTreeDatum {
 
   dataclasses::InteractionRecord record;
 
-  // Stable identity == position of this datum in the owning InteractionTree::tree
-  // vector. Assigned by InteractionTree::add_entry and never changed afterwards.
   std::uint32_t node_id = kNoParent;
-  // Index of the parent interaction within the owning tree, or kNoParent for a
-  // root. An integer back-reference cannot form an ownership cycle, and depth()
-  // can walk it without copying ancestors.
   std::uint32_t parent_index = kNoParent;
-  // Indices of the daughter interactions within the owning tree.
   std::vector<std::uint32_t> daughter_indices;
 
   bool is_root() const { return parent_index == kNoParent; }
 
-  // Depth of this datum below the root, resolving parent_index against its owning
-  // tree. O(depth) integer pointer-chase, zero record copies. There is
-  // deliberately NO zero-argument depth(): a datum holds no back-pointer to its
-  // tree (that would recreate the ownership cycle), so depth requires the owner.
+  // Depth of this datum, walks up the owner tree to the root
   int depth(InteractionTree const & owner) const;
 
   bool operator==(InteractionTreeDatum const & other) const;
 
-  // Legacy shared_ptr edges. Populated ONLY while loading a version-0 archive so
-  // that InteractionTree::load can rebuild the integer indices; cleared
-  // immediately afterwards and never written by the version-1 save path.
+  // Legacy shared_ptr edges. Populated ONLY while loading a version-0 archive,
+  // then cleared after rebuild_indices_from_legacy()
   std::shared_ptr<dataclasses::InteractionTreeDatum> legacy_parent = nullptr;
   std::vector<std::shared_ptr<dataclasses::InteractionTreeDatum>> legacy_daughters;
 
@@ -104,8 +93,6 @@ struct InteractionTreeDatum {
           archive(::cereal::make_nvp("DaughterIndices", daughter_indices));
       } else if(version == 0) {
           // Legacy layout: Record, Parent (shared_ptr), Daughters (vector<shared_ptr>).
-          // cereal pointer-tracking resolves the aliased nodes; indices are
-          // reconstructed by InteractionTree::load once every node exists.
           archive(::cereal::make_nvp("Record", record));
           archive(::cereal::make_nvp("Parent", legacy_parent));
           archive(::cereal::make_nvp("Daughters", legacy_daughters));

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionTree.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionTree.h
@@ -4,10 +4,14 @@
 
 #include "SIREN/dataclasses/InteractionRecord.h"
 
+#include <map>                                             // for map
 #include <set>                                             // for set
+#include <string>                                          // for string
+#include <limits>                                          // for numeric_limits
 #include <memory>                                          // for shared_ptr
 #include <vector>                                          // for vector
 #include <cstdint>                                         // for uint32_t
+#include <iosfwd>                                          // for ostream
 #include <stddef.h>                                        // for NULL
 #include <stdexcept>                                       // for runtime_error
 #include <fstream>                                         // for if/ofstream
@@ -15,50 +19,168 @@
 #include <cereal/cereal.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/archives/binary.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
 #include <cereal/types/array.hpp>
+#include <cereal/types/memory.hpp>
 #include <cereal/types/polymorphic.hpp>
 #include <cereal/types/base_class.hpp>
 #include <cereal/types/utility.hpp>
 
+namespace siren { namespace dataclasses { struct InteractionTreeDatum; } }
+namespace siren { namespace dataclasses { struct InteractionTreeHeader; } }
+namespace siren { namespace dataclasses { struct InteractionTree; } }
+
+std::ostream & operator<<(std::ostream & os, siren::dataclasses::InteractionTreeDatum const & datum);
+std::ostream & operator<<(std::ostream & os, siren::dataclasses::InteractionTreeHeader const & header);
+std::ostream & operator<<(std::ostream & os, siren::dataclasses::InteractionTree const & tree);
+
+std::string to_str(siren::dataclasses::InteractionTreeDatum const & datum);
+std::string to_str(siren::dataclasses::InteractionTreeHeader const & header);
+std::string to_str(siren::dataclasses::InteractionTree const & tree);
+
+std::string to_repr(siren::dataclasses::InteractionTreeDatum const & datum);
+std::string to_repr(siren::dataclasses::InteractionTreeHeader const & header);
+std::string to_repr(siren::dataclasses::InteractionTree const & tree);
+
 namespace siren {
 namespace dataclasses {
+
+// Sentinel value for InteractionTreeDatum::parent_index / node_id meaning "no
+// parent" (i.e. a root/primary interaction). Chosen as the max uint32_t so that
+// a valid index is never confused with "unset".
+static constexpr std::uint32_t kNoParent = std::numeric_limits<std::uint32_t>::max();
 
 struct InteractionTreeDatum {
   InteractionTreeDatum() {}
   InteractionTreeDatum(dataclasses::InteractionRecord& record) : record(record) {}
+
   dataclasses::InteractionRecord record;
-  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = NULL;
-  std::vector<std::shared_ptr<dataclasses::InteractionTreeDatum>> daughters;
-  int depth() const;
+
+  // Stable identity == position of this datum in the owning InteractionTree::tree
+  // vector. Assigned by InteractionTree::add_entry and never changed afterwards.
+  std::uint32_t node_id = kNoParent;
+  // Index of the parent interaction within the owning tree, or kNoParent for a
+  // root. An integer back-reference cannot form an ownership cycle, and depth()
+  // can walk it without copying ancestors.
+  std::uint32_t parent_index = kNoParent;
+  // Indices of the daughter interactions within the owning tree.
+  std::vector<std::uint32_t> daughter_indices;
+
+  bool is_root() const { return parent_index == kNoParent; }
+
+  // Depth of this datum below the root, resolving parent_index against its owning
+  // tree. O(depth) integer pointer-chase, zero record copies. There is
+  // deliberately NO zero-argument depth(): a datum holds no back-pointer to its
+  // tree (that would recreate the ownership cycle), so depth requires the owner.
+  int depth(InteractionTree const & owner) const;
+
+  bool operator==(InteractionTreeDatum const & other) const;
+
+  // Legacy shared_ptr edges. Populated ONLY while loading a version-0 archive so
+  // that InteractionTree::load can rebuild the integer indices; cleared
+  // immediately afterwards and never written by the version-1 save path.
+  std::shared_ptr<dataclasses::InteractionTreeDatum> legacy_parent = nullptr;
+  std::vector<std::shared_ptr<dataclasses::InteractionTreeDatum>> legacy_daughters;
+
+  template<class Archive>
+  void save(Archive & archive, std::uint32_t const version) const {
+      if(version == 1) {
+          archive(::cereal::make_nvp("Record", record));
+          archive(::cereal::make_nvp("NodeId", node_id));
+          archive(::cereal::make_nvp("ParentIndex", parent_index));
+          archive(::cereal::make_nvp("DaughterIndices", daughter_indices));
+      } else {
+          throw std::runtime_error("InteractionTreeDatum save only supports version 1!");
+      }
+  }
+  template<class Archive>
+  void load(Archive & archive, std::uint32_t const version) {
+      if(version == 1) {
+          archive(::cereal::make_nvp("Record", record));
+          archive(::cereal::make_nvp("NodeId", node_id));
+          archive(::cereal::make_nvp("ParentIndex", parent_index));
+          archive(::cereal::make_nvp("DaughterIndices", daughter_indices));
+      } else if(version == 0) {
+          // Legacy layout: Record, Parent (shared_ptr), Daughters (vector<shared_ptr>).
+          // cereal pointer-tracking resolves the aliased nodes; indices are
+          // reconstructed by InteractionTree::load once every node exists.
+          archive(::cereal::make_nvp("Record", record));
+          archive(::cereal::make_nvp("Parent", legacy_parent));
+          archive(::cereal::make_nvp("Daughters", legacy_daughters));
+      } else {
+          throw std::runtime_error("InteractionTreeDatum only supports version <= 1!");
+      }
+  }
+};
+
+// Event-level metadata for a tree. Maps onto HepMC3 GenEvent (event_number,
+// weights) and GenRunInfo (provenance) at export time.
+struct InteractionTreeHeader {
+  std::uint64_t event_number = 0;
+  std::vector<double> weights;                    // per-injector; names carried in provenance
+  std::map<std::string, std::string> provenance;  // generator name/version, run tag, etc.
+
+  bool operator==(InteractionTreeHeader const & other) const;
+
   template<class Archive>
   void serialize(Archive & archive, std::uint32_t const version) {
       if(version == 0) {
-          archive(::cereal::make_nvp("Record", record));
-          archive(::cereal::make_nvp("Parent", parent));
-          archive(::cereal::make_nvp("Daughters", daughters));
+          archive(::cereal::make_nvp("EventNumber", event_number));
+          archive(::cereal::make_nvp("Weights", weights));
+          archive(::cereal::make_nvp("Provenance", provenance));
       } else {
-          throw std::runtime_error("InteractionTreeDatum only supports version <= 0!");
+          throw std::runtime_error("InteractionTreeHeader only supports version 0!");
       }
-  };
+  }
 };
 
 struct InteractionTree {
+  // Flat vector of all nodes, parents strictly before their daughters. The
+  // enforced invariant is that every datum's node_id equals its position here.
   std::vector<std::shared_ptr<dataclasses::InteractionTreeDatum>> tree;
+  InteractionTreeHeader header;
+
   std::shared_ptr<InteractionTreeDatum> add_entry(std::shared_ptr<dataclasses::InteractionTreeDatum> datum,
-                                                  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = NULL);
+                                                  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = nullptr);
   std::shared_ptr<InteractionTreeDatum> add_entry(dataclasses::InteractionTreeDatum& datum,
-                                                  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = NULL);
+                                                  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = nullptr);
   std::shared_ptr<InteractionTreeDatum> add_entry(dataclasses::InteractionRecord& record,
-                                                  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = NULL);
+                                                  std::shared_ptr<dataclasses::InteractionTreeDatum> parent = nullptr);
+
+  std::shared_ptr<InteractionTreeDatum> const & at(std::uint32_t node_id) const { return tree.at(node_id); }
+  int depth(std::uint32_t node_id) const { return tree.at(node_id)->depth(*this); }
+
+  bool operator==(InteractionTree const & other) const;
+
   template<class Archive>
-  void serialize(Archive & archive, std::uint32_t const version) {
-      if(version == 0) {
+  void save(Archive & archive, std::uint32_t const version) const {
+      if(version == 1) {
           archive(::cereal::make_nvp("Tree", tree));
+          archive(::cereal::make_nvp("Header", header));
       } else {
-          throw std::runtime_error("InteractionTree only supports version <= 0!");
+          throw std::runtime_error("InteractionTree save only supports version 1!");
       }
-  };
+  }
+  template<class Archive>
+  void load(Archive & archive, std::uint32_t const version) {
+      if(version == 1) {
+          archive(::cereal::make_nvp("Tree", tree));
+          archive(::cereal::make_nvp("Header", header));
+      } else if(version == 0) {
+          archive(::cereal::make_nvp("Tree", tree));
+          rebuild_indices_from_legacy();
+      } else {
+          throw std::runtime_error("InteractionTree only supports version <= 1!");
+      }
+  }
+
+private:
+  // Reconstruct node_id/parent_index/daughter_indices from the legacy shared_ptr
+  // edges after a version-0 load, then clear the legacy pointers so no reference
+  // cycle survives into the running process.
+  void rebuild_indices_from_legacy();
 };
 
 void SaveInteractionTrees(std::vector<std::shared_ptr<InteractionTree>>& trees, std::string const & filename);
@@ -67,8 +189,8 @@ std::vector<std::shared_ptr<InteractionTree>> LoadInteractionTrees(std::string c
 } // namespace dataclasses
 } // namespace siren
 
-CEREAL_CLASS_VERSION(siren::dataclasses::InteractionTreeDatum, 0);
-CEREAL_CLASS_VERSION(siren::dataclasses::InteractionTree, 0);
+CEREAL_CLASS_VERSION(siren::dataclasses::InteractionTreeDatum, 1);
+CEREAL_CLASS_VERSION(siren::dataclasses::InteractionTreeHeader, 0);
+CEREAL_CLASS_VERSION(siren::dataclasses::InteractionTree, 1);
 
 #endif // SIREN_InteractionTree_H
-

--- a/projects/dataclasses/public/SIREN/dataclasses/InteractionTree.h
+++ b/projects/dataclasses/public/SIREN/dataclasses/InteractionTree.h
@@ -168,6 +168,7 @@ struct InteractionTree {
       if(version == 1) {
           archive(::cereal::make_nvp("Tree", tree));
           archive(::cereal::make_nvp("Header", header));
+          validate_indices();
       } else if(version == 0) {
           archive(::cereal::make_nvp("Tree", tree));
           rebuild_indices_from_legacy();
@@ -181,6 +182,11 @@ private:
   // edges after a version-0 load, then clear the legacy pointers so no reference
   // cycle survives into the running process.
   void rebuild_indices_from_legacy();
+
+  // Throw if any datum's node_id, parent_index, or daughter_indices is out of
+  // range for tree, so a corrupt archive fails loudly at load rather than
+  // silently corrupting downstream flattening or looping depth().
+  void validate_indices() const;
 };
 
 void SaveInteractionTrees(std::vector<std::shared_ptr<InteractionTree>>& trees, std::string const & filename);

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -310,7 +310,7 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
             if(it == secondary_process_map.end()) {
                 continue;
             }
-            if(stopping_condition(parent, i)) {
+            if(stopping_condition(tree, parent, i)) {
                 continue;
             }
             secondaries.emplace_back(
@@ -330,12 +330,20 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
 
                 siren::dataclasses::InteractionRecord secondary_record = SampleSecondaryProcess(*secondary_dist);
                 std::shared_ptr<siren::dataclasses::InteractionTreeDatum> secondary_datum = tree.add_entry(secondary_record, parent);
+                // Daughter record is authoritative for its production time; keep the
+                // parent's secondary_times slot in sync (single write point, after the
+                // daughter override is finalized).
+                size_t sidx = secondary_dist->GetSecondaryIndex();
+                if(sidx < parent->record.secondary_times.size())
+                    parent->record.secondary_times[sidx] = secondary_record.primary_initial_time;
                 add_secondaries(secondary_datum);
             }
         }
     } catch(siren::utilities::InjectionFailure const & e) {
         return siren::dataclasses::InteractionTree();
     }
+    tree.header.event_number = injected_events;
+    tree.header.provenance["generator"] = "SIREN";
     injected_events += 1;
     return tree;
 }
@@ -360,7 +368,7 @@ double Injector::GenerationProbability(siren::dataclasses::InteractionTree const
     double probability = 1.0;
     std::vector<std::shared_ptr<siren::dataclasses::InteractionTreeDatum>>::const_iterator it = tree.tree.cbegin();
     while(it != tree.tree.cend()) {
-        if((*it)->depth()==0) probability *= GenerationProbability((*it));
+        if((*it)->is_root()) probability *= GenerationProbability((*it));
         else probability *= SecondaryGenerationProbability((*it));
         ++it;
     }

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -116,7 +116,7 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
         double generation_probability = injectors[idx]->EventsToInject();//GenerationProbability(tree);
         for(auto const & datum : tree.tree) {
             std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
-            if(datum->depth() == 0) {
+            if(datum->is_root()) {
                 bounds = injectors[idx]->PrimaryInjectionBounds(datum->record);
                 physical_probability *= primary_process_weighters[idx]->PhysicalProbability(bounds, datum->record);
                 generation_probability *= primary_process_weighters[idx]->GenerationProbability(*datum);
@@ -147,7 +147,7 @@ std::vector<double> Weighter::GetInteractionProbabilities(siren::dataclasses::In
     std::vector<double> int_probs;
     for(auto const & datum : tree.tree) {
         std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
-        if(datum->depth() == 0) {
+        if(datum->is_root()) {
             bounds = injectors[i_inj]->PrimaryInjectionBounds(datum->record);
             int_probs.push_back(primary_process_weighters[i_inj]->InteractionProbability(bounds, datum->record));
         }
@@ -172,7 +172,7 @@ std::vector<double> Weighter::GetSurvivalProbabilities(siren::dataclasses::Inter
     std::vector<double> survival_probs;
     for(auto const & datum : tree.tree) {
         std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
-        if(datum->depth() == 0) {
+        if(datum->is_root()) {
             std::get<0>(bounds) = datum->record.primary_initial_position;
             std::get<1>(bounds) = std::get<0>(injectors[i_inj]->PrimaryInjectionBounds(datum->record));
             survival_probs.push_back(primary_process_weighters[i_inj]->SurvivalProbability(bounds, datum->record));

--- a/projects/injection/private/test/CCM_HNL_TEST.cxx
+++ b/projects/injection/private/test/CCM_HNL_TEST.cxx
@@ -294,9 +294,9 @@ TEST(Injector, Generation)
     std::shared_ptr<Injector> lower_injector = std::make_shared<Injector>(events_to_inject, detector_model, primary_injection_process_lower_injector, secondary_injection_processes, random);
 
     // Set stopping condition
-    std::function<bool(std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> stopping_condition =
-      [&] (std::shared_ptr<siren::dataclasses::InteractionTreeDatum> datum, size_t i) {
-        if(datum->depth() >=1) return true;
+    std::function<bool(siren::dataclasses::InteractionTree const &, std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> stopping_condition =
+      [&] (siren::dataclasses::InteractionTree const & tree, std::shared_ptr<siren::dataclasses::InteractionTreeDatum> datum, size_t i) {
+        if(datum->depth(tree) >=1) return true;
         return false;
     };
     upper_injector->SetStoppingCondition(stopping_condition);

--- a/projects/injection/public/SIREN/injection/Injector.h
+++ b/projects/injection/public/SIREN/injection/Injector.h
@@ -60,7 +60,7 @@ protected:
     std::shared_ptr<siren::detector::DetectorModel> detector_model;
     // This function returns true if the given secondary index i of the datum should not be simulated
     // Defaults to no secondary interactions being saved
-    std::function<bool(std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> stopping_condition= [&](std::shared_ptr<siren::dataclasses::InteractionTreeDatum> datum, size_t i) {
+    std::function<bool(siren::dataclasses::InteractionTree const &, std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> stopping_condition= [&](siren::dataclasses::InteractionTree const & tree, std::shared_ptr<siren::dataclasses::InteractionTreeDatum> datum, size_t i) {
         return true;
     };
     Injector();
@@ -78,8 +78,8 @@ public:
     Injector(unsigned int events_to_inject, std::shared_ptr<siren::detector::DetectorModel> detector_model, std::shared_ptr<injection::PrimaryInjectionProcess> primary_process, std::shared_ptr<siren::utilities::SIREN_random> random);
     Injector(unsigned int events_to_inject, std::shared_ptr<siren::detector::DetectorModel> detector_model, std::shared_ptr<injection::PrimaryInjectionProcess> primary_process, std::vector<std::shared_ptr<injection::SecondaryInjectionProcess>> secondary_processes, std::shared_ptr<siren::utilities::SIREN_random> random);
 
-    void SetStoppingCondition(std::function<bool(std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> f_in) {stopping_condition = f_in;}
-    std::function<bool(std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> GetStoppingCondition() {return stopping_condition;}
+    void SetStoppingCondition(std::function<bool(siren::dataclasses::InteractionTree const &, std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> f_in) {stopping_condition = f_in;}
+    std::function<bool(siren::dataclasses::InteractionTree const &, std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> GetStoppingCondition() {return stopping_condition;}
     std::shared_ptr<distributions::VertexPositionDistribution> FindPrimaryVertexDistribution(std::shared_ptr<siren::injection::PrimaryInjectionProcess> process);
     std::shared_ptr<distributions::SecondaryVertexPositionDistribution> FindSecondaryVertexDistribution(std::shared_ptr<siren::injection::SecondaryInjectionProcess> process);
     void SetPrimaryProcess(std::shared_ptr<siren::injection::PrimaryInjectionProcess> primary);

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -39,7 +39,7 @@ class Injector:
         primary_injection_distributions: List[_distributions.PrimaryInjectionDistribution] = None,
         secondary_interactions: Optional[Dict[_dataclasses.ParticleType, List[Union[_interactions.CrossSection, _interactions.Decay]]]] = None,
         secondary_injection_distributions: Optional[Dict[_dataclasses.ParticleType, List[_distributions.SecondaryInjectionDistribution]]] = None,
-        stopping_condition: Optional[Callable[[_dataclasses.InteractionTreeDatum, int], bool]] = None,
+        stopping_condition: Optional[Callable[[_dataclasses.InteractionTree, _dataclasses.InteractionTreeDatum, int], bool]] = None,
     ):
         self.__seed = None
         self.__number_of_events = 0

--- a/python/SIREN_Controller.py
+++ b/python/SIREN_Controller.py
@@ -669,7 +669,7 @@ class SIREN_Controller:
                  # primary particle stuff
                 datasets["primary_type"][-1].append(int(datum.record.signature.primary_type))
                 datasets["primary_momentum"][-1].append(np.array(datum.record.primary_momentum, dtype=float))
-                datasets["num_daughters"][-1].append(len(datum.daughters))
+                datasets["num_daughters"][-1].append(len(datum.daughter_indices))
 
                 # parent interaction index (from the tree's parent/daughter edges)
                 datasets["parent_idx"][-1].append(parent_indices[id])

--- a/python/_util.py
+++ b/python/_util.py
@@ -943,24 +943,21 @@ def get_parent_indices(tree):
     ``tree``) of the interaction whose secondary particle became this datum's
     primary, or ``-1`` for a root/primary interaction that has no parent.
 
-    Parentage is read directly from the tree's parent/daughter edges via the
-    ``InteractionTreeDatum.parent`` pointer -- the authoritative link the
-    injector records when it builds the tree. Earlier versions instead matched a
-    datum's primary four-momentum against earlier interactions' secondary
-    momenta, which is O(n^2) per tree and silently mis-links parentage whenever
-    two secondaries share identical four-momenta.
+    Parentage is read directly from each datum's ``.parent_index`` -- the
+    authoritative integer edge the injector records when it builds the tree.
+    Because a datum's ``node_id`` equals its position in the tree, a datum's
+    ``.parent_index`` is exactly the index of its parent within ``tree``, so it
+    is returned as-is (with ``-1`` substituted for roots). Earlier versions
+    instead matched a datum's primary four-momentum against earlier
+    interactions' secondary momenta, which is O(n^2) per tree and silently
+    mis-links parentage whenever two secondaries share identical four-momenta.
     """
-    # Map each datum's object identity to its position in the flattened tree.
-    # pybind11 returns the same wrapper object for a given C++ shared_ptr, so a
-    # datum's ``.parent`` is identity-equal to its entry in ``tree``.
-    index_of = {id(datum): i for i, datum in enumerate(tree)}
     parent_indices = []
     for datum in tree:
-        parent = datum.parent
-        if parent is None:
+        if datum.is_root():
             parent_indices.append(-1)
         else:
-            parent_indices.append(index_of.get(id(parent), -1))
+            parent_indices.append(int(datum.parent_index))
     return parent_indices
 
 def SaveEvents(events,

--- a/python/_util.py
+++ b/python/_util.py
@@ -943,14 +943,7 @@ def get_parent_indices(tree):
     ``tree``) of the interaction whose secondary particle became this datum's
     primary, or ``-1`` for a root/primary interaction that has no parent.
 
-    Parentage is read directly from each datum's ``.parent_index`` -- the
-    authoritative integer edge the injector records when it builds the tree.
-    Because a datum's ``node_id`` equals its position in the tree, a datum's
-    ``.parent_index`` is exactly the index of its parent within ``tree``, so it
-    is returned as-is (with ``-1`` substituted for roots). Earlier versions
-    instead matched a datum's primary four-momentum against earlier
-    interactions' secondary momenta, which is O(n^2) per tree and silently
-    mis-links parentage whenever two secondaries share identical four-momenta.
+    Parentage is read directly from each datum's ``.parent_index``
     """
     parent_indices = []
     for datum in tree:

--- a/resources/examples/example1/DIS_IceCube_charm.py
+++ b/resources/examples/example1/DIS_IceCube_charm.py
@@ -192,7 +192,7 @@ injector.primary_interactions              = primary_interactions
 injector.primary_injection_distributions   = primary_injection_distributions
 injector.secondary_interactions            = secondary_interactions
 injector.secondary_injection_distributions = secondary_injection_distributions
-injector.stopping_condition                = lambda datum, i: False
+injector.stopping_condition                = lambda tree, datum, i: False
 
 events, gen_times = GenerateEvents(injector)
 print(f"Generated {len(events)} events")

--- a/resources/examples/example2/DipolePortal_CCM.py
+++ b/resources/examples/example2/DipolePortal_CCM.py
@@ -92,7 +92,7 @@ for secondary_type in secondary_processes.keys():
     ]
 
 # Define stopping condition for the injector
-def stop(datum, i):
+def stop(tree, datum, i):
     secondary_type = datum.record.signature.secondary_types[i]
     return secondary_type != siren.dataclasses.Particle.ParticleType.N4
 

--- a/resources/examples/example2/DipolePortal_MINERvA.py
+++ b/resources/examples/example2/DipolePortal_MINERvA.py
@@ -67,7 +67,7 @@ controller.SetProcesses(
 
 controller.Initialize()
 
-def stop(datum, i):
+def stop(tree, datum, i):
     secondary_type = datum.record.signature.secondary_types[i]
     return secondary_type != siren.dataclasses.Particle.ParticleType.N4
 

--- a/resources/examples/example2/DipolePortal_MiniBooNE.py
+++ b/resources/examples/example2/DipolePortal_MiniBooNE.py
@@ -67,7 +67,7 @@ controller.SetProcesses(
 
 controller.Initialize()
 
-def stop(datum, i):
+def stop(tree, datum, i):
     secondary_type = datum.record.signature.secondary_types[i]
     return secondary_type != siren.dataclasses.Particle.ParticleType.N4
 

--- a/resources/examples/example2/DipolePortal_ND280UPGRD.py
+++ b/resources/examples/example2/DipolePortal_ND280UPGRD.py
@@ -70,7 +70,7 @@ controller.SetProcesses(
 
 controller.Initialize()
 
-def stop(datum, i):
+def stop(tree, datum, i):
     secondary_type = datum.record.signature.secondary_types[i]
     return secondary_type != siren.dataclasses.Particle.ParticleType.N4
 

--- a/tests/python/test_interaction_tree_parentage.py
+++ b/tests/python/test_interaction_tree_parentage.py
@@ -9,8 +9,8 @@ silently mis-links parentage whenever two secondaries share identical
 four-momenta (a common, physical situation).
 
 The fix reads parentage directly from the tree's parent/daughter edges via
-``InteractionTreeDatum.parent`` -- the authoritative link the injector records
-when it builds the tree. Both flattening functions now delegate to the shared
+``InteractionTreeDatum.parent_index`` -- the authoritative integer edge the
+injector records when it builds the tree. Both flattening functions now delegate to the shared
 ``siren._util.get_parent_indices`` helper. These tests build a small tree by
 hand with two secondaries that share identical momenta and prove the new
 reconstruction links each daughter to the correct parent where the old momentum
@@ -57,7 +57,7 @@ def _build_degenerate_momentum_tree(dc):
 
     Almost every particle shares the same momentum ``M``, so matching a primary
     momentum against earlier secondary momenta cannot tell the branches apart.
-    The true parentage (from the ``.parent`` edges) is ``[-1, 0, 0, 1, 2]``.
+    The true parentage (from the ``.parent_index`` edges) is ``[-1, 0, 0, 1, 2]``.
 
     Note idx4's true parent is index 2 while its depth is 2, so ``parent index``
     and ``depth - 1`` deliberately disagree there -- a reconstruction that merely
@@ -113,7 +113,7 @@ def _momentum_parent_indices(entries):
     parent_idx = []
     for datum in entries:
         primary_momentum = np.array(datum.record.primary_momentum, dtype=float)
-        if datum.depth() == 0:
+        if datum.is_root():
             parent_idx.append(-1)
         else:
             for _id in range(len(secondary_momenta)):
@@ -130,12 +130,12 @@ def test_ground_truth_edges(dc):
     """Sanity: the hand-built tree has the parent/daughter edges we expect."""
     tree, _expected = _build_degenerate_momentum_tree(dc)
     entries = list(tree.tree)
-    assert [d.depth() for d in entries] == [0, 1, 1, 2, 2]
-    assert entries[0].parent is None
-    assert entries[1].parent is entries[0]
-    assert entries[2].parent is entries[0]
-    assert entries[3].parent is entries[1]
-    assert entries[4].parent is entries[2]
+    assert [tree.depth(i) for i in range(len(entries))] == [0, 1, 1, 2, 2]
+    assert entries[0].is_root()
+    assert entries[1].parent_index == 0
+    assert entries[2].parent_index == 0
+    assert entries[3].parent_index == 1
+    assert entries[4].parent_index == 2
     # the two root secondaries genuinely share identical four-momenta
     m0, m1 = entries[0].record.secondary_momenta
     assert list(m0) == list(m1)
@@ -152,12 +152,12 @@ def test_get_parent_indices_uses_tree_edges(dc):
     # each entry points at the *actual* parent object, not merely a same-depth
     # node (idx4's parent is index 2, not depth-1 == 1)
     for i, datum in enumerate(tree.tree):
-        if datum.parent is None:
+        if datum.is_root():
             assert result[i] == -1
         else:
-            assert tree.tree[result[i]] is datum.parent
+            assert result[i] == datum.parent_index
     # guard specifically against a depth-based stand-in
-    depth_minus_one = [d.depth() - 1 for d in tree.tree]
+    depth_minus_one = [tree.depth(i) - 1 for i in range(len(tree.tree))]
     assert result != depth_minus_one
 
 


### PR DESCRIPTION
# Harden InteractionTree with integer node references

## Summary

SIREN events are currently represented as a tree structure that connects "datum" nodes (these each contain an `InteractionRecord`. Each node points to its parent with an `std::shared_ptr` and its children with a vector of `std::shared_ptr`. This circular reference between nodes causes a memory leak when implemented with shared pointers.

This PR removes changes the parent and child references from `std::shared_ptr` to integer indexes. This is also useful in the future HepMC3 event export.

The changes are almost entirely internal C++ plumbing: existing Python scripts and existing `.siren_events` files keep working, with one exception: a custom stopping-condition callback's signature changes (details below).

## Core representation change

- `InteractionTreeDatum` (one node of the tree) drops its `parent` and `daughters` `shared_ptr` fields. In their place it stores three integers:
  - `node_id` (`uint32_t`): this node's position in the tree.
  - `parent_index` (`uint32_t`): the position of this node's parent, or a sentinel value `kNoParent` marking a root (a starting interaction with no parent).
  - `daughter_indices` (`std::vector<uint32_t>`)
- `depth(InteractionTree const &)` (how many levels below the root a node sits) is computed by following `parent_index` up to the root — a short integer walk whose cost scales with the node's depth, and which copies no records. There is deliberately **no** zero-argument `depth()` to prevent a reference cycle
- `is_root()`: helper replaces the "`depth() == 0`" test

## Event header

`InteractionTree` gains an `InteractionTreeHeader` holding event-level metadata: an `event_number`, a vector of weights, and a provenance map (key/value strings recording where the event came from, e.g. generator name and version, run tag). The injector fills this in. **Nothing reads it yet in this PR**, but it will be used later for the HepMC3 output. #160 will map this onto HepMC3's `GenEvent`/`GenRunInfo` structures.

## On-disk format: version 1 with a version-0 read path

- Bump the version since we are changing the format of `InteractionTree`.
- Split the serialization routine of `InteractionTree` into `save()` and `load()` so we can handle older files.
- `rebuild_indices_from_legacy()` helper walks the v0 graph and derives the new integer `node_id`/`parent_index`/`daughter_indices`

## API changes

- **Breaking change:** the stopping-condition callback now requires the `InteractionTree` as an argument
  - `bool(InteractionTree const &, std::shared_ptr<InteractionTreeDatum>, size_t)` instead of `bool(std::shared_ptr<InteractionTreeDatum>, size_t)`
  - Needed so the depth can be computed via `depth(tree, datum, index)`
- The injector now keeps a parent's stored per-secondary production time consistent with the initial time of the finalized daughter that time refers to, reading the secondary's slot through a new accessor on `SecondaryDistributionRecord`. This is the intended single place where the two copies of that timing value (from #156) are reconciled: the parent's `secondary_times` slot and the daughter's `primary_initial_time`.
- Bindings (the Python-facing exposure of the C++ types): `node_id`, `parent_index`, `daughter_indices`, `is_root`, `depth(tree)`, and the new header type are now exposed to Python; the old `.parent` and `.daughters` properties are removed; and `LoadInteractionTrees` drops its incorrect reference return policy.
- Python-side event flattening (`_util.get_parent_indices`, the routine that turns a tree into flat per-event arrays) is simplified to just read each node's `parent_index`.

## Test coverage

`InteractionTree_TEST.cxx` gains nine cases:

- the `node_id == position` invariant,
- correct parent/daughter index structure,
- agreement between a node's depth and the tree's view of that depth,
- equality checks on nodes, headers, and whole trees, including under mutation,
- a version-1 JSON round trip (write then read, expecting an identical result),
- and, importantly, a legacy-load test that writes a **genuine version-0 archive** — produced via a local copy of the old pointer-based layout — and reads it back through the real compatibility path.

## Known issues, NOT fixed in this PR

- **Copying a node keeps stale child references** (`InteractionTree.cxx`). The `add_entry` overload that takes a node by value copies it without clearing its `daughter_indices`. So if you take a node out of a loaded or foreign tree and re-add it to a different tree, its old child indices come along — and now point at the wrong nodes, or at positions that do not exist in the new tree (possibly out of range).
- **No index validation when loading a version-1 file** (`InteractionTree.h`, the version-1 `load`). The `node_id` and `parent_index` values are read from the file exactly as stored, with no sanity check, and the depth walk has no guard against a cycle. A corrupted version-1 file can therefore hang the process (an endless depth walk) or silently produce wrong flattened output. A cheap check at load time — confirming each `parent_index` is smaller than the number of nodes and each `node_id` equals its position — would close both gaps.

---

## Fixes applied (post-review)

Both review-focus items are resolved in `Validate InteractionTree node indices and clear copied daughters`:

- `add_entry` clears a datum's `daughter_indices` on insertion, so a datum copied out of another tree can no longer carry dangling daughter references into this one.
- A version-1 load checks that every `node_id` equals its position and that parent/daughter indices are in range, and `depth()` stops once its parent-index walk exceeds the tree size — a corrupt archive now throws at load rather than looping or corrupting flattening.

The C++ InteractionTree unit tests and the full suite pass.
