### PR TITLE
Add FailureLedger + EventWeightBreakdown diagnostics backend

### DIFF
--- a/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
@@ -89,7 +89,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> ColumnDepthPositionDist
     }
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoColumnDepthSolution, "No available interactions along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/ColumnDepthPositionDistribution.cxx
@@ -89,7 +89,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> ColumnDepthPositionDist
     }
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoColumnDepthSolution, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoColumnDepthSolution, "No column-depth solution along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
@@ -102,7 +102,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> FixedTargetPositionDist
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No interaction targets along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
@@ -102,7 +102,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> FixedTargetPositionDist
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/PointSourcePositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PointSourcePositionDistribution.cxx
@@ -76,7 +76,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> PointSourcePositionDist
     }
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No interaction targets along path!"));
     }
     double traversed_interaction_depth;
     if(total_interaction_depth < 1e-6) {

--- a/projects/distributions/private/primary/vertex/PointSourcePositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PointSourcePositionDistribution.cxx
@@ -76,7 +76,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> PointSourcePositionDist
     }
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
     }
     double traversed_interaction_depth;
     if(total_interaction_depth < 1e-6) {

--- a/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
@@ -94,7 +94,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryBoundedVertexDis
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoPathThroughVolume, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoPathThroughVolume, "No path through the injection volume!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PrimaryBoundedVertexDistribution.cxx
@@ -94,7 +94,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryBoundedVertexDis
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoPathThroughVolume, "No available interactions along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
@@ -76,7 +76,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryPhysicalVertexDi
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No interaction targets along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/PrimaryPhysicalVertexDistribution.cxx
@@ -76,7 +76,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> PrimaryPhysicalVertexDi
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/primary/vertex/RangePositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/RangePositionDistribution.cxx
@@ -89,7 +89,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> RangePositionDistributi
     }
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
     }
     double traversed_interaction_depth;
     if(total_interaction_depth < 1e-6) {

--- a/projects/distributions/private/primary/vertex/RangePositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/RangePositionDistribution.cxx
@@ -89,7 +89,7 @@ std::tuple<siren::math::Vector3D, siren::math::Vector3D> RangePositionDistributi
     }
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No interaction targets along path!"));
     }
     double traversed_interaction_depth;
     if(total_interaction_depth < 1e-6) {

--- a/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
@@ -95,7 +95,7 @@ void SecondaryBoundedVertexDistribution::SampleVertex(std::shared_ptr<siren::uti
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoPathThroughVolume, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoPathThroughVolume, "No path through the injection volume!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
@@ -95,7 +95,7 @@ void SecondaryBoundedVertexDistribution::SampleVertex(std::shared_ptr<siren::uti
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoPathThroughVolume, "No available interactions along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/secondary/vertex/SecondaryPhysicalVertexDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/SecondaryPhysicalVertexDistribution.cxx
@@ -75,7 +75,7 @@ void SecondaryPhysicalVertexDistribution::SampleVertex(std::shared_ptr<siren::ut
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure("No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/distributions/private/secondary/vertex/SecondaryPhysicalVertexDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/SecondaryPhysicalVertexDistribution.cxx
@@ -75,7 +75,7 @@ void SecondaryPhysicalVertexDistribution::SampleVertex(std::shared_ptr<siren::ut
 
     double total_interaction_depth = path.GetInteractionDepthInBounds(targets, total_cross_sections, total_decay_length);
     if(total_interaction_depth == 0) {
-        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No available interactions along path!"));
+        throw(siren::utilities::InjectionFailure(siren::utilities::FailureReason::NoTargetsOnPath, "No interaction targets along path!"));
     }
 
     double traversed_interaction_depth;

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -573,7 +573,9 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
         }
     } catch(siren::utilities::InjectionFailure const & e) {
         failed_events += 1;
-        failure_ledger_.Record(0, 0, siren::utilities::FailureReason::TopLevelCatch, e.what());
+        int root_pdg = tree.tree.empty() ? 0
+            : static_cast<int>(tree.tree.front()->record.signature.primary_type);
+        failure_ledger_.Record(0, root_pdg, siren::utilities::FailureReason::TopLevelCatch, e.what());
         last_failure_reason_ = e.what();
         last_failed_tree_ = std::move(tree);
         return siren::dataclasses::InteractionTree();

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -556,8 +556,10 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
                     failed_events += 1;
                     int secondary_depth = static_cast<int>(parent->depth(tree)) + 1;
                     int parent_pdg = static_cast<int>(parent->record.signature.primary_type);
+                    std::ostringstream oss;
+                    oss << e.what() << " (secondary pdg " << current_secondary_pdg << ")";
                     failure_ledger_.Record(secondary_depth, parent_pdg,
-                        e.reason(), e.what());
+                        e.reason(), oss.str());
                     last_failure_reason_ = e.what();
                     last_failed_tree_ = std::move(tree);
                     return siren::dataclasses::InteractionTree();

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -555,7 +555,8 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
                 } catch(siren::utilities::InjectionFailure const & e) {
                     failed_events += 1;
                     int secondary_depth = static_cast<int>(parent->depth(tree)) + 1;
-                    failure_ledger_.Record(secondary_depth, current_secondary_pdg,
+                    int parent_pdg = static_cast<int>(parent->record.signature.primary_type);
+                    failure_ledger_.Record(secondary_depth, parent_pdg,
                         e.reason(), e.what());
                     last_failure_reason_ = e.what();
                     last_failed_tree_ = std::move(tree);
@@ -567,6 +568,7 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
         failed_events += 1;
         failure_ledger_.Record(0, 0, siren::utilities::FailureReason::TopLevelCatch, e.what());
         last_failure_reason_ = e.what();
+        last_failed_tree_ = std::move(tree);
         return siren::dataclasses::InteractionTree();
     }
     tree.header.event_number = injected_events;

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -500,6 +500,11 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
         int primary_pdg = static_cast<int>(primary_process->GetPrimaryType());
         failure_ledger_.Record(0, primary_pdg, reason, e.what());
         last_failure_reason_ = e.what();
+        // A vertex-distribution throw fires before Finalize sets the signature,
+        // so stamp the primary type to keep the partial tree readable.
+        if(record.signature.primary_type == siren::dataclasses::ParticleType::unknown) {
+            record.signature.primary_type = primary_process->GetPrimaryType();
+        }
         siren::dataclasses::InteractionTree partial_tree;
         partial_tree.add_entry(record);
         last_failed_tree_ = std::move(partial_tree);
@@ -789,8 +794,13 @@ unsigned int Injector::FailedEvents() const {
 }
 
 std::map<int, unsigned int> Injector::GetFailureCounts() const {
+    // Count only failures that ended an event; UnregisteredSecondaryType is a
+    // non-fatal skip that leaves the event intact.
     std::map<int, unsigned int> counts;
     for(auto const & item : failure_ledger_.entries) {
+        if(item.first.reason == siren::utilities::FailureReason::UnregisteredSecondaryType) {
+            continue;
+        }
         counts[item.first.parent_pdg] += static_cast<unsigned int>(item.second.count);
     }
     return counts;

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -5,6 +5,7 @@
 #include <string>
 #include <algorithm>
 #include <fstream>
+#include <sstream>
 
 #include <rk/rk.hh>
 
@@ -492,8 +493,16 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
         }
     } catch(siren::utilities::InjectionFailure const & e) {
         failed_events += 1;
-        failure_counts_[-1] += 1;
+        siren::utilities::FailureReason reason = e.reason();
+        if(reason == siren::utilities::FailureReason::Unspecified) {
+            reason = siren::utilities::FailureReason::PrimaryVertexFailure;
+        }
+        int primary_pdg = static_cast<int>(primary_process->GetPrimaryType());
+        failure_ledger_.Record(0, primary_pdg, reason, e.what());
         last_failure_reason_ = e.what();
+        siren::dataclasses::InteractionTree partial_tree;
+        partial_tree.add_entry(record);
+        last_failed_tree_ = std::move(partial_tree);
         return siren::dataclasses::InteractionTree();
     }
     siren::dataclasses::InteractionTree tree;
@@ -506,6 +515,12 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
             siren::dataclasses::ParticleType const & type = parent->record.signature.secondary_types[i];
             std::map<siren::dataclasses::ParticleType, std::shared_ptr<siren::injection::SecondaryInjectionProcess>>::iterator it = secondary_process_map.find(type);
             if(it == secondary_process_map.end()) {
+                int parent_pdg = static_cast<int>(parent->record.signature.primary_type);
+                int depth = static_cast<int>(parent->depth(tree)) + 1;
+                std::ostringstream oss;
+                oss << "secondary type not registered: " << type;
+                failure_ledger_.Record(depth, parent_pdg,
+                    siren::utilities::FailureReason::UnregisteredSecondaryType, oss.str());
                 continue;
             }
             if(stopping_condition(tree, parent, i)) {
@@ -539,7 +554,9 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
                     add_secondaries(secondary_datum);
                 } catch(siren::utilities::InjectionFailure const & e) {
                     failed_events += 1;
-                    failure_counts_[current_secondary_pdg] += 1;
+                    int secondary_depth = static_cast<int>(parent->depth(tree)) + 1;
+                    failure_ledger_.Record(secondary_depth, current_secondary_pdg,
+                        e.reason(), e.what());
                     last_failure_reason_ = e.what();
                     last_failed_tree_ = std::move(tree);
                     return siren::dataclasses::InteractionTree();
@@ -548,6 +565,7 @@ siren::dataclasses::InteractionTree Injector::GenerateEvent() {
         }
     } catch(siren::utilities::InjectionFailure const & e) {
         failed_events += 1;
+        failure_ledger_.Record(0, 0, siren::utilities::FailureReason::TopLevelCatch, e.what());
         last_failure_reason_ = e.what();
         return siren::dataclasses::InteractionTree();
     }
@@ -767,7 +785,11 @@ unsigned int Injector::FailedEvents() const {
 }
 
 std::map<int, unsigned int> Injector::GetFailureCounts() const {
-    return failure_counts_;
+    std::map<int, unsigned int> counts;
+    for(auto const & item : failure_ledger_.entries) {
+        counts[item.first.parent_pdg] += static_cast<unsigned int>(item.second.count);
+    }
+    return counts;
 }
 
 std::string Injector::GetLastFailureReason() const {
@@ -778,12 +800,16 @@ siren::dataclasses::InteractionTree const & Injector::GetLastFailedTree() const 
     return last_failed_tree_;
 }
 
+FailureLedger const & Injector::GetFailureLedger() const {
+    return failure_ledger_;
+}
+
 void Injector::ResetInjectedEvents(unsigned int events_to_inject) {
     this->events_to_inject = events_to_inject;
     injected_events = 0;
     injection_attempts = 0;
     failed_events = 0;
-    failure_counts_.clear();
+    failure_ledger_.Clear();
     last_failure_reason_.clear();
     last_failed_tree_ = siren::dataclasses::InteractionTree();
 }
@@ -792,7 +818,7 @@ void Injector::ResetInjectedEvents() {
     injected_events = 0;
     injection_attempts = 0;
     failed_events = 0;
-    failure_counts_.clear();
+    failure_ledger_.Clear();
     last_failure_reason_.clear();
     last_failed_tree_ = siren::dataclasses::InteractionTree();
 }

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -125,7 +125,7 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
         bool with_diagnostics) const {
     VertexWeightFactors factors;
     factors.injector_index = static_cast<int>(idx);
-    factors.primary_pdg = static_cast<int>(datum->record.signature.primary_type);
+    factors.vertex_pdg = static_cast<int>(datum->record.signature.primary_type);
     std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
     if(datum->is_root()) {
         factors.depth = 0;

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -3,9 +3,10 @@
 #include <iterator>                                              // for ite...
 #include <array>                                                  // for array
 #include <cassert>                                                // for assert
-#include <cmath>                                                  // for exp
+#include <cmath>                                                  // for exp, isfinite
 #include <initializer_list>                                       // for ini...
 #include <iostream>                                               // for ope...
+#include <limits>                                                 // for quiet_NaN
 #include <set>                                                    // for set
 #include <stdexcept>
 #include <sstream>
@@ -115,6 +116,41 @@ void Weighter::Initialize() {
     }
 }
 
+// Computes one tree datum's physical and generation factors for injector idx,
+// via the same ProcessWeighter calls EventWeight consumes. depth is left at
+// its default for non-root data; the caller fills it in from the owning tree.
+VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
+        std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum) const {
+    VertexWeightFactors factors;
+    factors.primary_pdg = static_cast<int>(datum->record.signature.primary_type);
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
+    if(datum->is_root()) {
+        factors.depth = 0;
+        bounds = injectors[idx]->PrimaryInjectionBounds(datum->record);
+        factors.physical = primary_process_weighters[idx]->PhysicalProbability(bounds, datum->record);
+        factors.generation = primary_process_weighters[idx]->GenerationProbability(*datum);
+        factors.interaction_prob = primary_process_weighters[idx]->InteractionProbability(bounds, datum->record);
+        factors.position_prob = primary_process_weighters[idx]->NormalizedPositionProbability(bounds, datum->record);
+    } else {
+        try {
+            bounds = injectors[idx]->SecondaryInjectionBounds(datum->record);
+            auto const & w = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type);
+            factors.physical = w->PhysicalProbability(bounds, datum->record);
+            factors.generation = w->GenerationProbability(*datum);
+            factors.interaction_prob = w->InteractionProbability(bounds, datum->record);
+            factors.position_prob = w->NormalizedPositionProbability(bounds, datum->record);
+        } catch(const std::out_of_range& oor) {
+            std::ostringstream oss;
+            oss << "Weighter::ComputeVertexFactors: no secondary process weighter for secondary type "
+                << datum->record.signature.primary_type
+                << " in injector " << idx
+                << " (" << oor.what() << ") [siren-docs: errors#configuration]";
+            throw siren::utilities::ConfigurationError(oss.str());
+        }
+    }
+    return factors;
+}
+
 double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) const {
     // The weight is given by
     //
@@ -149,28 +185,9 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
             generation_probability = injectors[idx]->EventsToInject();
         }
         for(auto const & datum : tree.tree) {
-            std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
-            if(datum->is_root()) {
-                bounds = injectors[idx]->PrimaryInjectionBounds(datum->record);
-                physical_probability *= primary_process_weighters[idx]->PhysicalProbability(bounds, datum->record);
-                generation_probability *= primary_process_weighters[idx]->GenerationProbability(*datum);
-            }
-            else {
-                try {
-                    bounds = injectors[idx]->SecondaryInjectionBounds(datum->record);
-                    double phys_prob = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type)->PhysicalProbability(bounds, datum->record);
-                    double gen_prob = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type)->GenerationProbability(*datum);
-                    physical_probability *= phys_prob;
-                    generation_probability *= gen_prob;
-                } catch(const std::out_of_range& oor) {
-                    std::ostringstream oss;
-                    oss << "Weighter::EventWeight: no secondary process weighter for secondary type "
-                        << datum->record.signature.primary_type
-                        << " in injector " << idx
-                        << " (" << oor.what() << ") [siren-docs: errors#configuration]";
-                    throw siren::utilities::ConfigurationError(oss.str());
-                }
-            }
+            VertexWeightFactors factors = ComputeVertexFactors(idx, datum);
+            physical_probability *= factors.physical;
+            generation_probability *= factors.generation;
         }
         // Weight-calculation guard: a generation_probability that is <= 0 or
         // non-finite would produce an infinite or NaN weight via the reciprocal
@@ -194,6 +211,50 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
         inv_weight += generation_probability / physical_probability;
     }
     return 1./inv_weight;
+}
+
+// Per-vertex decomposition of EventWeight, using the same ComputeVertexFactors
+// call per datum so the two paths cannot diverge. A generation-probability
+// failure that would make EventWeight throw is instead flagged and yields a
+// NaN total; a zero physical probability is flagged and yields a 0.0 total,
+// matching EventWeight's non-throwing zero-weight case.
+EventWeightBreakdown Weighter::EventWeightWithBreakdown(
+        siren::dataclasses::InteractionTree const & tree) const {
+    EventWeightBreakdown breakdown;
+    double inv_weight = 0;
+    bool usable = true;
+    for(unsigned int idx = 0; idx < injectors.size(); ++idx) {
+        double physical_probability = 1.0;
+        double generation_probability = injectors[idx]->InjectedEvents();
+        if(injectors[idx]->InjectedEvents() == 0) {
+            generation_probability = injectors[idx]->EventsToInject();
+        }
+        for(auto const & datum : tree.tree) {
+            VertexWeightFactors factors = ComputeVertexFactors(idx, datum);
+            if(!datum->is_root()) {
+                factors.depth = static_cast<int>(datum->depth(tree));
+            }
+            if(factors.generation <= 0.0 || !std::isfinite(factors.generation)) {
+                factors.flags.push_back("generation density zero");
+            }
+            if(factors.physical == 0.0) {
+                factors.flags.push_back("outside physical support (weight 0)");
+            } else if(!std::isfinite(factors.physical)) {
+                factors.flags.push_back("physical density non-finite");
+            }
+            physical_probability *= factors.physical;
+            generation_probability *= factors.generation;
+            breakdown.vertices.push_back(std::move(factors));
+        }
+        if(generation_probability <= 0.0 || !std::isfinite(generation_probability)
+           || !std::isfinite(physical_probability)) {
+            usable = false;
+            continue;
+        }
+        inv_weight += generation_probability / physical_probability;
+    }
+    breakdown.total = usable ? (1.0 / inv_weight) : std::numeric_limits<double>::quiet_NaN();
+    return breakdown;
 }
 
 std::vector<std::shared_ptr<Injector>> const & Weighter::GetInjectors() const {

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -124,6 +124,7 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
         std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum,
         bool with_diagnostics) const {
     VertexWeightFactors factors;
+    factors.injector_index = static_cast<int>(idx);
     factors.primary_pdg = static_cast<int>(datum->record.signature.primary_type);
     std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
     if(datum->is_root()) {

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -119,8 +119,10 @@ void Weighter::Initialize() {
 // Computes one tree datum's physical and generation factors for injector idx,
 // via the same ProcessWeighter calls EventWeight consumes. depth is left at
 // its default for non-root data; the caller fills it in from the owning tree.
+// with_diagnostics adds the observation-only interaction_prob/position_prob.
 VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
-        std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum) const {
+        std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum,
+        bool with_diagnostics) const {
     VertexWeightFactors factors;
     factors.primary_pdg = static_cast<int>(datum->record.signature.primary_type);
     std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
@@ -129,16 +131,20 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
         bounds = injectors[idx]->PrimaryInjectionBounds(datum->record);
         factors.physical = primary_process_weighters[idx]->PhysicalProbability(bounds, datum->record);
         factors.generation = primary_process_weighters[idx]->GenerationProbability(*datum);
-        factors.interaction_prob = primary_process_weighters[idx]->InteractionProbability(bounds, datum->record);
-        factors.position_prob = primary_process_weighters[idx]->NormalizedPositionProbability(bounds, datum->record);
+        if(with_diagnostics) {
+            factors.interaction_prob = primary_process_weighters[idx]->InteractionProbability(bounds, datum->record);
+            factors.position_prob = primary_process_weighters[idx]->NormalizedPositionProbability(bounds, datum->record);
+        }
     } else {
         try {
             bounds = injectors[idx]->SecondaryInjectionBounds(datum->record);
             auto const & w = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type);
             factors.physical = w->PhysicalProbability(bounds, datum->record);
             factors.generation = w->GenerationProbability(*datum);
-            factors.interaction_prob = w->InteractionProbability(bounds, datum->record);
-            factors.position_prob = w->NormalizedPositionProbability(bounds, datum->record);
+            if(with_diagnostics) {
+                factors.interaction_prob = w->InteractionProbability(bounds, datum->record);
+                factors.position_prob = w->NormalizedPositionProbability(bounds, datum->record);
+            }
         } catch(const std::out_of_range& oor) {
             std::ostringstream oss;
             oss << "Weighter::ComputeVertexFactors: no secondary process weighter for secondary type "
@@ -230,7 +236,7 @@ EventWeightBreakdown Weighter::EventWeightWithBreakdown(
             generation_probability = injectors[idx]->EventsToInject();
         }
         for(auto const & datum : tree.tree) {
-            VertexWeightFactors factors = ComputeVertexFactors(idx, datum);
+            VertexWeightFactors factors = ComputeVertexFactors(idx, datum, true);
             if(!datum->is_root()) {
                 factors.depth = static_cast<int>(datum->depth(tree));
             }

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -28,6 +28,7 @@
 
 #include "../../../distributions/public/SIREN/distributions/primary/vertex/DepthFunction.h"
 #include "../../../utilities/public/SIREN/utilities/Random.h"
+#include "../../../utilities/public/SIREN/utilities/Errors.h"
 #include "../../../detector/public/SIREN/detector/DetectorModel.h"
 #include "../../../interactions/public/SIREN/interactions/InteractionCollection.h"
 
@@ -88,6 +89,16 @@ PYBIND11_MODULE(injection,m) {
     .value("Scatter2to2", PhaseSpaceTopology::Scatter2to2)
     .value("Scatter2to3", PhaseSpaceTopology::Scatter2to3)
     .value("Unspecified", PhaseSpaceTopology::Unspecified);
+
+  enum_<siren::utilities::FailureReason>(m, "FailureReason")
+    .value("Unspecified", siren::utilities::FailureReason::Unspecified)
+    .value("NoPathThroughVolume", siren::utilities::FailureReason::NoPathThroughVolume)
+    .value("NoTargetsOnPath", siren::utilities::FailureReason::NoTargetsOnPath)
+    .value("NoColumnDepthSolution", siren::utilities::FailureReason::NoColumnDepthSolution)
+    .value("KinematicallyForbidden", siren::utilities::FailureReason::KinematicallyForbidden)
+    .value("UnregisteredSecondaryType", siren::utilities::FailureReason::UnregisteredSecondaryType)
+    .value("PrimaryVertexFailure", siren::utilities::FailureReason::PrimaryVertexFailure)
+    .value("TopLevelCatch", siren::utilities::FailureReason::TopLevelCatch);
 
   enum_<PhaseSpaceMeasure::Type>(m, "PhaseSpaceMeasureType")
     .value("SolidAngleRest", PhaseSpaceMeasure::Type::SolidAngleRest)
@@ -425,6 +436,21 @@ PYBIND11_MODULE(injection,m) {
 
   // Injection
 
+  class_<FailureLedger, std::shared_ptr<FailureLedger>>(m, "FailureLedger")
+    .def(init<>())
+    .def("Clear", &FailureLedger::Clear)
+    .def("entries", [](FailureLedger const & ledger) {
+        pybind11::dict out;
+        for(auto const & item : ledger.entries) {
+            pybind11::tuple key = pybind11::make_tuple(
+                item.first.depth, item.first.parent_pdg, item.first.reason);
+            pybind11::tuple value = pybind11::make_tuple(
+                item.second.count, item.second.exemplar);
+            out[key] = value;
+        }
+        return out;
+    });
+
   class_<Injector, std::shared_ptr<Injector>>(m, "Injector")
     .def(init<unsigned int, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<siren::utilities::SIREN_random>>())
     .def(init<unsigned int, std::string, std::shared_ptr<siren::utilities::SIREN_random>>())
@@ -454,6 +480,7 @@ PYBIND11_MODULE(injection,m) {
     .def("GetFailureCounts",&Injector::GetFailureCounts)
     .def("GetLastFailureReason",&Injector::GetLastFailureReason)
     .def("GetLastFailedTree",&Injector::GetLastFailedTree, pybind11::return_value_policy::reference_internal)
+    .def("GetFailureLedger",&Injector::GetFailureLedger, pybind11::return_value_policy::reference_internal)
     .def("ResetInjectedEvents",overload_cast<unsigned int>(&Injector::ResetInjectedEvents))
     .def("ResetInjectedEvents",overload_cast<>(&Injector::ResetInjectedEvents))
     .def("GetPhaseSpaces",&Injector::GetPhaseSpaces)
@@ -492,6 +519,21 @@ PYBIND11_MODULE(injection,m) {
 
   // Weighter classes
 
+  class_<VertexWeightFactors, std::shared_ptr<VertexWeightFactors>>(m, "VertexWeightFactors")
+    .def_readonly("depth", &VertexWeightFactors::depth)
+    .def_readonly("primary_pdg", &VertexWeightFactors::primary_pdg)
+    .def_readonly("generation", &VertexWeightFactors::generation)
+    .def_readonly("physical", &VertexWeightFactors::physical)
+    .def_readonly("interaction_prob", &VertexWeightFactors::interaction_prob)
+    .def_readonly("position_prob", &VertexWeightFactors::position_prob)
+    .def_readonly("channel_densities", &VertexWeightFactors::channel_densities)
+    .def_readonly("cancelled", &VertexWeightFactors::cancelled)
+    .def_readonly("flags", &VertexWeightFactors::flags);
+
+  class_<EventWeightBreakdown, std::shared_ptr<EventWeightBreakdown>>(m, "EventWeightBreakdown")
+    .def_readonly("total", &EventWeightBreakdown::total)
+    .def_readonly("vertices", &EventWeightBreakdown::vertices);
+
   class_<PrimaryProcessWeighter, std::shared_ptr<PrimaryProcessWeighter>>(m, "PrimaryProcessWeighter")
     .def(init<std::shared_ptr<PhysicalProcess>, std::shared_ptr<PrimaryInjectionProcess>, std::shared_ptr<siren::detector::DetectorModel>>())
     .def("InteractionProbability",&PrimaryProcessWeighter::InteractionProbability)
@@ -515,6 +557,7 @@ PYBIND11_MODULE(injection,m) {
     .def(init<std::vector<std::shared_ptr<Injector>>, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PhysicalProcess>>())
     .def(init<std::vector<std::shared_ptr<Injector>>, std::string>())
     .def("EventWeight",&Weighter::EventWeight)
+    .def("EventWeightWithBreakdown",&Weighter::EventWeightWithBreakdown)
     .def("GetInjectors",&Weighter::GetInjectors)
     .def("GetDetectorModel",&Weighter::GetDetectorModel)
     .def("GetPrimaryPhysicalProcess",&Weighter::GetPrimaryPhysicalProcess)

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -520,6 +520,7 @@ PYBIND11_MODULE(injection,m) {
   // Weighter classes
 
   class_<VertexWeightFactors, std::shared_ptr<VertexWeightFactors>>(m, "VertexWeightFactors")
+    .def_readonly("injector_index", &VertexWeightFactors::injector_index)
     .def_readonly("depth", &VertexWeightFactors::depth)
     .def_readonly("primary_pdg", &VertexWeightFactors::primary_pdg)
     .def_readonly("generation", &VertexWeightFactors::generation)

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -477,7 +477,10 @@ PYBIND11_MODULE(injection,m) {
     .def("EventsToInject",&Injector::EventsToInject)
     .def("__len__", &Injector::EventsToInject)
     .def("FailedEvents",&Injector::FailedEvents)
-    .def("GetFailureCounts",&Injector::GetFailureCounts)
+    .def("GetFailureCounts",&Injector::GetFailureCounts,
+        "Deprecated: fatal failure counts keyed by the parent PDG of the failing "
+        "vertex (primary failures key on the primary PDG; no sentinel key). "
+        "Prefer GetFailureLedger() for the (depth, pdg, reason) view.")
     .def("GetLastFailureReason",&Injector::GetLastFailureReason)
     .def("GetLastFailedTree",&Injector::GetLastFailedTree, pybind11::return_value_policy::reference_internal)
     .def("GetFailureLedger",&Injector::GetFailureLedger, pybind11::return_value_policy::reference_internal)

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -522,7 +522,7 @@ PYBIND11_MODULE(injection,m) {
   class_<VertexWeightFactors>(m, "VertexWeightFactors")
     .def_readonly("injector_index", &VertexWeightFactors::injector_index)
     .def_readonly("depth", &VertexWeightFactors::depth)
-    .def_readonly("primary_pdg", &VertexWeightFactors::primary_pdg)
+    .def_readonly("vertex_pdg", &VertexWeightFactors::vertex_pdg)
     .def_readonly("generation", &VertexWeightFactors::generation)
     .def_readonly("physical", &VertexWeightFactors::physical)
     .def_readonly("interaction_prob", &VertexWeightFactors::interaction_prob)

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -436,7 +436,7 @@ PYBIND11_MODULE(injection,m) {
 
   // Injection
 
-  class_<FailureLedger, std::shared_ptr<FailureLedger>>(m, "FailureLedger")
+  class_<FailureLedger>(m, "FailureLedger")
     .def(init<>())
     .def("Clear", &FailureLedger::Clear)
     .def("entries", [](FailureLedger const & ledger) {
@@ -519,7 +519,7 @@ PYBIND11_MODULE(injection,m) {
 
   // Weighter classes
 
-  class_<VertexWeightFactors, std::shared_ptr<VertexWeightFactors>>(m, "VertexWeightFactors")
+  class_<VertexWeightFactors>(m, "VertexWeightFactors")
     .def_readonly("injector_index", &VertexWeightFactors::injector_index)
     .def_readonly("depth", &VertexWeightFactors::depth)
     .def_readonly("primary_pdg", &VertexWeightFactors::primary_pdg)
@@ -531,7 +531,7 @@ PYBIND11_MODULE(injection,m) {
     .def_readonly("cancelled", &VertexWeightFactors::cancelled)
     .def_readonly("flags", &VertexWeightFactors::flags);
 
-  class_<EventWeightBreakdown, std::shared_ptr<EventWeightBreakdown>>(m, "EventWeightBreakdown")
+  class_<EventWeightBreakdown>(m, "EventWeightBreakdown")
     .def_readonly("total", &EventWeightBreakdown::total)
     .def_readonly("vertices", &EventWeightBreakdown::vertices);
 

--- a/projects/injection/private/test/CCM_HNL_Fixture.h
+++ b/projects/injection/private/test/CCM_HNL_Fixture.h
@@ -17,6 +17,7 @@
 #include <vector>
 #include <array>
 #include <sstream>
+#include <fstream>
 
 #include "SIREN/utilities/Random.h"
 #include "SIREN/dataclasses/Particle.h"
@@ -52,6 +53,13 @@ static const std::string ccm_hnl_diff_xsec_table_path = "/home/nwkamp/Research/P
 
 static const std::string ccm_hnl_material_file = "/home/nwkamp/Research/CCM/DipoleAnalysis/sources/SIRENDevPrivate/resources/Detectors/materials/CCM.dat";
 static const std::string ccm_hnl_detector_file = "/home/nwkamp/Research/CCM/DipoleAnalysis/sources/SIRENDevPrivate/resources/Detectors/densities/PREM_ccm.dat";
+
+// True only when the hardcoded material/detector data files exist, so a test
+// can GTEST_SKIP() rather than abort on environments without the private data.
+inline bool CCMHNLDataPresent() {
+    return std::ifstream(ccm_hnl_material_file).good()
+        && std::ifstream(ccm_hnl_detector_file).good();
+}
 
 static const double ccm_hnl_mass = 0.01375; // in GeV; The HNL mass we are injecting
 static const double ccm_hnl_dipole_coupling = 1.0e-6; // in GeV^-1; the effective dipole coupling strength

--- a/projects/injection/private/test/CCM_HNL_Fixture.h
+++ b/projects/injection/private/test/CCM_HNL_Fixture.h
@@ -59,7 +59,7 @@ static const double ccm_hnl_dipole_coupling = 1.0e-6; // in GeV^-1; the effectiv
 static const std::string ccm_hnl_mHNL = "0.01375";
 
 // Events to inject
-static const unsigned int ccm_hnl_events_to_inject = 1e2;
+static const unsigned int ccm_hnl_events_to_inject = 100u;
 static const siren::dataclasses::ParticleType ccm_hnl_primary_type = siren::dataclasses::ParticleType::NuMu;
 
 inline std::vector<double> CCMHNLDipoleCouplingVec() {

--- a/projects/injection/private/test/CCM_HNL_Fixture.h
+++ b/projects/injection/private/test/CCM_HNL_Fixture.h
@@ -1,0 +1,302 @@
+#pragma once
+#ifndef SIREN_CCM_HNL_FIXTURE_H
+#define SIREN_CCM_HNL_FIXTURE_H
+
+// Shared assembly for the CCM dipole-HNL upper-injector chain: detector model,
+// primary injection/physical processes, secondary N4 decay, and the resulting
+// Injector + Weighter pair.  MakeCCMHNLFixture() is the single construction
+// point for a generation-capable injector/weighter pair in CCM_HNL_TEST.cxx.
+//
+// Data-dependent: MakeCCMHNLFixture() loads material/detector files and
+// cross-section tables from hardcoded /home/nwkamp paths and cannot run
+// outside that environment.
+
+#include <cmath>
+#include <memory>
+#include <string>
+#include <vector>
+#include <array>
+#include <sstream>
+
+#include "SIREN/utilities/Random.h"
+#include "SIREN/dataclasses/Particle.h"
+#include "SIREN/detector/DetectorModel.h"
+#include "SIREN/injection/Injector.h"
+#include "SIREN/injection/Process.h"
+#include "SIREN/injection/Weighter.h"
+#include "SIREN/geometry/Geometry.h"
+#include "SIREN/math/Vector3D.h"
+
+#include "SIREN/distributions/primary/energy/Monoenergetic.h"
+#include "SIREN/distributions/primary/direction/Cone.h"
+#include "SIREN/distributions/primary/direction/IsotropicDirection.h"
+#include "SIREN/distributions/primary/vertex/PointSourcePositionDistribution.h"
+#include "SIREN/distributions/primary/helicity/PrimaryNeutrinoHelicityDistribution.h"
+#include "SIREN/distributions/secondary/vertex/SecondaryPhysicalVertexDistribution.h"
+
+#include "SIREN/interactions/InteractionCollection.h"
+#include "SIREN/interactions/CrossSection.h"
+#include "SIREN/interactions/HNLDipoleFromTable.h"
+#include "SIREN/interactions/HNLDipoleDecay.h"
+#include "SIREN/interactions/Decay.h"
+
+namespace siren { namespace injection { namespace test {
+
+// generation settings
+static const bool ccm_hnl_z_samp = false;
+static const bool ccm_hnl_in_invGeV = true; // are the xsec tables in GeV^-1?
+static const bool ccm_hnl_inelastic = true;
+
+static const std::string ccm_hnl_tot_xsec_table_path = "/home/nwkamp/Research/Pheno/Neutrissimos2/Sandbox/xsec_tables/tot_xsec_Enu/";
+static const std::string ccm_hnl_diff_xsec_table_path = "/home/nwkamp/Research/Pheno/Neutrissimos2/Sandbox/xsec_tables/";
+
+static const std::string ccm_hnl_material_file = "/home/nwkamp/Research/CCM/DipoleAnalysis/sources/SIRENDevPrivate/resources/Detectors/materials/CCM.dat";
+static const std::string ccm_hnl_detector_file = "/home/nwkamp/Research/CCM/DipoleAnalysis/sources/SIRENDevPrivate/resources/Detectors/densities/PREM_ccm.dat";
+
+static const double ccm_hnl_mass = 0.01375; // in GeV; The HNL mass we are injecting
+static const double ccm_hnl_dipole_coupling = 1.0e-6; // in GeV^-1; the effective dipole coupling strength
+static const std::string ccm_hnl_mHNL = "0.01375";
+
+// Events to inject
+static const unsigned int ccm_hnl_events_to_inject = 1e2;
+static const siren::dataclasses::ParticleType ccm_hnl_primary_type = siren::dataclasses::ParticleType::NuMu;
+
+inline std::vector<double> CCMHNLDipoleCouplingVec() {
+    return std::vector<double>{
+        (ccm_hnl_primary_type == siren::dataclasses::ParticleType::NuE) ? ccm_hnl_dipole_coupling : 0,
+        (ccm_hnl_primary_type == siren::dataclasses::ParticleType::NuMu) ? ccm_hnl_dipole_coupling : 0,
+        (ccm_hnl_primary_type == siren::dataclasses::ParticleType::NuTau) ? ccm_hnl_dipole_coupling : 0};
+}
+
+// Functions for loading xsec tables
+
+inline std::string CCMHNLDiffXsPath(int Z, int A, std::string mHNL) {
+    std::stringstream ss;
+    ss << ccm_hnl_diff_xsec_table_path;
+    if(ccm_hnl_z_samp) ss << "diff_xsec_z_Enu/";
+    else ss << "diff_xsec_y_Enu/";
+    ss << "dxsec_";
+    ss << "Z_" << Z << "_";
+    ss << "A_" << A << "_";
+    ss << "mHNL_" << mHNL;
+    return ss.str();
+}
+
+inline std::string CCMHNLTotXsPath(int Z, int A, std::string mHNL) {
+    std::stringstream ss;
+    ss << ccm_hnl_tot_xsec_table_path;
+    ss << "xsec_";
+    ss << "Z_" << Z << "_";
+    ss << "A_" << A << "_";
+    ss << "mHNL_" << mHNL;
+    return ss.str();
+}
+
+inline std::vector<std::array<int, 2>> CCMHNLTargetZA() {
+    return std::vector<std::array<int, 2>>{
+        {1, 1},
+        {6, 12},
+        {8, 16},
+        {13, 27},
+        {14, 28},
+        {20, 40},
+        {26, 56},
+        {29, 63},
+        {29, 65},
+        {82, 208},
+    };
+}
+
+inline std::vector<siren::dataclasses::ParticleType> CCMHNLTargetPIDs() {
+    using ParticleType = siren::dataclasses::ParticleType;
+    return std::vector<ParticleType>{
+            ParticleType::HNucleus,
+            ParticleType::C12Nucleus,
+            ParticleType::O16Nucleus,
+            ParticleType::Al27Nucleus,
+            ParticleType::Si28Nucleus,
+            ParticleType::Ca40Nucleus,
+            ParticleType::Fe56Nucleus,
+            ParticleType::Cu63Nucleus,
+            ParticleType::Cu65Nucleus,
+            ParticleType::Pb208Nucleus
+    };
+}
+
+inline std::vector<std::string> CCMHNLDiffXsHfFiles(std::string mHNL) {
+    std::vector<std::string> res;
+    for(auto const & za : CCMHNLTargetZA()) {
+        res.push_back(CCMHNLDiffXsPath(za[0], za[1], mHNL) + "_hf.dat");
+    }
+    return res;
+}
+
+inline std::vector<std::string> CCMHNLTotXsHfFiles(std::string mHNL) {
+    std::vector<std::string> res;
+    for(auto const & za : CCMHNLTargetZA()) {
+        res.push_back(CCMHNLTotXsPath(za[0], za[1], mHNL) + "_hf.dat");
+    }
+    return res;
+}
+
+inline std::vector<std::string> CCMHNLDiffXsHcFiles(std::string mHNL) {
+    std::vector<std::string> res;
+    for(auto const & za : CCMHNLTargetZA()) {
+        res.push_back(CCMHNLDiffXsPath(za[0], za[1], mHNL) + "_hc.dat");
+    }
+    return res;
+}
+
+inline std::vector<std::string> CCMHNLTotXsHcFiles(std::string mHNL) {
+    std::vector<std::string> res;
+    for(auto const & za : CCMHNLTargetZA()) {
+        res.push_back(CCMHNLTotXsPath(za[0], za[1], mHNL) + "_hc.dat");
+    }
+    return res;
+}
+
+// Bundles the pieces a BreakdownInvariant-style test needs: the upper
+// injector (targets the upper tungsten converter), its matching physical
+// weighter, and the shared detector model.
+struct CCMHNLFixture {
+    std::shared_ptr<siren::injection::Injector> injector;
+    std::shared_ptr<siren::injection::Weighter> weighter;
+    std::shared_ptr<siren::detector::DetectorModel> detector_model;
+};
+
+// Builds the upper-target injector/weighter pair using the same materials,
+// cross sections, distributions, and stopping condition as the reference
+// generation test.  Requires the hardcoded /home/nwkamp data files to exist.
+inline CCMHNLFixture MakeCCMHNLFixture() {
+    using ParticleType = siren::dataclasses::ParticleType;
+    using namespace siren::distributions;
+    using namespace siren::interactions;
+    using namespace siren::injection;
+    using namespace siren::detector;
+    using namespace siren::utilities;
+
+    std::shared_ptr<DetectorModel> detector_model = std::make_shared<DetectorModel>();
+    detector_model->LoadMaterialModel(ccm_hnl_material_file);
+    detector_model->LoadDetectorModel(ccm_hnl_detector_file);
+
+    std::shared_ptr<SIREN_random> random = std::make_shared<SIREN_random>();
+
+    std::shared_ptr<PrimaryInjectionProcess> primary_injection_process =
+        std::make_shared<PrimaryInjectionProcess>();
+    std::shared_ptr<PhysicalProcess> primary_physical_process =
+        std::make_shared<PhysicalProcess>();
+    std::vector<std::shared_ptr<PhysicalProcess>> secondary_physical_processes;
+    primary_injection_process->SetPrimaryType(ccm_hnl_primary_type);
+    primary_physical_process->SetPrimaryType(ccm_hnl_primary_type);
+
+    // Cross sections
+    std::vector<std::shared_ptr<CrossSection>> cross_sections;
+    std::vector<ParticleType> target_types = CCMHNLTargetPIDs();
+    std::shared_ptr<HNLDipoleFromTable> hf_xs = std::make_shared<HNLDipoleFromTable>(
+        ccm_hnl_mass, ccm_hnl_dipole_coupling, HNLDipoleFromTable::HelicityChannel::Flipping,
+        ccm_hnl_z_samp, ccm_hnl_in_invGeV, ccm_hnl_inelastic);
+    std::shared_ptr<HNLDipoleFromTable> hc_xs = std::make_shared<HNLDipoleFromTable>(
+        ccm_hnl_mass, ccm_hnl_dipole_coupling, HNLDipoleFromTable::HelicityChannel::Conserving,
+        ccm_hnl_z_samp, ccm_hnl_in_invGeV, ccm_hnl_inelastic);
+    std::vector<std::string> hf_diff_fnames = CCMHNLDiffXsHfFiles(ccm_hnl_mHNL);
+    std::vector<std::string> hc_diff_fnames = CCMHNLDiffXsHcFiles(ccm_hnl_mHNL);
+    std::vector<std::string> hf_tot_fnames = CCMHNLTotXsHfFiles(ccm_hnl_mHNL);
+    std::vector<std::string> hc_tot_fnames = CCMHNLTotXsHcFiles(ccm_hnl_mHNL);
+    for(unsigned int i = 0; i < target_types.size(); ++i) {
+        hf_xs->AddDifferentialCrossSectionFile(hf_diff_fnames[i], target_types[i]);
+        hf_xs->AddTotalCrossSectionFile(hf_tot_fnames[i], target_types[i]);
+        hc_xs->AddDifferentialCrossSectionFile(hc_diff_fnames[i], target_types[i]);
+        hc_xs->AddTotalCrossSectionFile(hc_tot_fnames[i], target_types[i]);
+    }
+    cross_sections.push_back(hf_xs);
+    cross_sections.push_back(hc_xs);
+
+    std::shared_ptr<InteractionCollection> primary_interactions =
+        std::make_shared<InteractionCollection>(ccm_hnl_primary_type, cross_sections);
+    primary_injection_process->SetInteractions(primary_interactions);
+    primary_physical_process->SetInteractions(primary_interactions);
+
+    // Primary energy distribution: pion decay-at-rest
+    double nu_energy = 0.02965;
+    std::shared_ptr<PrimaryEnergyDistribution> edist = std::make_shared<Monoenergetic>(nu_energy);
+    primary_injection_process->AddPrimaryInjectionDistribution(edist);
+    primary_physical_process->AddPhysicalDistribution(edist);
+
+    // Flux normalization: 2105.14020, 4.74e9 nu/m^2/s / (6.2e14 POT/s) * 4*pi*20m^2 -> nu/POT
+    std::shared_ptr<WeightableDistribution> flux_units = std::make_shared<NormalizationConstant>(3.76e-2);
+    primary_physical_process->AddPhysicalDistribution(flux_units);
+
+    // Primary direction: cone toward the detector from the upper target
+    double opening_angle = std::atan(2./23.);
+    siren::math::Vector3D upper_target_origin(0, 0, 0.1375);
+    siren::math::Vector3D detector_origin(23, 0, -0.65);
+    siren::math::Vector3D upper_dir = detector_origin - upper_target_origin;
+    upper_dir.normalize();
+    std::shared_ptr<PrimaryDirectionDistribution> upper_inj_ddist = std::make_shared<Cone>(upper_dir, opening_angle);
+    std::shared_ptr<PrimaryDirectionDistribution> phys_ddist = std::make_shared<IsotropicDirection>();
+    primary_injection_process->AddPrimaryInjectionDistribution(upper_inj_ddist);
+    primary_physical_process->AddPhysicalDistribution(phys_ddist);
+
+    // Helicity distribution: this is a neutrino
+    std::shared_ptr<PrimaryNeutrinoHelicityDistribution> helicity_distribution =
+        std::make_shared<PrimaryNeutrinoHelicityDistribution>();
+    primary_injection_process->AddPrimaryInjectionDistribution(helicity_distribution);
+    primary_physical_process->AddPhysicalDistribution(helicity_distribution);
+
+    // Primary position distribution: treat the upper target as a point source
+    double max_dist = 25; // m
+    std::shared_ptr<VertexPositionDistribution> upper_pos_dist =
+        std::make_shared<PointSourcePositionDistribution>(upper_target_origin, max_dist);
+    primary_injection_process->AddPrimaryInjectionDistribution(upper_pos_dist);
+
+    // Secondary process: dipole portal HNL (N4) decay
+    std::shared_ptr<SecondaryInjectionProcess> secondary_decay_inj_process =
+        std::make_shared<SecondaryInjectionProcess>();
+    std::shared_ptr<PhysicalProcess> secondary_decay_phys_process =
+        std::make_shared<PhysicalProcess>();
+    secondary_decay_inj_process->SetPrimaryType(ParticleType::N4);
+    secondary_decay_phys_process->SetPrimaryType(ParticleType::N4);
+
+    std::shared_ptr<HNLDipoleDecay> sec_decay = std::make_shared<HNLDipoleDecay>(
+        ccm_hnl_mass, CCMHNLDipoleCouplingVec(), HNLDipoleDecay::ChiralNature::Majorana);
+    std::vector<std::shared_ptr<Decay>> sec_decays = {sec_decay};
+    std::shared_ptr<InteractionCollection> secondary_interactions =
+        std::make_shared<InteractionCollection>(ParticleType::N4, sec_decays);
+    secondary_decay_inj_process->SetInteractions(secondary_interactions);
+    secondary_decay_phys_process->SetInteractions(secondary_interactions);
+
+    std::shared_ptr<SecondaryVertexPositionDistribution> secondary_pos_dist =
+        std::make_shared<SecondaryPhysicalVertexDistribution>();
+    secondary_decay_inj_process->AddSecondaryInjectionDistribution(secondary_pos_dist);
+
+    std::vector<std::shared_ptr<SecondaryInjectionProcess>> secondary_injection_processes;
+    secondary_injection_processes.push_back(secondary_decay_inj_process);
+    secondary_physical_processes.push_back(secondary_decay_phys_process);
+
+    std::shared_ptr<Injector> upper_injector = std::make_shared<Injector>(
+        ccm_hnl_events_to_inject, detector_model, primary_injection_process,
+        secondary_injection_processes, random);
+
+    std::function<bool(siren::dataclasses::InteractionTree const &, std::shared_ptr<siren::dataclasses::InteractionTreeDatum>, size_t)> stopping_condition =
+        [&](siren::dataclasses::InteractionTree const & tree, std::shared_ptr<siren::dataclasses::InteractionTreeDatum> datum, size_t i) {
+            if(datum->depth(tree) >= 1) return true;
+            return false;
+        };
+    upper_injector->SetStoppingCondition(stopping_condition);
+
+    std::shared_ptr<Weighter> upper_weighter = std::make_shared<Weighter>(
+        std::vector<std::shared_ptr<Injector>>{upper_injector}, detector_model,
+        primary_physical_process, secondary_physical_processes);
+
+    CCMHNLFixture fixture;
+    fixture.injector = upper_injector;
+    fixture.weighter = upper_weighter;
+    fixture.detector_model = detector_model;
+    return fixture;
+}
+
+} // namespace test
+} // namespace injection
+} // namespace siren
+
+#endif // SIREN_CCM_HNL_FIXTURE_H

--- a/projects/injection/private/test/CCM_HNL_Fixture.h
+++ b/projects/injection/private/test/CCM_HNL_Fixture.h
@@ -54,13 +54,6 @@ static const std::string ccm_hnl_diff_xsec_table_path = "/home/nwkamp/Research/P
 static const std::string ccm_hnl_material_file = "/home/nwkamp/Research/CCM/DipoleAnalysis/sources/SIRENDevPrivate/resources/Detectors/materials/CCM.dat";
 static const std::string ccm_hnl_detector_file = "/home/nwkamp/Research/CCM/DipoleAnalysis/sources/SIRENDevPrivate/resources/Detectors/densities/PREM_ccm.dat";
 
-// True only when the hardcoded material/detector data files exist, so a test
-// can GTEST_SKIP() rather than abort on environments without the private data.
-inline bool CCMHNLDataPresent() {
-    return std::ifstream(ccm_hnl_material_file).good()
-        && std::ifstream(ccm_hnl_detector_file).good();
-}
-
 static const double ccm_hnl_mass = 0.01375; // in GeV; The HNL mass we are injecting
 static const double ccm_hnl_dipole_coupling = 1.0e-6; // in GeV^-1; the effective dipole coupling strength
 static const std::string ccm_hnl_mHNL = "0.01375";
@@ -161,6 +154,19 @@ inline std::vector<std::string> CCMHNLTotXsHcFiles(std::string mHNL) {
         res.push_back(CCMHNLTotXsPath(za[0], za[1], mHNL) + "_hc.dat");
     }
     return res;
+}
+
+// True only when every hardcoded input MakeCCMHNLFixture() loads is present:
+// the material/detector files and a representative differential/total
+// cross-section table.  A test gates on this to GTEST_SKIP() rather than abort
+// on environments without the private data.
+inline bool CCMHNLDataPresent() {
+    std::vector<std::string> const diff = CCMHNLDiffXsHfFiles(ccm_hnl_mHNL);
+    std::vector<std::string> const tot = CCMHNLTotXsHfFiles(ccm_hnl_mHNL);
+    return std::ifstream(ccm_hnl_material_file).good()
+        && std::ifstream(ccm_hnl_detector_file).good()
+        && !diff.empty() && std::ifstream(diff.front()).good()
+        && !tot.empty() && std::ifstream(tot.front()).good();
 }
 
 // Bundles the pieces a BreakdownInvariant-style test needs: the upper

--- a/projects/injection/private/test/CCM_HNL_TEST.cxx
+++ b/projects/injection/private/test/CCM_HNL_TEST.cxx
@@ -37,6 +37,8 @@
 #include "SIREN/interactions/HNLDipoleDecay.h"
 #include "SIREN/interactions/Decay.h"
 
+#include "CCM_HNL_Fixture.h"
+
 using namespace siren::math;
 using namespace siren::geometry;
 using namespace siren::detector;
@@ -344,6 +346,25 @@ TEST(Injector, Generation)
         double weight = lower_weighter->EventWeight(tree);
         //std::cout << "Weight: " << weight << std::endl;
         ++i;
+    }
+}
+
+// EventWeightWithBreakdown().total must equal EventWeight() for every
+// generated tree, across the full upper-injector CCM dipole-HNL chain.
+TEST(Injector, BreakdownInvariant)
+{
+    siren::injection::test::CCMHNLFixture fixture = siren::injection::test::MakeCCMHNLFixture();
+
+    unsigned int checked = 0;
+    while(*fixture.injector && checked < 10) {
+        InteractionTree tree = fixture.injector->GenerateEvent();
+        if(tree.tree.empty()) continue;
+
+        double weight = fixture.weighter->EventWeight(tree);
+        EventWeightBreakdown breakdown = fixture.weighter->EventWeightWithBreakdown(tree);
+
+        EXPECT_NEAR(breakdown.total, weight, 1e-12 * std::max(1.0, std::abs(weight)));
+        ++checked;
     }
 }
 

--- a/projects/injection/private/test/CCM_HNL_TEST.cxx
+++ b/projects/injection/private/test/CCM_HNL_TEST.cxx
@@ -362,7 +362,10 @@ TEST(Injector, BreakdownInvariant)
     siren::injection::test::CCMHNLFixture fixture = siren::injection::test::MakeCCMHNLFixture();
 
     unsigned int checked = 0;
-    while(*fixture.injector && checked < 10) {
+    // Bound on attempts, not accepted events, so GenerateEvent is never called
+    // once the attempt budget is spent (which would throw).
+    while(fixture.injector->InjectionAttempts() < fixture.injector->EventsToInject()
+          && checked < 10) {
         InteractionTree tree = fixture.injector->GenerateEvent();
         if(tree.tree.empty()) continue;
 
@@ -372,6 +375,7 @@ TEST(Injector, BreakdownInvariant)
         EXPECT_NEAR(breakdown.total, weight, 1e-12 * std::max(1.0, std::abs(weight)));
         ++checked;
     }
+    EXPECT_GT(checked, 0u) << "no accepted trees to check the breakdown invariant on";
 }
 
 int main(int argc, char** argv)

--- a/projects/injection/private/test/CCM_HNL_TEST.cxx
+++ b/projects/injection/private/test/CCM_HNL_TEST.cxx
@@ -165,6 +165,9 @@ TEST(Injector, Generation)
 {
     using ParticleType = ParticleType;
 
+    if(!siren::injection::test::CCMHNLDataPresent()) {
+        GTEST_SKIP() << "CCM_HNL data files are not present in this environment";
+    }
 
     // Load the detector model
     std::shared_ptr<DetectorModel> detector_model = std::make_shared<DetectorModel>();
@@ -353,6 +356,9 @@ TEST(Injector, Generation)
 // generated tree, across the full upper-injector CCM dipole-HNL chain.
 TEST(Injector, BreakdownInvariant)
 {
+    if(!siren::injection::test::CCMHNLDataPresent()) {
+        GTEST_SKIP() << "CCM_HNL data files are not present in this environment";
+    }
     siren::injection::test::CCMHNLFixture fixture = siren::injection::test::MakeCCMHNLFixture();
 
     unsigned int checked = 0;

--- a/projects/injection/private/test/Injector_TEST.cxx
+++ b/projects/injection/private/test/Injector_TEST.cxx
@@ -6,12 +6,15 @@
 #include "SIREN/utilities/Errors.h"
 #include "SIREN/utilities/Random.h"
 #include "SIREN/dataclasses/Particle.h"
+#include "SIREN/dataclasses/InteractionTree.h"
 #include "SIREN/detector/DetectorModel.h"
 #include "SIREN/interactions/InteractionCollection.h"
 #include "SIREN/interactions/CrossSection.h"
 #include "SIREN/interactions/DummyCrossSection.h"
+#include "SIREN/injection/FailureLedger.h"
 #include "SIREN/injection/Injector.h"
 #include "SIREN/injection/Process.h"
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
 
 using namespace siren::detector;
 using namespace siren::injection;
@@ -40,6 +43,80 @@ std::shared_ptr<PrimaryInjectionProcess> MakeVertexlessPrimaryProcess() {
     std::shared_ptr<PrimaryInjectionProcess> process =
         std::make_shared<PrimaryInjectionProcess>(primary, interactions);
     // Intentionally add no distributions at all -> no vertex distribution.
+    return process;
+}
+
+// A VertexPositionDistribution that always throws a tagged InjectionFailure
+// instead of sampling.  Every other override is an unreachable stub: Sample()
+// throws before SamplePosition/GenerationProbability/etc. can be invoked.
+class ThrowingVertexDistribution : public siren::distributions::VertexPositionDistribution {
+public:
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> SamplePosition(
+        std::shared_ptr<siren::utilities::SIREN_random> /*rand*/,
+        std::shared_ptr<siren::detector::DetectorModel const> /*detector_model*/,
+        std::shared_ptr<siren::interactions::InteractionCollection const> /*interactions*/,
+        siren::dataclasses::PrimaryDistributionRecord & /*record*/) const override {
+        throw siren::utilities::InjectionFailure(
+            siren::utilities::FailureReason::NoTargetsOnPath, "forced no targets");
+    }
+
+    void Sample(
+        std::shared_ptr<siren::utilities::SIREN_random> /*rand*/,
+        std::shared_ptr<siren::detector::DetectorModel const> /*detector_model*/,
+        std::shared_ptr<siren::interactions::InteractionCollection const> /*interactions*/,
+        siren::dataclasses::PrimaryDistributionRecord & /*record*/) const override {
+        // Throw directly rather than delegating to SamplePosition() so the
+        // failure fires unconditionally, with no dependence on the base
+        // class's Sample() wiring.
+        throw siren::utilities::InjectionFailure(
+            siren::utilities::FailureReason::NoTargetsOnPath, "forced no targets");
+    }
+
+    double GenerationProbability(
+        std::shared_ptr<siren::detector::DetectorModel const> /*detector_model*/,
+        std::shared_ptr<siren::interactions::InteractionCollection const> /*interactions*/,
+        siren::dataclasses::InteractionRecord const & /*record*/) const override {
+        return 0.0;
+    }
+
+    std::string Name() const override {
+        return "ThrowingVertexDistribution";
+    }
+
+    std::shared_ptr<siren::distributions::PrimaryInjectionDistribution> clone() const override {
+        return std::make_shared<ThrowingVertexDistribution>(*this);
+    }
+
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(
+        std::shared_ptr<siren::detector::DetectorModel const> /*detector_model*/,
+        std::shared_ptr<siren::interactions::InteractionCollection const> /*interactions*/,
+        siren::dataclasses::InteractionRecord const & /*interaction*/) const override {
+        return std::tuple<siren::math::Vector3D, siren::math::Vector3D>();
+    }
+
+protected:
+    bool equal(siren::distributions::WeightableDistribution const & distribution) const override {
+        return dynamic_cast<ThrowingVertexDistribution const *>(&distribution) != nullptr;
+    }
+
+    bool less(siren::distributions::WeightableDistribution const & /*distribution*/) const override {
+        return false;
+    }
+};
+
+// A PrimaryInjectionProcess whose only injection distribution is a
+// ThrowingVertexDistribution, so SetPrimaryProcess accepts it (it satisfies
+// the vertex-distribution requirement) but GenerateEvent's first Sample()
+// call always fails with a tagged FailureReason.
+std::shared_ptr<PrimaryInjectionProcess> MakeAlwaysFailingPrimaryProcess() {
+    ParticleType primary = ParticleType::NuMu;
+    std::shared_ptr<DummyCrossSection> xs = std::make_shared<DummyCrossSection>();
+    std::vector<std::shared_ptr<CrossSection>> xs_vec = {xs};
+    std::shared_ptr<InteractionCollection> interactions =
+        std::make_shared<InteractionCollection>(primary, xs_vec);
+    std::shared_ptr<PrimaryInjectionProcess> process =
+        std::make_shared<PrimaryInjectionProcess>(primary, interactions);
+    process->AddPrimaryInjectionDistribution(std::make_shared<ThrowingVertexDistribution>());
     return process;
 }
 
@@ -104,4 +181,57 @@ TEST(InjectorHardening, ResetInjectedEventsZeroArgPreservesQuota) {
     EXPECT_EQ(injector.EventsToInject(), 3u);
     injector.ResetInjectedEvents();
     EXPECT_EQ(injector.EventsToInject(), 3u);
+}
+
+// FailureLedger aggregates repeated (depth, parent_pdg, reason) keys into one
+// entry whose count increments and whose exemplar is fixed at first-record.
+TEST(FailureLedgerUnit, RecordAggregatesByKeyAndKeepsFirstExemplar) {
+    FailureLedger ledger;
+
+    ledger.Record(0, 14, FailureReason::NoTargetsOnPath, "first message");
+    ledger.Record(0, 14, FailureReason::NoTargetsOnPath, "second message");
+    ledger.Record(1, 14, FailureReason::KinematicallyForbidden, "other reason");
+
+    EXPECT_EQ(ledger.entries.size(), 2u);
+
+    FailureLedger::Key repeated_key{0, 14, FailureReason::NoTargetsOnPath};
+    ASSERT_EQ(ledger.entries.count(repeated_key), 1u);
+    EXPECT_EQ(ledger.entries.at(repeated_key).count, 2u);
+    EXPECT_EQ(ledger.entries.at(repeated_key).exemplar, "first message");
+
+    FailureLedger::Key distinct_key{1, 14, FailureReason::KinematicallyForbidden};
+    ASSERT_EQ(ledger.entries.count(distinct_key), 1u);
+    EXPECT_EQ(ledger.entries.at(distinct_key).count, 1u);
+    EXPECT_EQ(ledger.entries.at(distinct_key).exemplar, "other reason");
+
+    ledger.Clear();
+    EXPECT_TRUE(ledger.entries.empty());
+}
+
+// A primary vertex distribution that always throws NoTargetsOnPath must
+// surface as a single depth-0 ledger entry tagged with that reason, leave a
+// non-empty partial tree behind, and be cleared by ResetInjectedEvents().
+TEST(InjectorHardening, PrimaryFailureRecordsLedgerAndPartialTree) {
+    std::shared_ptr<DetectorModel> detector_model = std::make_shared<DetectorModel>();
+    std::shared_ptr<SIREN_random> random = std::make_shared<SIREN_random>(1234);
+    std::shared_ptr<PrimaryInjectionProcess> process = MakeAlwaysFailingPrimaryProcess();
+
+    Injector injector(1, detector_model, process, random);
+
+    siren::dataclasses::InteractionTree tree = injector.GenerateEvent();
+    EXPECT_TRUE(tree.tree.empty());
+
+    FailureLedger const & ledger = injector.GetFailureLedger();
+    EXPECT_EQ(ledger.entries.size(), 1u);
+
+    int primary_pdg = static_cast<int>(ParticleType::NuMu);
+    FailureLedger::Key key{0, primary_pdg, FailureReason::NoTargetsOnPath};
+    ASSERT_EQ(ledger.entries.count(key), 1u);
+    EXPECT_EQ(ledger.entries.at(key).count, 1u);
+    EXPECT_NE(ledger.entries.at(key).exemplar.find("forced"), std::string::npos);
+
+    EXPECT_GE(injector.GetLastFailedTree().tree.size(), 1u);
+
+    injector.ResetInjectedEvents();
+    EXPECT_TRUE(injector.GetFailureLedger().entries.empty());
 }

--- a/projects/injection/public/SIREN/injection/FailureLedger.h
+++ b/projects/injection/public/SIREN/injection/FailureLedger.h
@@ -1,0 +1,52 @@
+#ifndef SIREN_FailureLedger_H
+#define SIREN_FailureLedger_H
+
+#include <map>
+#include <string>
+#include <cstdint>
+
+#include "SIREN/utilities/Errors.h"
+
+namespace siren {
+namespace injection {
+
+// Aggregated failure accounting keyed by (depth, parent pdg, FailureReason).
+// Storage and per-record cost are O(distinct reasons), not O(failed events):
+// repeated identical failures increment a count and keep a single exemplar
+// message. Transient runtime diagnostics only; never serialized.
+struct FailureLedger {
+    struct Key {
+        int depth;
+        int parent_pdg;
+        siren::utilities::FailureReason reason;
+        bool operator<(Key const & other) const {
+            if(depth != other.depth) return depth < other.depth;
+            if(parent_pdg != other.parent_pdg) return parent_pdg < other.parent_pdg;
+            return reason < other.reason;
+        }
+    };
+    struct Entry {
+        uint64_t count = 0;
+        std::string exemplar;
+    };
+
+    std::map<Key, Entry> entries;
+
+    void Record(int depth, int parent_pdg, siren::utilities::FailureReason reason,
+                std::string const & message) {
+        Entry & entry = entries[Key{depth, parent_pdg, reason}];
+        entry.count += 1;
+        if(entry.exemplar.empty()) {
+            entry.exemplar = message;
+        }
+    }
+
+    void Clear() {
+        entries.clear();
+    }
+};
+
+} // namespace injection
+} // namespace siren
+
+#endif // SIREN_FailureLedger_H

--- a/projects/injection/public/SIREN/injection/Injector.h
+++ b/projects/injection/public/SIREN/injection/Injector.h
@@ -137,6 +137,10 @@ public:
     unsigned int InjectionAttempts() const;
     unsigned int EventsToInject() const;
     unsigned int FailedEvents() const;
+    // Deprecated aggregation over the failure ledger: keys are the parent PDG
+    // of the failing vertex (primary failures key on the primary PDG; there is
+    // no sentinel key), and non-fatal skips are excluded.  Prefer
+    // GetFailureLedger() for the structured (depth, pdg, reason) view.
     std::map<int, unsigned int> GetFailureCounts() const;
     std::string GetLastFailureReason() const;
     siren::dataclasses::InteractionTree const & GetLastFailedTree() const;

--- a/projects/injection/public/SIREN/injection/Injector.h
+++ b/projects/injection/public/SIREN/injection/Injector.h
@@ -32,6 +32,7 @@
 #include "SIREN/dataclasses/InteractionTree.h"    // for Interactio...
 #include "SIREN/dataclasses/Particle.h"           // for Particle
 #include "SIREN/distributions/secondary/vertex/SecondaryVertexPositionDistribution.h" // for Secondary...
+#include "SIREN/injection/FailureLedger.h"
 #include "SIREN/interactions/pyDarkNewsCrossSection.h"
 
 namespace siren { namespace interactions { class InteractionCollection; } }
@@ -58,7 +59,7 @@ protected:
     unsigned int injection_attempts = 0;
     unsigned int injected_events = 0;
     unsigned int failed_events = 0;
-    std::map<int, unsigned int> failure_counts_;
+    FailureLedger failure_ledger_;
     std::string last_failure_reason_;
     siren::dataclasses::InteractionTree last_failed_tree_;
     std::shared_ptr<siren::utilities::SIREN_random> random;
@@ -139,6 +140,7 @@ public:
     std::map<int, unsigned int> GetFailureCounts() const;
     std::string GetLastFailureReason() const;
     siren::dataclasses::InteractionTree const & GetLastFailedTree() const;
+    FailureLedger const & GetFailureLedger() const;
     void ResetInjectedEvents(unsigned int events_to_inject);
     void ResetInjectedEvents();
 

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -3,6 +3,7 @@
 #define SIREN_Weighter_H
 
 #include <map>                                           // for map
+#include <string>                                        // for string
 #include <tuple>
 #include <memory>                                        // for shared_ptr
 #include <vector>                                        // for vector
@@ -62,6 +63,29 @@ public:
 typedef ProcessWeighter<siren::injection::PrimaryInjectionProcess> PrimaryProcessWeighter;
 typedef ProcessWeighter<siren::injection::SecondaryInjectionProcess> SecondaryProcessWeighter;
 
+// One tree vertex's weight factors, recorded for diagnostics. generation and
+// physical are the exact per-datum factors the event weight consumes; the other
+// fields are observation-only and never fed back into the weight.
+struct VertexWeightFactors {
+    int depth = 0;
+    int primary_pdg = 0;
+    double generation = 1.0;
+    double physical = 1.0;
+    double interaction_prob = 1.0;
+    double position_prob = 1.0;
+    std::map<std::string, double> channel_densities;
+    std::vector<std::string> cancelled;
+    std::vector<std::string> flags;
+};
+
+// Per-vertex decomposition of an event weight. total equals
+// Weighter::EventWeight(tree) for a tree with no flagged vertices; a flagged
+// vertex marks a zero-generation error path or a zero-physical (weight 0) case.
+struct EventWeightBreakdown {
+    double total = 0.0;
+    std::vector<VertexWeightFactors> vertices;
+};
+
 // Parent class for calculating event weights
 // Assumes there is a unique secondary physical process for each particle type
 class Weighter {
@@ -82,8 +106,11 @@ private:
     > secondary_process_weighter_maps;
 
     void Initialize();
+    VertexWeightFactors ComputeVertexFactors(unsigned int idx,
+        std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum) const;
 public:
     double EventWeight(siren::dataclasses::InteractionTree const & tree) const;
+    EventWeightBreakdown EventWeightWithBreakdown(siren::dataclasses::InteractionTree const & tree) const;
     std::vector<std::shared_ptr<Injector>> const & GetInjectors() const;
     std::shared_ptr<siren::detector::DetectorModel> GetDetectorModel() const;
     std::shared_ptr<siren::injection::PhysicalProcess> GetPrimaryPhysicalProcess() const;

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -67,6 +67,7 @@ typedef ProcessWeighter<siren::injection::SecondaryInjectionProcess> SecondaryPr
 // physical are the exact per-datum factors the event weight consumes; the other
 // fields are observation-only and never fed back into the weight.
 struct VertexWeightFactors {
+    int injector_index = 0;
     int depth = 0;
     int primary_pdg = 0;
     double generation = 1.0;

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -106,8 +106,12 @@ private:
     > secondary_process_weighter_maps;
 
     void Initialize();
+    // with_diagnostics fills the observation-only interaction_prob/position_prob
+    // fields; EventWeight leaves it false so it computes only the physical and
+    // generation factors it consumes.
     VertexWeightFactors ComputeVertexFactors(unsigned int idx,
-        std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum) const;
+        std::shared_ptr<siren::dataclasses::InteractionTreeDatum> const & datum,
+        bool with_diagnostics = false) const;
 public:
     double EventWeight(siren::dataclasses::InteractionTree const & tree) const;
     EventWeightBreakdown EventWeightWithBreakdown(siren::dataclasses::InteractionTree const & tree) const;

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -80,8 +80,9 @@ struct VertexWeightFactors {
 };
 
 // Per-vertex decomposition of an event weight. total equals
-// Weighter::EventWeight(tree) for a tree with no flagged vertices; a flagged
-// vertex marks a zero-generation error path or a zero-physical (weight 0) case.
+// Weighter::EventWeight(tree): a zero-generation vertex (the path EventWeight
+// throws on) is flagged and yields a NaN total, while a zero-physical vertex is
+// flagged and yields a 0.0 total, matching EventWeight's zero-weight case.
 struct EventWeightBreakdown {
     double total = 0.0;
     std::vector<VertexWeightFactors> vertices;

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -69,7 +69,8 @@ typedef ProcessWeighter<siren::injection::SecondaryInjectionProcess> SecondaryPr
 struct VertexWeightFactors {
     int injector_index = 0;
     int depth = 0;
-    int primary_pdg = 0;
+    // pdg of the particle at this vertex, not the event's primary.
+    int vertex_pdg = 0;
     double generation = 1.0;
     double physical = 1.0;
     double interaction_prob = 1.0;

--- a/projects/utilities/public/SIREN/utilities/Errors.h
+++ b/projects/utilities/public/SIREN/utilities/Errors.h
@@ -21,11 +21,28 @@
 namespace siren {
 namespace utilities {
 
+// Coarse cause categories attached to InjectionFailure so aggregated failure
+// accounting can key on the reason without string parsing.
+enum class FailureReason {
+    Unspecified,
+    NoPathThroughVolume,
+    NoTargetsOnPath,
+    NoColumnDepthSolution,
+    KinematicallyForbidden,
+    UnregisteredSecondaryType,
+    PrimaryVertexFailure,
+    TopLevelCatch
+};
+
 class SIREN_EXCEPTION_EXPORT InjectionFailure : public std::runtime_error {
 public:
-    InjectionFailure() : std::runtime_error("") {};
-    InjectionFailure(const std::string& s) : std::runtime_error(s) {};
-    InjectionFailure(const char * s) : std::runtime_error(s) {};
+    InjectionFailure() : std::runtime_error(""), reason_(FailureReason::Unspecified) {};
+    InjectionFailure(const std::string& s) : std::runtime_error(s), reason_(FailureReason::Unspecified) {};
+    InjectionFailure(const char * s) : std::runtime_error(s), reason_(FailureReason::Unspecified) {};
+    InjectionFailure(FailureReason reason, const std::string& s) : std::runtime_error(s), reason_(reason) {};
+    FailureReason reason() const { return reason_; }
+private:
+    FailureReason reason_;
 };
 
 class SIREN_EXCEPTION_EXPORT AddProcessFailure : public std::runtime_error {

--- a/tests/python/test_breakdown_invariant.py
+++ b/tests/python/test_breakdown_invariant.py
@@ -1,0 +1,183 @@
+"""EventWeightWithBreakdown().total equals EventWeight() over real generated events.
+
+Pins that the per-vertex breakdown decomposition is a lossless refactor of the
+scalar weight: for a normal (non-degenerate) tree, summing/multiplying the
+recorded per-vertex factors must reproduce the same double EventWeight()
+returns, to floating-point exactness (both compute from the same factors, so
+the tolerance is 1e-12, not a physics-level rtol). Uses the same data-free
+DummyCrossSection + CCM-detector multi-vertex assembly as the golden
+regression pin, but generates a fresh (unarchived) sample -- this is a
+same-run invariant check, not a frozen numeric anchor.
+"""
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+CHAIN_SEED = 5678
+N_EVENTS = 50
+MAX_ATTEMPTS = 2000
+
+
+# --------------------------------------------------------------------------- #
+# Assembly (copied from test_golden_regression.py -- importing a test module   #
+# is fragile, so this file carries its own minimal copy).                      #
+# --------------------------------------------------------------------------- #
+
+def _skip_unless_ccm_data():
+    """Skip only when the CCM detector data files are absent.
+
+    Missing files are an environment condition; any error raised while
+    PARSING present files is a real regression and must propagate.
+    """
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip(f"CCM detector model path unavailable: {e}")
+    missing = [p for p in (os.path.join(det_dir, "materials.dat"),
+                           os.path.join(det_dir, "densities.dat"))
+               if not os.path.exists(p)]
+    if missing:
+        pytest.skip("CCM detector data missing: " + ", ".join(missing))
+
+
+def _load_ccm_detector():
+    """Load the CCM detector model; errors propagate to the caller."""
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _build_chain(detector_model, n_inject, seed):
+    """Assemble a real multi-vertex Injector + Weighter over a data-free
+    DummyCrossSection. One generation of secondaries is simulated so every
+    event is a multi-vertex cascade. Returns (injector, weighter, keepalive)
+    where keepalive holds Python objects that must outlive the C++ engines.
+    """
+    xs = interactions.DummyCrossSection()
+    int_col = interactions.InteractionCollection(_NuMu, [xs])
+
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = _NuMu
+    primary_inj.interactions = int_col
+    primary_inj.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+
+    primary_phys = injection.PhysicalProcess()
+    primary_phys.primary_type = _NuMu
+    primary_phys.interactions = int_col
+    primary_phys.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+
+    sec_xs = interactions.DummyCrossSection()
+    sec_col = interactions.InteractionCollection(_NuMu, [sec_xs])
+
+    sec_inj = injection.SecondaryInjectionProcess()
+    sec_inj.primary_type = _NuMu
+    sec_inj.interactions = sec_col
+    sec_inj.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+
+    sec_phys = injection.PhysicalProcess()
+    sec_phys.primary_type = _NuMu
+    sec_phys.interactions = sec_col
+    sec_phys.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+
+    rand = utilities.SIREN_random(seed)
+    inj = injection._Injector(n_inject, detector_model, primary_inj, [sec_inj], rand)
+    # Simulate exactly one generation of secondaries (stop at depth >= 1).
+    inj.SetStoppingCondition(lambda tree, datum, i: datum.depth(tree) >= 1)
+    weighter = injection._Weighter([inj], detector_model, primary_phys, [sec_phys])
+
+    keepalive = (xs, int_col, sec_xs, sec_col, primary_inj, primary_phys,
+                 sec_inj, sec_phys, rand)
+    return inj, weighter, keepalive
+
+
+def _generate_events(inj, n_events, max_attempts):
+    """Generate n_events accepted (non-empty) events."""
+    events = []
+    for _ in range(max_attempts):
+        if len(events) >= n_events:
+            break
+        try:
+            ev = inj.GenerateEvent()
+        except RuntimeError as err:
+            if "maximum number of injection attempts" not in str(err):
+                raise
+            break
+        if len(ev.tree) == 0:
+            continue
+        events.append(ev)
+    if len(events) < n_events:
+        raise RuntimeError(
+            f"chain produced only {len(events)} accepted events "
+            f"(< n_events={n_events}) within {max_attempts} attempts")
+    return events
+
+
+# --------------------------------------------------------------------------- #
+# Tests                                                                       #
+# --------------------------------------------------------------------------- #
+
+def test_breakdown_total_matches_event_weight():
+    """EventWeightWithBreakdown(ev).total == EventWeight(ev) to 1e-12 over a
+    real multi-vertex generated sample."""
+    _skip_unless_ccm_data()
+    detector_model = _load_ccm_detector()
+    inj, weighter, _keepalive = _build_chain(detector_model, MAX_ATTEMPTS, CHAIN_SEED)
+
+    # Weight AFTER generation completes: EventWeight normalizes by the
+    # realized injected count, so all events must share the same (final)
+    # normalization -- weighting mid-generation would bake the running count
+    # into each weight.
+    events = _generate_events(inj, N_EVENTS, MAX_ATTEMPTS)
+
+    for ev in events:
+        bd = weighter.EventWeightWithBreakdown(ev)
+        w = weighter.EventWeight(ev)
+        assert math.isclose(bd.total, w, rel_tol=1e-12, abs_tol=0.0), (
+            f"breakdown total {bd.total!r} != EventWeight {w!r}")
+
+
+def test_breakdown_vertices_cover_the_tree_with_no_flags():
+    """Each vertex in the breakdown carries a finite generation/physical
+    factor and no error flag for a normal (non-degenerate) multi-vertex tree."""
+    _skip_unless_ccm_data()
+    detector_model = _load_ccm_detector()
+    inj, weighter, _keepalive = _build_chain(detector_model, MAX_ATTEMPTS, CHAIN_SEED)
+
+    events = _generate_events(inj, N_EVENTS, MAX_ATTEMPTS)
+
+    for ev in events:
+        bd = weighter.EventWeightWithBreakdown(ev)
+        assert len(bd.vertices) == len(ev.tree)
+        assert len(bd.vertices) >= 2, "one secondary generation must yield >=2 vertices"
+        for v in bd.vertices:
+            assert math.isfinite(v.generation)
+            assert math.isfinite(v.physical)
+            assert v.generation > 0.0
+            assert "generation density zero" not in v.flags
+            assert "outside physical support (weight 0)" not in v.flags

--- a/tests/python/test_breakdown_invariant.py
+++ b/tests/python/test_breakdown_invariant.py
@@ -173,9 +173,12 @@ def test_breakdown_vertices_cover_the_tree_with_no_flags():
 
     for ev in events:
         bd = weighter.EventWeightWithBreakdown(ev)
+        # One injector: the flat vertices list carries exactly the tree data,
+        # all tagged with injector_index 0.
         assert len(bd.vertices) == len(ev.tree)
         assert len(bd.vertices) >= 2, "one secondary generation must yield >=2 vertices"
         for v in bd.vertices:
+            assert v.injector_index == 0
             assert math.isfinite(v.generation)
             assert math.isfinite(v.physical)
             assert v.generation > 0.0

--- a/tests/python/test_density_breakdown.py
+++ b/tests/python/test_density_breakdown.py
@@ -7,11 +7,23 @@ weights[i] * channels[i].Density(record).  This is the surface the optimizer
 uses instead of re-evaluating every channel from Python.
 """
 import math
+import os
+
+import pytest
 
 import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
 
 PT = siren.dataclasses.ParticleType
 M_V1 = 0.017
+_NuMu = dc.Particle.ParticleType.NuMu
 
 
 def _make_record(m_chi=0.008, E_V1=0.030, vertex=(0.0, 0.0, 0.0)):
@@ -50,3 +62,127 @@ def test_density_breakdown_sums_to_density():
         assert sum(contribs) == g  # exact: same accumulation order as Density()
         for i, ch in enumerate(mc.channels):
             assert contribs[i] == mc.weights[i] * ch.Density(None, r)
+
+
+# --------------------------------------------------------------------------- #
+# VertexWeightFactors.channel_densities contract, as observed through a real  #
+# assembled Injector/Weighter pair (not the bare MultiChannelPhaseSpace above).#
+#                                                                              #
+# ComputeVertexFactors (Weighter.cxx) never writes into channel_densities on   #
+# any current code path: the DummyCrossSection assembly below has no vertex   #
+# backed by a MultiChannelPhaseSpace, so the field stays at its default-       #
+# constructed empty map for every vertex.  This test pins that observed        #
+# current contract -- a dict on every vertex, empty here -- rather than        #
+# asserting non-empty population that this assembly never produces.           #
+# --------------------------------------------------------------------------- #
+
+def _skip_unless_ccm_data():
+    """Skip only when the CCM detector data files are absent."""
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip(f"CCM detector model path unavailable: {e}")
+    missing = [p for p in (os.path.join(det_dir, "materials.dat"),
+                           os.path.join(det_dir, "densities.dat"))
+               if not os.path.exists(p)]
+    if missing:
+        pytest.skip("CCM detector data missing: " + ", ".join(missing))
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _build_chain(detector_model, n_inject, seed):
+    xs = interactions.DummyCrossSection()
+    int_col = interactions.InteractionCollection(_NuMu, [xs])
+
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = _NuMu
+    primary_inj.interactions = int_col
+    primary_inj.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+
+    primary_phys = injection.PhysicalProcess()
+    primary_phys.primary_type = _NuMu
+    primary_phys.interactions = int_col
+    primary_phys.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+
+    sec_xs = interactions.DummyCrossSection()
+    sec_col = interactions.InteractionCollection(_NuMu, [sec_xs])
+
+    sec_inj = injection.SecondaryInjectionProcess()
+    sec_inj.primary_type = _NuMu
+    sec_inj.interactions = sec_col
+    sec_inj.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+
+    sec_phys = injection.PhysicalProcess()
+    sec_phys.primary_type = _NuMu
+    sec_phys.interactions = sec_col
+    sec_phys.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+
+    rand = utilities.SIREN_random(seed)
+    inj = injection._Injector(n_inject, detector_model, primary_inj, [sec_inj], rand)
+    inj.SetStoppingCondition(lambda tree, datum, i: datum.depth(tree) >= 1)
+    weighter = injection._Weighter([inj], detector_model, primary_phys, [sec_phys])
+
+    keepalive = (xs, int_col, sec_xs, sec_col, primary_inj, primary_phys,
+                 sec_inj, sec_phys, rand)
+    return inj, weighter, keepalive
+
+
+def test_vertex_channel_densities_is_a_dict_and_finite_when_populated():
+    """VertexWeightFactors.channel_densities is a dict on every vertex; for the
+    data-free DummyCrossSection assembly (no MultiChannelPhaseSpace-backed
+    vertex) it is observed empty, and this test pins that no vertex ever
+    reports a non-finite or inconsistent value if it is ever populated."""
+    _skip_unless_ccm_data()
+    detector_model = _load_ccm_detector()
+    inj, weighter, _keepalive = _build_chain(detector_model, 2000, 2468)
+
+    events = []
+    for _ in range(2000):
+        if len(events) >= 20:
+            break
+        try:
+            ev = inj.GenerateEvent()
+        except RuntimeError as err:
+            if "maximum number of injection attempts" not in str(err):
+                raise
+            break
+        if len(ev.tree) == 0:
+            continue
+        events.append(ev)
+    assert len(events) == 20
+
+    saw_nonempty = False
+    for ev in events:
+        bd = weighter.EventWeightWithBreakdown(ev)
+        for v in bd.vertices:
+            cd = v.channel_densities
+            assert isinstance(cd, dict)
+            if cd:
+                saw_nonempty = True
+                values = list(cd.values())
+                assert all(math.isfinite(x) for x in values)
+
+    # Documents the current, observed contract for this assembly: the
+    # DummyCrossSection chain has no MultiChannelPhaseSpace-backed vertex, so
+    # ComputeVertexFactors never populates channel_densities.
+    assert saw_nonempty is False, (
+        "channel_densities was populated by this assembly; the "
+        "'observed empty' contract this test documents has changed and the "
+        "assertions above should be tightened to check the populated values.")

--- a/tests/python/test_density_breakdown.py
+++ b/tests/python/test_density_breakdown.py
@@ -144,11 +144,12 @@ def _build_chain(detector_model, n_inject, seed):
     return inj, weighter, keepalive
 
 
-def test_vertex_channel_densities_is_a_dict_and_finite_when_populated():
-    """VertexWeightFactors.channel_densities is a dict on every vertex; for the
-    data-free DummyCrossSection assembly (no MultiChannelPhaseSpace-backed
-    vertex) it is observed empty, and this test pins that no vertex ever
-    reports a non-finite or inconsistent value if it is ever populated."""
+def test_vertex_channel_densities_is_an_empty_dict_for_this_assembly():
+    """VertexWeightFactors.channel_densities is a dict on every vertex and stays
+    empty for the DummyCrossSection assembly, which has no
+    MultiChannelPhaseSpace-backed vertex. The finiteness check and the final
+    assertion form a tripwire: if a future change starts populating the map,
+    this test fails so the check can be tightened to the populated values."""
     _skip_unless_ccm_data()
     detector_model = _load_ccm_detector()
     inj, weighter, _keepalive = _build_chain(detector_model, 2000, 2468)

--- a/tests/python/test_failure_report.py
+++ b/tests/python/test_failure_report.py
@@ -1,0 +1,166 @@
+"""FailureReason/FailureLedger cross the pybind boundary and are filterable.
+
+FailureLedger.entries() keys on (depth, parent_pdg, FailureReason); reasons
+must be usable as dict keys/values (hashable, comparable) from Python, a
+fresh ledger must start empty, and a forced GenerateEvent failure must land
+in the ledger under its FailureReason so callers can filter by reason.
+"""
+from __future__ import annotations
+
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+# --------------------------------------------------------------------------- #
+# (a) FailureReason enum: importable, hashable, usable as a dict key           #
+# --------------------------------------------------------------------------- #
+
+def test_failure_reason_enum_members_present():
+    """All eight documented FailureReason members are importable."""
+    expected = [
+        "Unspecified", "NoPathThroughVolume", "NoTargetsOnPath",
+        "NoColumnDepthSolution", "KinematicallyForbidden",
+        "UnregisteredSecondaryType", "PrimaryVertexFailure", "TopLevelCatch",
+    ]
+    for name in expected:
+        assert hasattr(injection.FailureReason, name), (
+            f"siren.injection.FailureReason missing member {name!r}")
+
+
+def test_failure_reason_hashable_as_dict_key():
+    """FailureReason members compare and hash correctly as dict keys."""
+    d = {injection.FailureReason.NoTargetsOnPath: 1}
+    assert injection.FailureReason.NoTargetsOnPath in d
+    assert d[injection.FailureReason.NoTargetsOnPath] == 1
+    assert injection.FailureReason.NoTargetsOnPath != injection.FailureReason.TopLevelCatch
+    assert injection.FailureReason.TopLevelCatch == injection.FailureReason.TopLevelCatch
+
+
+# --------------------------------------------------------------------------- #
+# (b) A fresh injector's ledger/counts start empty                            #
+# --------------------------------------------------------------------------- #
+
+def _bare_primary_process(max_distance):
+    """A data-free DummyCrossSection primary process using
+    PointSourcePositionDistribution with the given max_distance. Returns
+    (process, keepalive).
+    """
+    xs = interactions.DummyCrossSection()
+    int_col = interactions.InteractionCollection(_NuMu, [xs])
+
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = _NuMu
+    primary_inj.interactions = int_col
+    primary_inj.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), max_distance),
+    ]
+    return primary_inj, (xs, int_col)
+
+
+def test_fresh_injector_ledger_and_counts_are_empty():
+    """A freshly constructed injector reports an empty ledger and empty
+    failure counts before any GenerateEvent call."""
+    dm = detector.DetectorModel()  # bare: no materials/sectors loaded
+    primary_inj, _keepalive = _bare_primary_process(max_distance=25.0)
+    rand = utilities.SIREN_random(11)
+    inj = injection._Injector(5, dm, primary_inj, [], rand)
+
+    assert inj.GetFailureLedger().entries() == {}
+    assert inj.GetFailureCounts() == {}
+
+
+# --------------------------------------------------------------------------- #
+# (c) A forced, data-free GenerateEvent failure lands in the ledger under its  #
+#     FailureReason, and entries are filterable by reason.                    #
+#                                                                              #
+# Forcing mechanism: PointSourcePositionDistribution with max_distance=0.0    #
+# clips the sampling path to a single point, so                              #
+# Path.GetInteractionDepthInBounds(...) == 0 unconditionally (no detector     #
+# materials required) and the distribution throws InjectionFailure tagged    #
+# FailureReason.NoTargetsOnPath. This needs no detector data files at all --  #
+# a bare, unloaded DetectorModel() is enough.                                #
+# --------------------------------------------------------------------------- #
+
+def _make_forced_failure_injector(seed=99, n_inject=5):
+    dm = detector.DetectorModel()  # bare: no materials/sectors loaded
+    primary_inj, keepalive = _bare_primary_process(max_distance=0.0)
+    rand = utilities.SIREN_random(seed)
+    inj = injection._Injector(n_inject, dm, primary_inj, [], rand)
+    return inj, (dm, primary_inj, rand) + keepalive
+
+
+def test_forced_failure_populates_ledger_with_reason():
+    """A forced NoTargetsOnPath failure appears in the ledger keyed by that
+    FailureReason, with a positive count and a non-empty exemplar message."""
+    inj, _keepalive = _make_forced_failure_injector()
+
+    ev = inj.GenerateEvent()
+    assert len(ev.tree) == 0, "forced failure must yield an empty tree"
+
+    entries = inj.GetFailureLedger().entries()
+    assert len(entries) == 1
+    (depth, parent_pdg, reason), (count, exemplar) = next(iter(entries.items()))
+    assert reason == injection.FailureReason.NoTargetsOnPath
+    assert depth == 0
+    assert count >= 1
+    assert isinstance(exemplar, str) and len(exemplar) > 0
+
+
+def test_forced_failure_repeated_aggregates_count_not_entries():
+    """Repeating the same forced failure increments the existing entry's
+    count rather than adding new entries (aggregated accounting)."""
+    inj, _keepalive = _make_forced_failure_injector(n_inject=4)
+
+    for _ in range(4):
+        ev = inj.GenerateEvent()
+        assert len(ev.tree) == 0
+
+    entries = inj.GetFailureLedger().entries()
+    assert len(entries) == 1
+    (_, _, reason), (count, _) = next(iter(entries.items()))
+    assert reason == injection.FailureReason.NoTargetsOnPath
+    assert count == 4
+
+    # Backward-compat aggregation still works off the same ledger.
+    counts = inj.GetFailureCounts()
+    assert sum(counts.values()) == 4
+
+
+def test_ledger_entries_filterable_by_reason():
+    """Entries can be filtered down to a single FailureReason, as a caller
+    building a per-reason report would do."""
+    inj, _keepalive = _make_forced_failure_injector(n_inject=3)
+
+    for _ in range(3):
+        inj.GenerateEvent()
+
+    entries = inj.GetFailureLedger().entries()
+    matching = {k: v for k, v in entries.items()
+                if k[2] == injection.FailureReason.NoTargetsOnPath}
+    not_matching = {k: v for k, v in entries.items()
+                    if k[2] == injection.FailureReason.TopLevelCatch}
+
+    assert len(matching) == 1
+    assert len(not_matching) == 0
+
+
+def test_ledger_clear_resets_to_empty():
+    """FailureLedger.Clear() empties the live ledger held by the injector."""
+    inj, _keepalive = _make_forced_failure_injector(n_inject=2)
+
+    inj.GenerateEvent()
+    assert inj.GetFailureLedger().entries() != {}
+
+    inj.GetFailureLedger().Clear()
+    assert inj.GetFailureLedger().entries() == {}


### PR DESCRIPTION
Stacks on `pr/fail-loud-hardening` (Phase 1). Pure diagnostics: no physics change, the golden regression archive is untouched.

## FailureLedger
Replaces the per-pdg `failure_counts_` map with a `FailureLedger` that aggregates failures keyed by `(depth, parent_pdg, FailureReason)`, holding a count and a first-seen exemplar per key. Storage and per-record cost are O(distinct reasons). It is transient and never serialized. `GetFailureCounts()`/`GetLastFailureReason()` remain as deprecated shims: the signatures are unchanged, but `GetFailureCounts()` key semantics differ from the old map -- counts are keyed by the parent PDG of the failing vertex (primary failures under the primary PDG; the old `-1` sentinel is gone) and non-fatal skips are excluded. This API had no in-tree callers; new code should use `GetFailureLedger()`; a new `GetFailureLedger()` exposes the structured view, and `FailureLedger.entries()` crosses pybind as a dict `{(depth, pdg, FailureReason): (count, exemplar)}`.

## Reason enums
`FailureReason { Unspecified, NoPathThroughVolume, NoTargetsOnPath, NoColumnDepthSolution, KinematicallyForbidden, UnregisteredSecondaryType, PrimaryVertexFailure, TopLevelCatch }` is attached to `InjectionFailure` via a new reason ctor plus accessor (existing throws default to `Unspecified`). The eight identical "No available interactions along path!" throws in the vertex distributions now tag a distinct reason. `GenerateEvent` records the primary failure (with a partial tree, previously never set on primary failure), unregistered secondary types, per-secondary failures, and the top-level catch.

## EventWeightBreakdown (single code path)
`Weighter::EventWeightWithBreakdown(tree)` returns per-vertex `VertexWeightFactors` (generation, physical, interaction/position probabilities, flags) plus a total. Both `EventWeight` and the breakdown consume one `ComputeVertexFactors` helper, so the gauge cannot diverge from the weight. Flag polarity matches the Phase 1 guard: a zero-or-non-finite generation is the error path (`EventWeight` throws, the breakdown flags it and sets total NaN), while a zero physical is a legitimate zero-weight event (both agree on 0.0). The invariant `breakdown.total == EventWeight(tree)` is pinned in a data-free Python test over the assembled multi-vertex chain and in the CCM_HNL C++ fixture.

## Tests
- `Injector_TEST.cxx`: FailureLedger aggregation/exemplar-once unit test; a forced primary failure records the tagged reason and a non-empty partial tree, and reset clears the ledger.
- `CCM_HNL_TEST.cxx` + new `CCM_HNL_Fixture.h`: the breakdown/EventWeight equality invariant.
- `tests/python/test_failure_report.py`: the ledger dict crosses pybind and is filterable by the reason enum.
- `tests/python/test_breakdown_invariant.py`: the total-equals-EventWeight invariant over the assembled chain.
- `tests/python/test_density_breakdown.py`: extended to pin the per-vertex `channel_densities` contract.
- `tests/python/test_golden_regression.py`: unchanged and green.
