### PR TITLE
Phase 3: spec vocabulary + Layer-2 Injector/Weighter rework

### DIFF
--- a/projects/geometry/private/pybindings/geometry.cxx
+++ b/projects/geometry/private/pybindings/geometry.cxx
@@ -1,4 +1,5 @@
 
+#include <array>
 #include <vector>
 
 #include "../../public/SIREN/geometry/Placement.h"
@@ -92,7 +93,21 @@ PYBIND11_MODULE(geometry,m) {
 
     class_<Box, std::shared_ptr<Box>, Geometry>(m, "Box")
         .def(init<>())
-        .def(init<double, double, double>())
+        // Positional Box(x, y, z) places the box at the ORIGIN, which reads as
+        // a size-only constructor and silently drops the intended center. Warn
+        // and keep the origin placement; the hard error lands once callers move
+        // to the widths/center form.
+        .def(init([](double x, double y, double z) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                "Box(x, y, z) places the box at the ORIGIN; pass "
+                "Box(widths=(x, y, z), center=(cx, cy, cz))",
+                1);
+            return std::make_shared<Box>(x, y, z);
+        }))
+        .def(init([](std::array<double, 3> widths, std::array<double, 3> center) {
+            Placement placement(siren::math::Vector3D(center[0], center[1], center[2]));
+            return std::make_shared<Box>(placement, widths[0], widths[1], widths[2]);
+        }), arg("widths"), arg("center") = std::array<double, 3>{0.0, 0.0, 0.0})
         .def(init<Placement const &>())
         .def(init<Placement const &, double, double, double>())
         .def(init<const Box&>())

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -116,6 +116,27 @@ void Weighter::Initialize() {
     }
 }
 
+// Fills the observation-only channel_densities and cancelled fields. The
+// per-channel generation densities come from the injection process's mixture
+// for this signature (empty when the vertex has no phase space); cancelled
+// lists the shared distributions removed from both sides of the weight ratio.
+// Never consumed by the weight itself.
+template<typename ProcessPtr>
+static void RecordMixtureDiagnostics(VertexWeightFactors & factors,
+        ProcessPtr const & inj_process,
+        std::vector<std::string> const & cancelled_names,
+        siren::dataclasses::InteractionRecord const & record,
+        std::shared_ptr<siren::detector::DetectorModel> const & detector_model) {
+    factors.cancelled = cancelled_names;
+    if(inj_process && inj_process->HasPhaseSpace(record.signature)) {
+        auto ps = inj_process->GetPhaseSpace(record.signature);
+        std::vector<double> contributions = ps->DensityBreakdown(detector_model, record);
+        for(std::size_t c = 0; c < contributions.size(); ++c) {
+            factors.channel_densities["channel[" + std::to_string(c) + "]"] = contributions[c];
+        }
+    }
+}
+
 // Computes one tree datum's physical and generation factors for injector idx,
 // via the same ProcessWeighter calls EventWeight consumes. depth is left at
 // its default for non-root data; the caller fills it in from the owning tree.
@@ -135,6 +156,10 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
         if(with_diagnostics) {
             factors.interaction_prob = primary_process_weighters[idx]->InteractionProbability(bounds, datum->record);
             factors.position_prob = primary_process_weighters[idx]->NormalizedPositionProbability(bounds, datum->record);
+            RecordMixtureDiagnostics(factors,
+                injectors[idx]->GetPrimaryProcess(),
+                primary_process_weighters[idx]->GetCancelledDistributionNames(),
+                datum->record, detector_model);
         }
     } else {
         try {
@@ -145,6 +170,10 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
             if(with_diagnostics) {
                 factors.interaction_prob = w->InteractionProbability(bounds, datum->record);
                 factors.position_prob = w->NormalizedPositionProbability(bounds, datum->record);
+                RecordMixtureDiagnostics(factors,
+                    injectors[idx]->GetSecondaryProcessMap().at(datum->record.signature.primary_type),
+                    w->GetCancelledDistributionNames(),
+                    datum->record, detector_model);
             }
         } catch(const std::out_of_range& oor) {
             std::ostringstream oss;

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -411,6 +411,7 @@ PYBIND11_MODULE(injection,m) {
     .def_property("distributions", &PhysicalProcess::GetPhysicalDistributions, &PhysicalProcess::SetPhysicalDistributions)
     .def("SetPhaseSpace", &PhysicalProcess::SetPhaseSpace)
     .def("GetPhaseSpace", &PhysicalProcess::GetPhaseSpace)
+    .def("GetPhaseSpaceMap", &PhysicalProcess::GetPhaseSpaceMap)
     .def("HasPhaseSpace", overload_cast<siren::dataclasses::InteractionSignature const &>(&PhysicalProcess::HasPhaseSpace, const_))
     .def("HasAnyPhaseSpace", &PhysicalProcess::HasAnyPhaseSpace)
     .def("SetWeightingMode", &PhysicalProcess::SetWeightingMode)

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -45,6 +45,10 @@ private:
     std::shared_ptr<ProcessType> inj_process;
     std::vector<std::shared_ptr<typename ProcessType::InjectionType>> unique_gen_distributions;
     std::vector<std::shared_ptr<siren::distributions::WeightableDistribution>> unique_phys_distributions;
+    // Names of the injection/physical distributions that matched by operator==
+    // and were removed from both unique_* sets because they cancel in the weight
+    // ratio. Observation-only; recorded once at Initialize().
+    std::vector<std::string> cancelled_distribution_names;
     std::shared_ptr<siren::detector::DetectorModel> detector_model;
     std::vector<std::shared_ptr<typename ProcessType::InjectionType>> const & GetInjectionDistributions();
     void Initialize();
@@ -56,6 +60,8 @@ public:
     double PhysicalProbability(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionRecord const & record) const;
     double GenerationProbability(siren::dataclasses::InteractionTreeDatum const & datum) const;
     double EventWeight(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionTreeDatum const & datum) const;
+    std::vector<std::string> const & GetCancelledDistributionNames() const { return cancelled_distribution_names; }
+    std::shared_ptr<ProcessType> GetInjectionProcess() const { return inj_process; }
     ProcessWeighter(std::shared_ptr<siren::injection::PhysicalProcess> phys_process, std::shared_ptr<ProcessType> inj_process, std::shared_ptr<siren::detector::DetectorModel> detector_model);
 
 }; // ProcessWeighter

--- a/projects/injection/public/SIREN/injection/Weighter.tcc
+++ b/projects/injection/public/SIREN/injection/Weighter.tcc
@@ -82,11 +82,13 @@ void ProcessWeighter<ProcessType>::Initialize() {
     }
     unique_gen_distributions = GetInjectionDistributions();
     unique_phys_distributions = phys_process->GetPhysicalDistributions();
+    cancelled_distribution_names.clear();
     for(typename std::vector<std::shared_ptr<typename ProcessType::InjectionType>>::reverse_iterator gen_it = unique_gen_distributions.rbegin();
             gen_it != unique_gen_distributions.rend(); ++gen_it) {
         for(std::vector<std::shared_ptr<siren::distributions::WeightableDistribution>>::reverse_iterator phys_it = unique_phys_distributions.rbegin();
                 phys_it != unique_phys_distributions.rend(); ++phys_it) {
             if((*gen_it) == (*phys_it)) {
+                cancelled_distribution_names.push_back((*gen_it)->Name());
                 unique_gen_distributions.erase(std::next(gen_it).base());
                 unique_phys_distributions.erase(std::next(phys_it).base());
                 break;

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -333,21 +333,28 @@ class Injector:
         if max_attempts is None:
             max_attempts = events * 1000
 
+        # Give the efficiency estimate a minimum sample before it can abort, so
+        # an unlucky early run is not cut short.
+        min_efficiency_warmup = 50
+
         trees = []
         attempts = 0
         while len(trees) < events and attempts < max_attempts:
             attempts += 1
             try:
                 tree = self.__injector.GenerateEvent()
-            except RuntimeError:
-                # The engine raises once its own attempt quota is exhausted.
-                break
+            except RuntimeError as err:
+                # The engine raises once its own attempt quota is exhausted;
+                # any other error is a real fault and must not be swallowed.
+                if "maximum number of injection attempts" in str(err):
+                    break
+                raise
             if len(tree.tree) == 0:
                 continue
             trees.append(tree)
             if progress is not None:
                 progress(len(trees), events)
-            if (min_efficiency is not None and attempts >= 50
+            if (min_efficiency is not None and attempts >= min_efficiency_warmup
                     and (len(trees) / attempts) < min_efficiency):
                 report = self.report()
                 message = (

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -290,9 +290,13 @@ class Injector:
                             secondary_processes, validation_random):
         """Run the detector-dependent ValidateChannelDensities probe.
 
-        Only mixtures actually registered on a process are probed; a probe
-        failure surfaces a sampler/density mismatch before any event is drawn.
+        Only mixtures actually registered on a process are probed. A measure
+        incompatibility is a real configuration error and propagates; a probe
+        that simply cannot run on the synthetic template (unsolvable kinematics,
+        missing target mass) is skipped -- the config-time Mixture.validate()
+        already screened measures without a detector.
         """
+        measure_error = _utilities.MeasureCompatibilityError
         processes = [primary_process] + list(secondary_processes)
         for process in processes:
             ps_map = process.GetPhaseSpaceMap()
@@ -300,10 +304,9 @@ class Injector:
                 try:
                     _validation.probe_channel_densities(
                         mcps, sig, self.__detector_model, validation_random)
-                except (ValueError, TypeError):
-                    # A probe that cannot run data-free (missing target mass,
-                    # unconvertible template) is not a configuration error; the
-                    # config-time Mixture.validate() already screened measures.
+                except measure_error:
+                    raise
+                except (ValueError, TypeError, RuntimeError):
                     continue
 
     def __initialize_injector(self):

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -7,7 +7,8 @@ from . import interactions as _interactions
 from . import distributions as _distributions
 from . import injection as _injection
 
-import collections
+import json
+import warnings
 from functools import wraps
 
 from typing import Tuple, List, Dict, Optional, Union, Callable
@@ -28,7 +29,23 @@ SecondaryInjectionDistribution = _distributions.SecondaryInjectionDistribution
 SecondaryInjectionProcess = _injection.SecondaryInjectionProcess
 InteractionTreeDatum = _dataclasses.InteractionTreeDatum
 
+
 class Injector:
+    """Biased-sampling injector.
+
+    Two authoring surfaces compile to one engine configuration:
+
+    * the spec form ``Injector(detector=..., primary=Vertex(...),
+      secondaries=(...), events=N)`` builds each process from a Vertex; and
+    * the legacy keyword form (``number_of_events``, ``primary_type``,
+      ``primary_interactions``, the four ``secondary_*`` dicts,
+      ``stopping_condition``) is compiled through the same validation and
+      assembly path -- a translation shim, not a parallel code path.
+
+    ``generate(events)`` counts successful trees; ``report()`` renders the
+    engine failure ledger; ``engine`` exposes the raw C++ injector.
+    """
+
     def __init__(
         self,
         number_of_events: Optional[int] = None,
@@ -38,12 +55,18 @@ class Injector:
         primary_interactions: List[Union[_interactions.CrossSection, _interactions.Decay]] = None,
         primary_injection_distributions: List[_distributions.PrimaryInjectionDistribution] = None,
         primary_phase_spaces: Optional[Dict[_dataclasses.InteractionSignature, _injection.MultiChannelPhaseSpace]] = None,
-        primary_weighting_mode = None,
+        primary_weighting_mode=None,
         secondary_interactions: Optional[Dict[_dataclasses.ParticleType, List[Union[_interactions.CrossSection, _interactions.Decay]]]] = None,
         secondary_injection_distributions: Optional[Dict[_dataclasses.ParticleType, List[_distributions.SecondaryInjectionDistribution]]] = None,
         secondary_phase_spaces: Optional[Dict[_dataclasses.ParticleType, Dict[_dataclasses.InteractionSignature, _injection.MultiChannelPhaseSpace]]] = None,
         secondary_weighting_modes: Optional[Dict[_dataclasses.ParticleType, object]] = None,
         stopping_condition: Optional[Callable[[_dataclasses.InteractionTree, _dataclasses.InteractionTreeDatum, int], bool]] = None,
+        *,
+        detector: Optional[_detector.DetectorModel] = None,
+        primary=None,
+        secondaries=(),
+        events: Optional[int] = None,
+        max_attempts: Optional[int] = None,
     ):
         self.__seed = None
         self.__number_of_events = 0
@@ -62,6 +85,21 @@ class Injector:
         self.__stopping_condition = None
 
         self.__injector = None
+
+        # Spec-form fields (Vertex-based authoring).
+        self.__primary_vertex = None
+        self.__secondary_vertices = []
+        self.__primary_compiled_process = None
+        self.__secondary_compiled_processes = {}
+        self.__max_attempts = max_attempts
+
+        # Strong references to Python models/distributions/mixtures so their
+        # pybind trampolines survive gc while the compiled processes hold them.
+        self.__keepalive = []
+
+        detector_model = detector_model if detector_model is not None else detector
+        if events is not None:
+            number_of_events = events
 
         if seed is not None:
             self.__seed = seed
@@ -90,13 +128,36 @@ class Injector:
         if stopping_condition is not None:
             self.__stopping_condition = stopping_condition
 
+        if primary is not None:
+            self.__primary_vertex = primary
+            self.__secondary_vertices = list(secondaries)
 
-    def __initialize_injector(self):
+    # ------------------------------------------------------------------ #
+    #  Build (single validation choke point)                              #
+    # ------------------------------------------------------------------ #
+
+    def _build(self):
+        """Validate the configuration and construct the engine injector.
+
+        Every path -- spec Vertices or legacy kwargs -- lands here. It resolves
+        the RNG streams, compiles processes, checks the injection
+        distributions, expand wiring, per-signature name resolution and mixture
+        measures, runs the detector-dependent channel-density probe, and builds
+        the C++ injector.
+        """
+        from . import _validation
+        from . import expand as _expand
+        from . import errors as _errors
+
         if self.__seed is None:
             random = _utilities.SIREN_random()
             self.__seed = random.get_seed()
         else:
             random = _utilities.SIREN_random(self.__seed)
+        # An independent stream for config-time validation probes, so a probe
+        # draw never perturbs the generation stream. The seed is masked to the
+        # 32-bit range the RNG constructor accepts.
+        validation_random = _utilities.SIREN_random(int(self.__seed) & 0x7FFFFFFF)
 
         if self.__number_of_events is None:
             raise ValueError("number_of_events must be provided")
@@ -106,54 +167,42 @@ class Injector:
         if self.__detector_model is None:
             raise ValueError("detector_model must be provided")
 
+        if self.__primary_vertex is not None:
+            self._compile_from_vertices(_validation, _expand)
+
         if self.__primary_type is None:
             raise ValueError("primary_type must be provided")
-
         if len(self.__primary_interactions) == 0:
             raise ValueError("primary_interactions must be provided")
-
         if len(self.__primary_injection_distributions) == 0:
             raise ValueError("primary_injection_distributions must be provided")
 
-        if list(sorted(self.__secondary_interactions.keys())) != list(sorted(self.__secondary_injection_distributions.keys())):
-            raise ValueError("secondary_interactions and secondary_injection_distributions must have the same keys")
+        _validation.validate_injection_distributions(
+            self.__primary_injection_distributions)
 
-        primary_type = self.primary_type
-        primary_interaction_collection = _interactions.InteractionCollection(
-            primary_type, self.primary_interactions
+        # Cross-key validation of every secondary-keyed dict (a typo'd key in
+        # any of the four dicts raises here rather than silently vanishing).
+        _validation.validate_secondary_keys(
+            ("secondary_interactions", self.__secondary_interactions),
+            ("secondary_injection_distributions", self.__secondary_injection_distributions),
+            ("secondary_phase_spaces", self.__secondary_phase_spaces),
+            ("secondary_weighting_modes", self.__secondary_weighting_modes),
         )
-        primary_process = _injection.PrimaryInjectionProcess(
-            primary_type, primary_interaction_collection
-        )
-        primary_process.distributions = self.primary_injection_distributions
-        for sig, ps in self.__primary_phase_spaces.items():
-            primary_process.SetPhaseSpace(sig, ps)
-        if self.__primary_weighting_mode is not None:
-            primary_process.weighting_mode = self.__primary_weighting_mode
+        if sorted(self.__secondary_interactions.keys()) != sorted(
+                self.__secondary_injection_distributions.keys()):
+            raise ValueError(
+                "secondary_interactions and secondary_injection_distributions "
+                "must have the same keys")
 
-        secondary_interactions = self.secondary_interactions
-        secondary_injection_distributions = self.secondary_injection_distributions
+        primary_process = self._assemble_primary_process()
+        secondary_processes = self._assemble_secondary_processes()
 
-        secondary_interaction_collections = []
-        secondary_processes = []
-        for secondary_type, secondary_interactions in secondary_interactions.items():
-            secondary_interaction_collection = _interactions.InteractionCollection(
-                secondary_type, secondary_interactions
-            )
-            secondary_process = SecondaryInjectionProcess(
-                secondary_type, secondary_interaction_collection
-            )
-            secondary_process.distributions = secondary_injection_distributions[secondary_type]
-            if secondary_type in self.__secondary_phase_spaces:
-                for sig, ps in self.__secondary_phase_spaces[secondary_type].items():
-                    secondary_process.SetPhaseSpace(sig, ps)
-            if secondary_type in self.__secondary_weighting_modes:
-                secondary_process.weighting_mode = self.__secondary_weighting_modes[secondary_type]
-            secondary_processes.append(secondary_process)
+        self._probe_phase_spaces(
+            _validation, primary_process, secondary_processes, validation_random)
 
         self.__injector = _Injector(
-            self.number_of_events,
-            self.detector_model,
+            self.__number_of_events,
+            self.__detector_model,
             primary_process,
             secondary_processes,
             random,
@@ -162,19 +211,348 @@ class Injector:
         if self.__stopping_condition is not None:
             self.__injector.SetStoppingCondition(self.__stopping_condition)
 
-    # Custom method to retrieve the internal state for pickling
+    def _compile_from_vertices(self, _validation, _expand):
+        """Translate spec Vertices into the legacy field storage.
+
+        The compiled processes and their distributions/phase spaces are read
+        back into the same private fields the legacy path populates, so a
+        single assembly path serves both surfaces.
+        """
+        from . import errors as _errors
+        if self.__stopping_condition is not None:
+            _validation.check_expand_vs_legacy_stopping(True, True)
+
+        primary = self.__primary_vertex
+        self.__keepalive.append(primary)
+        self.__primary_type = primary._resolved_particle
+        self.__primary_interactions = list(primary.interactions)
+        self.__primary_injection_distributions = list(primary.distributions)
+
+        specs = [primary.as_vertex_spec()]
+        for sv in self.__secondary_vertices:
+            self.__keepalive.append(sv)
+            ptype = sv._resolved_particle
+            self.__secondary_interactions[ptype] = list(sv.interactions)
+            self.__secondary_injection_distributions[ptype] = list(sv.distributions)
+            specs.append(sv.as_vertex_spec())
+
+        if self.__secondary_vertices:
+            _validation.validate_expansion_wiring(specs)
+            self.__stopping_condition = _expand.compile_expansion(specs)
+
+        # Compile per-signature phase spaces from each Vertex's kinematics.
+        primary_process = primary.compile(
+            is_primary=True, detector=self.__detector_model)
+        self.__primary_compiled_process = primary_process
+        self.__secondary_compiled_processes = {}
+        for sv in self.__secondary_vertices:
+            proc = sv.compile(is_primary=False, detector=self.__detector_model)
+            self.__secondary_compiled_processes[sv._resolved_particle] = proc
+
+    def _assemble_primary_process(self):
+        if self.__primary_compiled_process is not None:
+            return self.__primary_compiled_process
+        primary_interaction_collection = _interactions.InteractionCollection(
+            self.__primary_type, self.__primary_interactions)
+        primary_process = _injection.PrimaryInjectionProcess(
+            self.__primary_type, primary_interaction_collection)
+        primary_process.distributions = self.__primary_injection_distributions
+        for sig, ps in self.__primary_phase_spaces.items():
+            primary_process.SetPhaseSpace(sig, ps)
+        if self.__primary_weighting_mode is not None:
+            primary_process.weighting_mode = self.__primary_weighting_mode
+        return primary_process
+
+    def _assemble_secondary_processes(self):
+        if self.__secondary_compiled_processes:
+            return list(self.__secondary_compiled_processes.values())
+        secondary_processes = []
+        for secondary_type, sec_ints in self.__secondary_interactions.items():
+            secondary_interaction_collection = _interactions.InteractionCollection(
+                secondary_type, sec_ints)
+            secondary_process = SecondaryInjectionProcess(
+                secondary_type, secondary_interaction_collection)
+            secondary_process.distributions = (
+                self.__secondary_injection_distributions[secondary_type])
+            if secondary_type in self.__secondary_phase_spaces:
+                for sig, ps in self.__secondary_phase_spaces[secondary_type].items():
+                    secondary_process.SetPhaseSpace(sig, ps)
+            if secondary_type in self.__secondary_weighting_modes:
+                secondary_process.weighting_mode = (
+                    self.__secondary_weighting_modes[secondary_type])
+            secondary_processes.append(secondary_process)
+        return secondary_processes
+
+    def _probe_phase_spaces(self, _validation, primary_process,
+                            secondary_processes, validation_random):
+        """Run the detector-dependent ValidateChannelDensities probe.
+
+        Only mixtures actually registered on a process are probed; a probe
+        failure surfaces a sampler/density mismatch before any event is drawn.
+        """
+        processes = [primary_process] + list(secondary_processes)
+        for process in processes:
+            ps_map = process.GetPhaseSpaceMap()
+            for sig, mcps in ps_map.items():
+                try:
+                    _validation.probe_channel_densities(
+                        mcps, sig, self.__detector_model, validation_random)
+                except (ValueError, TypeError):
+                    # A probe that cannot run data-free (missing target mass,
+                    # unconvertible template) is not a configuration error; the
+                    # config-time Mixture.validate() already screened measures.
+                    continue
+
+    def __initialize_injector(self):
+        self._build()
+
+    # ------------------------------------------------------------------ #
+    #  Generation                                                          #
+    # ------------------------------------------------------------------ #
+
+    def generate(self, events=None, *, on_shortfall="warn", progress=None,
+                 min_efficiency=None):
+        """Generate `events` successful trees.
+
+        Retries failed ``GenerateEvent`` calls (never yields an empty tree) up
+        to ``max_attempts`` (default ``events * 1000``). Counts SUCCESSES, not
+        attempts. ``min_efficiency`` aborts early if the success rate falls
+        below it. On shortfall, ``on_shortfall`` chooses ``'warn'`` (default),
+        ``'raise'``, or ``'ignore'``, carrying an InjectionReport.
+        """
+        from . import errors as _errors
+
+        if self.__injector is None:
+            self._build()
+        if events is None:
+            events = self.__number_of_events
+        if events <= 0:
+            raise ValueError("events must be positive")
+
+        max_attempts = self.__max_attempts
+        if max_attempts is None:
+            max_attempts = events * 1000
+
+        trees = []
+        attempts = 0
+        while len(trees) < events and attempts < max_attempts:
+            attempts += 1
+            try:
+                tree = self.__injector.GenerateEvent()
+            except RuntimeError:
+                # The engine raises once its own attempt quota is exhausted.
+                break
+            if len(tree.tree) == 0:
+                continue
+            trees.append(tree)
+            if progress is not None:
+                progress(len(trees), events)
+            if (min_efficiency is not None and attempts >= 50
+                    and (len(trees) / attempts) < min_efficiency):
+                report = self.report()
+                message = (
+                    "injection efficiency {:.2%} fell below min_efficiency "
+                    "{:.2%} after {} attempts ({} succeeded)".format(
+                        len(trees) / attempts, min_efficiency, attempts,
+                        len(trees)))
+                self._handle_shortfall(on_shortfall, message, report, _errors)
+                return trees
+
+        if len(trees) < events:
+            report = self.report()
+            message = (
+                "requested {} events but only {} succeeded in {} attempts"
+                .format(events, len(trees), attempts))
+            self._handle_shortfall(on_shortfall, message, report, _errors)
+        return trees
+
+    def _handle_shortfall(self, on_shortfall, message, report, _errors):
+        if on_shortfall == "ignore":
+            return
+        if on_shortfall == "raise":
+            raise _errors.InjectionShortfall(message, report=report)
+        if on_shortfall == "warn":
+            warnings.warn(_errors.InjectionShortfall(message, report=report))
+            return
+        raise ValueError(
+            "on_shortfall must be 'warn', 'raise', or 'ignore', got {!r}"
+            .format(on_shortfall))
+
+    def reset(self, events=None):
+        """Reset the injected/attempt counters and failure ledger.
+
+        With ``events`` given, also change the target count.
+        """
+        if self.__injector is None:
+            if events is not None:
+                self.__number_of_events = events
+            return
+        if events is not None:
+            self.__injector.ResetInjectedEvents(events)
+            self.__number_of_events = events
+        else:
+            self.__injector.ResetInjectedEvents()
+
+    def report(self):
+        """Render the engine failure ledger as an InjectionReport."""
+        from .report import InjectionReport
+        if self.__injector is None:
+            return InjectionReport(0, 0, [], None)
+        ledger = self.__injector.GetFailureLedger()
+        attempts = self.__injector.InjectionAttempts()
+        successes = self.__injector.InjectedEvents()
+        last_tree = self.__injector.GetLastFailedTree()
+        return InjectionReport.from_ledger(
+            ledger, attempts=attempts, successes=successes,
+            last_failed_tree=last_tree)
+
+    # ------------------------------------------------------------------ #
+    #  Optimizer tuning I/O                                                #
+    # ------------------------------------------------------------------ #
+
+    def export_tuning(self, path=None):
+        """Return (and optionally write) each mixture's channel weights.
+
+        The result maps a stable mixture index to its weight list, so a tuned
+        run's channel weights can be reloaded via apply_tuning().
+        """
+        if self.__injector is None:
+            self._build()
+        tuning = {}
+        for i, mcps in enumerate(self.__injector.GetPhaseSpaces()):
+            tuning[str(i)] = list(mcps.weights)
+        if path is not None:
+            with open(path, "w") as f:
+                json.dump(tuning, f)
+        return tuning
+
+    def apply_tuning(self, dict_or_path):
+        """Set each mixture's channel weights from a dict or a JSON path."""
+        if self.__injector is None:
+            self._build()
+        if isinstance(dict_or_path, str):
+            with open(dict_or_path) as f:
+                tuning = json.load(f)
+        else:
+            tuning = dict_or_path
+        mixtures = self.__injector.GetPhaseSpaces()
+        for key, weights in tuning.items():
+            idx = int(key)
+            if idx < len(mixtures):
+                mixtures[idx].weights = list(weights)
+                mixtures[idx].Normalize()
+
+    # ------------------------------------------------------------------ #
+    #  Introspection                                                       #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def engine(self):
+        """The raw C++ injector, building it on first access."""
+        if self.__injector is None:
+            self._build()
+        return self.__injector
+
+    def describe(self):
+        """A short human-readable description of the configuration."""
+        lines = ["Injector(events={}, primary={})".format(
+            self.__number_of_events, self.__primary_type)]
+        if self.__secondary_interactions:
+            lines.append("  secondaries: {}".format(
+                sorted(str(k) for k in self.__secondary_interactions)))
+        return "\n".join(lines)
+
+    def to_dict(self):
+        """A plain-dict snapshot of the configuration counts."""
+        return {
+            "events": self.__number_of_events,
+            "seed": self.__seed,
+            "primary_type": str(self.__primary_type),
+            "secondary_types": [str(k) for k in self.__secondary_interactions],
+        }
+
+    def save(self, filename):
+        """Serialize the injector, refusing configurations that cannot survive.
+
+        The engine archives processes but not their weighting mode or phase
+        space map, and it cannot serialize Python trampoline-derived
+        interactions/distributions. Either would silently reload with the wrong
+        physics, so both raise NotSerializableError instead.
+        """
+        from . import errors as _errors
+        if self.__injector is None:
+            self._build()
+        self._guard_serializable(_errors)
+        self.__injector.SaveInjector(filename)
+
+    def _guard_serializable(self, _errors):
+        offenders = []
+        primary = self.__injector.GetPrimaryProcess()
+        processes = [primary] + list(self.__injector.GetSecondaryProcessMap().values())
+        propagated = _injection.VertexWeightingMode.Propagated()
+        for process in processes:
+            mode = process.GetWeightingMode()
+            if (mode.compute_interaction_probability
+                    != propagated.compute_interaction_probability
+                    or mode.compute_position_probability
+                    != propagated.compute_position_probability):
+                offenders.append(
+                    "process {} uses a non-Propagated weighting mode "
+                    "(not archived)".format(process.primary_type))
+            if process.HasAnyPhaseSpace():
+                offenders.append(
+                    "process {} carries a phase space map (not archived)"
+                    .format(process.primary_type))
+        for interaction in self.__primary_interactions:
+            if _is_trampoline(interaction):
+                offenders.append(
+                    "primary interaction {!r} is a Python subclass (not "
+                    "serializable)".format(type(interaction).__name__))
+        for dist in self.__primary_injection_distributions:
+            if _is_trampoline(dist):
+                offenders.append(
+                    "primary distribution {!r} is a Python subclass (not "
+                    "serializable)".format(type(dist).__name__))
+        if offenders:
+            raise _errors.NotSerializableError(
+                "this injector cannot be saved without silently changing "
+                "physics on reload:\n  - " + "\n  - ".join(offenders),
+                offenders=offenders)
+
+    @classmethod
+    def load(cls, filename):
+        """Construct an Injector from a saved archive."""
+        obj = cls()
+        obj.__injector = _Injector.__new__(_Injector)
+        obj.__injector.LoadInjector(filename)
+        obj.__number_of_events = obj.__injector.EventsToInject()
+        obj.__detector_model = obj.__injector.GetDetectorModel()
+        primary_process = obj.__injector.GetPrimaryProcess()
+        obj.__primary_type = primary_process.primary_type
+        obj.__primary_interactions = list(
+            primary_process.interactions.GetCrossSections()) + list(
+            primary_process.interactions.GetDecays())
+        obj.__primary_injection_distributions = list(primary_process.distributions)
+        obj.__secondary_interactions = {}
+        obj.__secondary_injection_distributions = {}
+        for stype, sproc in obj.__injector.GetSecondaryProcessMap().items():
+            obj.__secondary_interactions[stype] = list(
+                sproc.interactions.GetCrossSections()) + list(
+                sproc.interactions.GetDecays())
+            obj.__secondary_injection_distributions[stype] = list(sproc.distributions)
+        return obj
+
+    # ------------------------------------------------------------------ #
+    #  Pickling                                                            #
+    # ------------------------------------------------------------------ #
+
     def __getstate__(self):
-        # The seed and stopping condition are the only things we cannot serialize
         state = (self.__seed, self.__stopping_condition, self.__injector.__getstate__())
         return state
 
-    # Custom method to restore the state from a pickle
     def __setstate__(self, state):
-
         self.__seed, self.__stopping_condition, injector_state = state
-
-        # Create a new instance of the C++ class and restore its state
-        self.__injector = _Injector.__new__(_Injector)  # Create an empty instance
+        self.__injector = _Injector.__new__(_Injector)
         if self.__injector is None:
             raise TypeError("Failed to create C++ Injector object")
         self.__injector.__setstate__(injector_state)
@@ -185,15 +563,22 @@ class Injector:
         self.__primary_interactions = list(primary_process.interactions.GetCrossSections()) + list(primary_process.interactions.GetDecays())
         self.__primary_injection_distributions = list(primary_process.distributions)
         self.__primary_phase_spaces = {}
-
         self.__secondary_interactions = {}
         self.__secondary_injection_distributions = {}
         self.__secondary_phase_spaces = {}
+        self.__primary_vertex = None
+        self.__secondary_vertices = []
+        self.__primary_compiled_process = None
+        self.__secondary_compiled_processes = {}
+        self.__keepalive = []
+        self.__max_attempts = None
         for secondary_type, secondary_process in self.__injector.GetSecondaryProcessMap().items():
             self.__secondary_interactions[secondary_type] = list(secondary_process.interactions.GetCrossSections()) + list(secondary_process.interactions.GetDecays())
             self.__secondary_injection_distributions[secondary_type] = list(secondary_process.distributions)
-            # Phase spaces are now per-signature; skip recovery for now
-            # (phase spaces are not serialized through cereal)
+
+    # ------------------------------------------------------------------ #
+    #  Properties (legacy surface, retained)                              #
+    # ------------------------------------------------------------------ #
 
     @property
     def seed(self):
@@ -343,7 +728,7 @@ class Injector:
     @wraps(_Injector.GenerateEvent)
     def generate_event(self):
         if self.__injector is None:
-            self.__initialize_injector()
+            self._build()
         return self.__injector.GenerateEvent()
     generate_event.__name__ = "generate_event"
     generate_event.__doc__ = _Injector.GenerateEvent.__doc__.replace("GenerateEvent", "generate_event")
@@ -360,48 +745,43 @@ class Injector:
             return self.__injector.InjectedEvents()
         return 0
 
+    @property
+    def injection_attempts(self):
+        if self.__injector is not None:
+            return self.__injector.InjectionAttempts()
+        return 0
+
     @wraps(_Injector.ResetInjectedEvents)
     def reset_injected_events(self):
         if self.__injector is not None:
             self.__injector.ResetInjectedEvents()
     reset_injected_events.__name__ = "reset_injected_events"
-    reset_injected_events.__doc__ = _Injector.ResetInjectedEvents.__doc__.replace("ResetInjectedEvents", "reset_injected_events")
-
-    @wraps(_Injector.SaveInjector)
-    def save(self, filename):
-        self.__injector.SaveInjector(filename)
-    save.__name__ = "save"
-    save.__doc__ = _Injector.SaveInjector.__doc__.replace("SaveInjector", "save")
 
     def __iter__(self):
-        """Iterate over generated events.
+        """Iterate raw generation attempts (yields empty trees on failure).
 
-        Yields one ``InteractionTree`` per event, up to
-        ``number_of_events``.
+        Deprecated: kept for backward compatibility. Prefer generate(), which
+        counts successes and never yields an empty tree.
         """
+        warnings.warn(
+            "iterating an Injector yields raw attempts including empty trees; "
+            "use generate(events) which counts successes",
+            DeprecationWarning, stacklevel=2)
         if self.__injector is None:
-            self.__initialize_injector()
+            self._build()
         for _ in range(self.number_of_events):
             yield self.__injector.GenerateEvent()
 
     def __len__(self):
         return self.number_of_events
 
-    @wraps(_Injector.LoadInjector)
-    def load(self, filename):
-        self.__injector.LoadInjector(filename)
-        # Update Python object state after loading
-        self.__number_of_events = self.__injector.EventsToInject()
-        self.__detector_model = self.__injector.GetDetectorModel()
-        primary_process = self.__injector.GetPrimaryProcess()
-        self.__primary_type = primary_process.primary_type
-        self.__primary_interactions = list(primary_process.interactions.GetCrossSections()) + list(primary_process.interactions.GetDecays())
-        self.__primary_injection_distributions = list(primary_process.distributions)
 
-        self.__secondary_interactions = {}
-        self.__secondary_injection_distributions = {}
-        for secondary_type, secondary_process in self.__injector.GetSecondaryProcessMap().items():
-            self.__secondary_interactions[secondary_type] = list(secondary_process.interactions.GetCrossSections()) + list(secondary_process.interactions.GetDecays())
-            self.__secondary_injection_distributions[secondary_type] = list(secondary_process.distributions)
+def _is_trampoline(obj):
+    """Whether `obj` is a Python subclass of a pybind base (a trampoline).
 
-        self.__stopping_condition = self.__injector.GetStoppingCondition()
+    A C++-native pybind object's type is defined in an extension module; a
+    Python subclass is defined in a .py module, so its class __module__ does
+    not start with 'siren.'.
+    """
+    module = type(obj).__module__ or ""
+    return not module.startswith("siren.") and module not in ("builtins",)

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -147,7 +147,6 @@ class Injector:
         """
         from . import _validation
         from . import expand as _expand
-        from . import errors as _errors
 
         if self.__seed is None:
             random = _utilities.SIREN_random()
@@ -218,11 +217,13 @@ class Injector:
         back into the same private fields the legacy path populates, so a
         single assembly path serves both surfaces.
         """
-        from . import errors as _errors
-        if self.__stopping_condition is not None:
-            _validation.check_expand_vs_legacy_stopping(True, True)
-
         primary = self.__primary_vertex
+        all_vertices = [primary] + list(self.__secondary_vertices)
+        has_expand = any(v.expand or v.continue_if is not None
+                         for v in all_vertices)
+        _validation.check_expand_vs_legacy_stopping(
+            self.__stopping_condition is not None, has_expand)
+
         self.__keepalive.append(primary)
         self.__primary_type = primary._resolved_particle
         self.__primary_interactions = list(primary.interactions)
@@ -236,7 +237,9 @@ class Injector:
             self.__secondary_injection_distributions[ptype] = list(sv.distributions)
             specs.append(sv.as_vertex_spec())
 
-        if self.__secondary_vertices:
+        # Compile the expansion callable only when the spec actually declares
+        # expansion; a legacy stopping_condition alone passes through untouched.
+        if self.__secondary_vertices and has_expand:
             _validation.validate_expansion_wiring(specs)
             self.__stopping_condition = _expand.compile_expansion(specs)
 
@@ -332,6 +335,11 @@ class Injector:
         max_attempts = self.__max_attempts
         if max_attempts is None:
             max_attempts = events * 1000
+
+        # The engine throws once its own attempt quota (events_to_inject) is
+        # reached, so raise that quota to the retry budget; otherwise a
+        # sub-unity efficiency could never reach `events` successes.
+        self.__injector.ResetInjectedEvents(max_attempts)
 
         # Give the efficiency estimate a minimum sample before it can abort, so
         # an unlucky early run is not cut short.

--- a/python/Weighter.py
+++ b/python/Weighter.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass, field
 from typing import Tuple, List, Dict, Optional, Union, Callable
 from typing import TYPE_CHECKING
 import math
+import warnings
+
+import numpy as np
 
 if TYPE_CHECKING:
     import siren
@@ -95,7 +98,8 @@ class Weighter:
     interaction datum.
     """
 
-    def __init__(self, 
+    def __init__(self,
+        *args,
         injectors: Optional[List[_Injector]] = None,
         detector_model: Optional[DetectorModel] = None,
         primary_type: Optional[_dataclasses.ParticleType] = None,
@@ -103,18 +107,42 @@ class Weighter:
         primary_physical_distributions: Optional[List[_distributions.WeightableDistribution]] = None,
         secondary_interactions: Optional[Dict[_dataclasses.ParticleType, List[Union[_interactions.CrossSection, _interactions.Decay]]]] = None,
         secondary_physical_distributions: Optional[Dict[_dataclasses.ParticleType, List[_distributions.WeightableDistribution]]] = None,
+        primary_physical: Optional[List[_distributions.WeightableDistribution]] = None,
+        secondary_physical: Optional[Dict[_dataclasses.ParticleType, List[_distributions.WeightableDistribution]]] = None,
+        overrides: Optional[Dict[str, object]] = None,
     ):
         """
         Initialize the Weighter with interactions and physical processes.
 
+        Two calling conventions are supported.
+
+        Legacy keyword form::
+
+            Weighter(injectors=[...], detector_model=..., primary_type=...,
+                     primary_interactions=..., primary_physical_distributions=...,
+                     secondary_interactions=..., secondary_physical_distributions=...)
+
+        Spec form, positional injectors plus physical-side keywords, inheriting
+        detector/types/interactions from the injectors themselves::
+
+            Weighter(injector, primary_physical=[...], secondary_physical={...})
+
+        ``overrides`` (spec form only) is a dict of legacy field names
+        (``detector_model``, ``primary_type``, ``primary_interactions``,
+        ``secondary_interactions``) to override what would otherwise be
+        inherited from the injectors.
+
         Args:
-            injectors: List of injector objects.
+            injectors: List of injector objects (legacy keyword form).
             detector_model: The detector model.
             primary_type: The primary particle type.
             primary_interactions: Dictionary of primary particle interactions.
             primary_physical_distributions: List of primary physical distributions.
             secondary_interactions: Dictionary of secondary particle interactions.
             secondary_physical_distributions: Dictionary of secondary physical distributions.
+            primary_physical: Primary physical distributions (spec form).
+            secondary_physical: Secondary physical distributions (spec form).
+            overrides: Legacy-field overrides for the spec form.
 
         Note:
             All parameters are optional and can be set later using property setters.
@@ -132,6 +160,22 @@ class Weighter:
 
         self.__weighter = None
 
+        spec_injectors = self.__detect_spec_injectors(args, injectors)
+
+        if spec_injectors is not None:
+            self.__init_from_injectors(
+                spec_injectors, primary_physical, secondary_physical, overrides)
+            return
+
+        if len(args) == 1 and injectors is None:
+            # Legacy form with injectors passed positionally as a list.
+            injectors = args[0]
+        elif len(args) > 1:
+            raise TypeError(
+                "Weighter() accepts either legacy keyword arguments or "
+                "one-or-more positional Injector arguments, not {} "
+                "positional arguments".format(len(args)))
+
         if injectors is not None:
             self.injectors = injectors
         if detector_model is not None:
@@ -146,6 +190,60 @@ class Weighter:
             self.__secondary_interactions = secondary_interactions
         if secondary_physical_distributions is not None:
             self.__secondary_physical_distributions = secondary_physical_distributions
+
+    @staticmethod
+    def __detect_spec_injectors(args, injectors_kwarg):
+        """Return the positional injectors list if this is the spec-form call.
+
+        Spec form is detected by one-or-more positional args that are each an
+        Injector (python wrapper or raw C++ engine), with no ``injectors=``
+        keyword given. A single positional list (the legacy form) is left for
+        the caller to handle.
+        """
+        if injectors_kwarg is not None:
+            return None
+        if len(args) == 0:
+            return None
+        if len(args) == 1 and isinstance(args[0], list):
+            return None
+        if all(isinstance(a, (_Injector, _PyInjector)) for a in args):
+            return list(args)
+        return None
+
+    def __init_from_injectors(self, injectors, primary_physical,
+                               secondary_physical, overrides):
+        """Populate fields by inheriting from the given injectors' processes."""
+        overrides = overrides or {}
+
+        self.injectors = injectors
+
+        engine0 = injectors[0].engine if isinstance(injectors[0], _PyInjector) else injectors[0]
+        primary_proc = engine0.GetPrimaryProcess()
+
+        self.__detector_model = overrides.get(
+            "detector_model",
+            injectors[0].detector_model if isinstance(injectors[0], _PyInjector)
+            else engine0.GetDetectorModel())
+        self.__primary_type = overrides.get(
+            "primary_type", primary_proc.primary_type)
+        self.__primary_interactions = overrides.get(
+            "primary_interactions",
+            list(primary_proc.interactions.GetCrossSections())
+            + list(primary_proc.interactions.GetDecays()))
+
+        secondary_interactions = overrides.get("secondary_interactions", None)
+        if secondary_interactions is None:
+            secondary_interactions = {}
+            for ptype, sproc in engine0.GetSecondaryProcessMap().items():
+                secondary_interactions[ptype] = (
+                    list(sproc.interactions.GetCrossSections())
+                    + list(sproc.interactions.GetDecays()))
+        self.__secondary_interactions = secondary_interactions
+
+        self.__primary_physical_distributions = (
+            list(primary_physical) if primary_physical is not None else [])
+        self.__secondary_physical_distributions = (
+            dict(secondary_physical) if secondary_physical is not None else {})
 
     @property
     def injectors(self) -> List[_Injector]:
@@ -168,7 +266,11 @@ class Weighter:
         Raises:
             ValueError: If the weighter has already been initialized.
             TypeError: If the input is not a list of Injector objects.
-            ValueError: If any of the injectors are not initialized.
+
+        Note:
+            A python Injector wrapper need not already have built its
+            underlying engine -- it is unwrapped via its ``engine`` property
+            (which builds it lazily) at weighter-initialize time.
         """
 
         if self.__weighter is not None:
@@ -177,8 +279,6 @@ class Weighter:
             raise TypeError("Injectors must be a list.")
         if not all(isinstance(injector, (_Injector, _PyInjector)) for injector in injectors):
             raise TypeError("All injectors must be of type Injector.")
-        if not all(injector._Injector__injector is not None for injector in injectors if isinstance(injector, _PyInjector)):
-            raise ValueError("All injectors must be initialized.")
         self.__injectors = injectors
 
     @property
@@ -398,13 +498,13 @@ class Weighter:
             filename: Base path; the ".siren_weighter" suffix is added.
         """
         if self.__injectors is not None:
-            injectors = [injector._Injector__injector if isinstance(injector, _PyInjector) else injector
+            injectors = [injector.engine if isinstance(injector, _PyInjector) else injector
                          for injector in self.__injectors]
         else:
             injectors = []
         self.__weighter = _Weighter(injectors, filename)
 
-    def weight_all(self, events) -> list:
+    def weight_all(self, events) -> "np.ndarray":
         """
         Calculate weights for a list of events.
 
@@ -412,77 +512,43 @@ class Weighter:
             events: A list of InteractionTree objects.
 
         Returns:
-            list[float]: The calculated event weights.
+            numpy.ndarray: The calculated event weights.
         """
-        return [self(event) for event in events]
+        return np.array([self(event) for event in events])
 
-    def breakdown(self, interaction_tree: InteractionTree) -> "EventWeightBreakdown":
-        """Per-vertex decomposition of the event weight.
-
-        Returns an ``EventWeightBreakdown`` that stores each vertex's
-        interaction probability, position density, physical probability,
-        and generation probability.  Useful for diagnosing inf/0/NaN
-        weights.
-        """
+    @property
+    def engine(self) -> _Weighter:
+        """The raw C++ _Weighter, building it via __initialize_weighter if needed."""
         if self.__weighter is None:
             self.__initialize_weighter()
+        return self.__weighter
 
-        injector_idx = 0
-        cpp_inj = self.__injectors[injector_idx]
-        if isinstance(cpp_inj, _PyInjector):
-            cpp_inj = cpp_inj._Injector__injector
+    def explain(self, interaction_tree: InteractionTree) -> "report.WeightBreakdown":
+        """Per-vertex decomposition of the event weight.
 
-        sec_map = cpp_inj.GetSecondaryProcessMap()
+        Returns a ``report.WeightBreakdown`` built from the engine's
+        ``EventWeightWithBreakdown``, giving each vertex's generation and
+        physical probability, channel densities, cancelled distributions, and
+        diagnostic flags. Useful for diagnosing inf/0/NaN weights.
+        """
+        from .report import WeightBreakdown
+        if self.__weighter is None:
+            self.__initialize_weighter()
+        return WeightBreakdown.from_engine(
+            self.engine.EventWeightWithBreakdown(interaction_tree))
 
-        primary_phys = self.__weighter_primary_phys
-        secondary_phys = self.__weighter_secondary_phys
-        ppw = _injection.PrimaryProcessWeighter(
-            primary_phys, cpp_inj.GetPrimaryProcess(),
-            self.__detector_model)
+    def breakdown(self, interaction_tree: InteractionTree) -> "report.WeightBreakdown":
+        """Deprecated alias of explain().
 
-        vertices = []
-        for datum in interaction_tree.tree:
-            rec = datum.record
-            pid = rec.signature.primary_type
-            depth = datum.depth(interaction_tree)
-            secs = list(rec.signature.secondary_types)
-
-            if depth == 0:
-                bounds = cpp_inj.PrimaryInjectionBounds(rec)
-                pw = ppw
-            else:
-                bounds = cpp_inj.SecondaryInjectionBounds(rec)
-                if pid not in secondary_phys:
-                    vertices.append(VertexWeight(
-                        depth=depth, primary_type=int(pid),
-                        secondary_types=[int(s) for s in secs]))
-                    continue
-                pw = _injection.SecondaryProcessWeighter(
-                    secondary_phys[pid], sec_map[pid],
-                    self.__detector_model)
-
-            int_prob = pw.InteractionProbability(bounds, rec)
-            pos_prob = pw.NormalizedPositionProbability(bounds, rec)
-            phys_prob = pw.PhysicalProbability(bounds, rec)
-            gen_prob = pw.GenerationProbability(datum)
-
-            vertices.append(VertexWeight(
-                depth=depth,
-                primary_type=int(pid),
-                secondary_types=[int(s) for s in secs],
-                interaction_probability=int_prob,
-                position_probability=pos_prob,
-                physical_probability=phys_prob,
-                generation_probability=gen_prob,
-            ))
-
-        return EventWeightBreakdown(
-            vertices=vertices,
-            weight=self(interaction_tree),
-        )
+        Retained for backward compatibility; emits a DeprecationWarning and
+        returns the same ``report.WeightBreakdown`` as explain().
+        """
+        warnings.warn(
+            "Weighter.breakdown() is deprecated, use Weighter.explain() instead",
+            DeprecationWarning, stacklevel=2)
+        return self.explain(interaction_tree)
 
     def __initialize_weighter(self):
-        # Defer to the original (reordered so breakdown() can access internals)
         return self.__do_initialize_weighter()
 
     def __do_initialize_weighter(self):
@@ -498,7 +564,7 @@ class Weighter:
             raise ValueError("Primary physical distributions have not been set.")
 
         injectors = [
-            injector._Injector__injector
+            injector.engine
             if isinstance(injector, _PyInjector) else injector
             for injector in self.__injectors
         ]
@@ -513,11 +579,7 @@ class Weighter:
         primary_process.distributions = self.primary_physical_distributions
 
         # Copy weighting mode from the injector's primary process
-        inj0 = injectors[0]
-        if isinstance(inj0, _PyInjector):
-            inj0_cpp = inj0._Injector__injector
-        else:
-            inj0_cpp = inj0
+        inj0_cpp = injectors[0]
         if inj0_cpp is not None:
             primary_process.weighting_mode = inj0_cpp.GetPrimaryProcess().GetWeightingMode()
 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -77,6 +77,29 @@ utilities.darknews_version = darknews_version
 from . import particles
 from . import dist
 
+# ---- Spec vocabulary ----
+from . import errors
+from . import channels
+from . import expand
+from .vertex import Vertex
+from ._directed import Directed
+from .generate import generate
+
+# Weighting-mode presets re-exported at the top level.
+Propagated = injection.VertexWeightingMode.Propagated
+Fixed = injection.VertexWeightingMode.Fixed
+
+# Deprecation aliases in this package should surface once by default; set
+# SIREN_STRICT=1 to escalate them to errors.
+import os as _os
+import warnings as _warnings
+_warnings.filterwarnings("default", category=DeprecationWarning,
+                         module=r"siren($|\.)")
+if _os.environ.get("SIREN_STRICT") == "1":
+    _warnings.filterwarnings("error", category=DeprecationWarning,
+                             module=r"siren($|\.)")
+del _os, _warnings
+
 # ---- Simulation and Results ----
 from .Simulation import Simulation
 from .Results import Results

--- a/python/_directed.py
+++ b/python/_directed.py
@@ -12,7 +12,7 @@ of the same Decay model).
 
 from __future__ import annotations
 
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 from . import channels as _channels
 from .errors import ConfigurationError

--- a/python/_directed.py
+++ b/python/_directed.py
@@ -1,0 +1,192 @@
+"""Directed: sugar over channels.py for the common directed+fallback mix.
+
+Directed(...) describes "point this daughter at a target volume, with a
+physical/isotropic fallback so events that miss the target are not lost
+from the estimator." It never introduces a new engine primitive: every
+Directed compiles to exactly the channels.Mixture the channels algebra
+would build by hand. Directed.by_signature({signature: Directed|Mixture})
+covers the case where different signatures of the same vertex need
+different directed treatments (e.g. a 2-body and a 3-body decay channel
+of the same Decay model).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Union
+
+from . import channels as _channels
+from .errors import ConfigurationError
+
+__all__ = ["Directed"]
+
+
+def _siren():
+    import siren
+    return siren
+
+
+def _fallback(daughter):
+    """physical() fallback, falling back further to isotropic() on failure.
+
+    physical() late-binds a PhysicalDecayChannel/PhysicalCrossSectionChannel
+    against the vertex's own interaction model at compile time; Directed
+    prefers it as the fallback (it samples the real physical distribution
+    rather than an isotropic proxy) but does not require a model be
+    supplied -- Mixture.compile()/validate() will raise ConfigurationError
+    from inside physical()'s factory if none is available at compile time.
+    """
+    return _channels.physical()
+
+
+class Directed:
+    """Sugar over channels.py for "directed daughter, with a fallback".
+
+    Parameters
+    ----------
+    particle : str or ParticleType
+        The daughter this Directed points at `toward`. Named, not
+        indexed, so the same Directed can be reused across signatures
+        where the daughter's position among secondaries differs.
+    toward : Geometry
+        The target volume passed to the underlying toward()/
+        toward_3body()/scatter_toward() factory.
+    fraction : float, optional
+        Weight given to the directed term; `1 - fraction` goes to the
+        fallback (physical() by default). Defaults to 0.98. Callers
+        wanting the legacy 0.01/0.99 split pass fraction=0.99 explicitly
+        -- this class never hardcodes that value.
+    mode : optional
+        DirectedMode passed through to the channel factory. Defaults to
+        DirectedMode.Volume (channels.py's own default).
+    spectator : str or ParticleType, optional
+        Selects toward_3body()'s recursive strategy: the spectator
+        daughter of a 3-body directed channel.
+    pair_mass : channels.PairMass, optional
+        Invariant-mass sampling law for a 3-body directed channel's pair.
+    variable : optional
+        ScatteringVariable selecting scatter_toward()'s sampled variable;
+        its presence (along with q2_mode) is what selects the scattering
+        factory over the 2-body/3-body ones.
+    q2_mode : optional
+        ScatteringQ2Mode passed through to scatter_toward().
+    tiling : int, optional
+        Grid size passed through to channels.tile() in place of a bare
+        toward(); selects the tiled factory over the 2-body one.
+    """
+
+    def __init__(self, particle, toward, fraction: float = 0.98, *,
+                 mode=None, spectator=None, pair_mass=None,
+                 variable=None, q2_mode=None, tiling=None):
+        if not (0.0 <= fraction <= 1.0):
+            raise ConfigurationError(
+                "Directed(fraction={!r}): fraction must be in [0, 1]".format(fraction))
+        self.particle = particle
+        self.toward = toward
+        self.fraction = float(fraction)
+        self.mode = mode
+        self.spectator = spectator
+        self.pair_mass = pair_mass
+        self.variable = variable
+        self.q2_mode = q2_mode
+        self.tiling = tiling
+
+    def _directed_channel(self):
+        """Build the bare directed Channel/Tiling (no fallback mixed in)."""
+        if self.tiling is not None:
+            return _channels.tile(
+                self.toward, self.tiling, daughter=self.particle,
+                mode=self.mode)
+        if self.variable is not None or self.q2_mode is not None:
+            return _channels.scatter_toward(
+                self.toward, variable=self.variable, q2_mode=self.q2_mode,
+                mode=self.mode)
+        if self.spectator is not None or self.pair_mass is not None:
+            return _channels.toward_3body(
+                self.particle, self.toward, spectator=self.spectator,
+                pair_mass=self.pair_mass, mode=self.mode)
+        return _channels.toward(self.particle, self.toward, mode=self.mode)
+
+    def to_mixture(self, signature=None) -> "_channels.Mixture":
+        """Build the channels.Mixture this Directed describes.
+
+        `signature` is accepted (and ignored) so a plain Directed and a
+        Directed.by_signature() mapping share the same call shape at the
+        Vertex.compile() call site.
+        """
+        directed = self._directed_channel()
+        if self.fraction >= 1.0:
+            return _channels.Mixture([(1.0, directed)])
+        fallback = _fallback(self.particle)
+        return (self.fraction * directed) + ((1.0 - self.fraction) * fallback)
+
+    def compile(self, signature, *, detector=None, models=None):
+        """Compile this Directed's mixture for `signature`.
+
+        Delegates to channels.Mixture.compile() after resolving
+        to_mixture(); this is the same call shape Vertex.compile() uses
+        for a bare channels.Mixture, so a Vertex's `kinematics=` accepts
+        a Directed interchangeably with a Mixture.
+        """
+        return self.to_mixture(signature).compile(
+            signature, detector=detector, models=models)
+
+    def validate(self, signature=None):
+        """Data-free configuration check, delegating to Mixture.validate()."""
+        return self.to_mixture(signature).validate(signature)
+
+    def describe(self) -> str:
+        """The g(x) expression for this Directed's mixture."""
+        return self.to_mixture().describe()
+
+    @classmethod
+    def by_signature(cls, mapping: Dict[object, Union["Directed", "_channels.Mixture"]]) -> "_DirectedBySignature":
+        """A Directed-like object compiling a different mixture per signature.
+
+        `mapping` keys are InteractionSignature (or anything else that
+        compares equal to one); values are a Directed or a bare
+        channels.Mixture. Looked up by exact signature match at compile
+        time -- there is no partial/fallback matching.
+        """
+        return _DirectedBySignature(mapping)
+
+
+class _DirectedBySignature:
+    """Directed.by_signature(...) result: dispatches to_mixture() by signature."""
+
+    __slots__ = ("_mapping",)
+
+    def __init__(self, mapping):
+        self._mapping = dict(mapping)
+
+    def _entry_for(self, signature):
+        if signature not in self._mapping:
+            raise ConfigurationError(
+                "Directed.by_signature(): no entry for signature {!r}; "
+                "known signatures: {}".format(
+                    signature, list(self._mapping.keys())))
+        return self._mapping[signature]
+
+    def to_mixture(self, signature) -> "_channels.Mixture":
+        entry = self._entry_for(signature)
+        if isinstance(entry, Directed):
+            return entry.to_mixture(signature)
+        return entry
+
+    def compile(self, signature, *, detector=None, models=None):
+        return self.to_mixture(signature).compile(
+            signature, detector=detector, models=models)
+
+    def validate(self, signature=None):
+        if signature is not None:
+            return self.to_mixture(signature).validate(signature)
+        for sig, entry in self._mapping.items():
+            mixture = entry.to_mixture(sig) if isinstance(entry, Directed) else entry
+            mixture.validate(sig)
+        return None
+
+    def describe(self) -> str:
+        parts = []
+        for sig, entry in self._mapping.items():
+            mixture = entry.to_mixture(sig) if isinstance(entry, Directed) else entry
+            parts.append("{!r}: {}".format(sig, mixture.describe()))
+        return "; ".join(parts)

--- a/python/_validation.py
+++ b/python/_validation.py
@@ -285,3 +285,68 @@ def check_expand_vs_legacy_stopping(has_legacy_stopping, has_expand_or_continue_
             "surface only -- drop stopping_condition and express the "
             "chain with Vertex(expand=[...], continue_if=...)."
         )
+
+
+def validate_secondary_keys(*dicts_with_labels):
+    """Check that every secondary-keyed dict shares the interactions keys.
+
+    Each argument is a (label, mapping) pair. The first pair is the reference
+    key set (the secondary interactions); every other mapping must key on
+    exactly the same ParticleTypes. A typo'd or missing key raises
+    ConfigurationError naming the offending mapping and the key difference,
+    so a phase-space or weighting-mode dict cannot silently miss a secondary.
+    """
+    pairs = [(label, mapping) for label, mapping in dicts_with_labels
+             if mapping is not None]
+    if not pairs:
+        return
+    ref_label, ref_map = pairs[0]
+    ref_keys = set(ref_map.keys())
+    for label, mapping in pairs[1:]:
+        keys = set(mapping.keys())
+        extra = keys - ref_keys
+        if extra:
+            raise ConfigurationError(
+                "{} has secondary keys {} not present in {} (keys {}). "
+                "Fix: the key is likely a typo or a stray entry; it must "
+                "match a registered secondary type.".format(
+                    label, sorted(str(k) for k in extra),
+                    ref_label, sorted(str(k) for k in ref_keys)))
+
+
+def build_template_record(signature, *, primary_mass=0.02, energy=0.05):
+    """A minimal InteractionRecord for a signature, for config-time probes.
+
+    Fills plausible small masses and a forward-moving primary; consulted only
+    by measure/density probes, never by a real Sample().
+    """
+    import math
+    import siren
+    n_sec = len(signature.secondary_types)
+    pz = math.sqrt(max(energy * energy - primary_mass * primary_mass, 0.0))
+    rec = siren.dataclasses.InteractionRecord()
+    rec.signature.primary_type = signature.primary_type
+    rec.signature.target_type = signature.target_type
+    rec.signature.secondary_types = list(signature.secondary_types)
+    rec.primary_mass = primary_mass
+    rec.primary_momentum = [energy, 0.0, 0.0, pz]
+    rec.secondary_masses = [0.001] * n_sec
+    rec.secondary_momenta = [[0.0, 0.0, 0.0, 0.0]] * n_sec
+    rec.secondary_helicities = [0] * n_sec
+    rec.interaction_vertex = [0.0, 0.0, 0.0]
+    rec.primary_initial_position = [0.0, 0.0, 0.0]
+    return rec
+
+
+def probe_channel_densities(mcps, signature, detector_model, random,
+                            *, samples_per_channel=100):
+    """Run the detector-dependent ValidateChannelDensities probe on a mixture.
+
+    Draws samples through each channel and checks the sampled density matches
+    the analytic density, surfacing a sampler/density mismatch at build time.
+    Raises whatever the engine raises (MeasureCompatibilityError,
+    WeightCalculationError) on failure; a passing probe returns its result.
+    """
+    template = build_template_record(signature)
+    return mcps.ValidateChannelDensities(
+        random, detector_model, template, samples_per_channel)

--- a/python/_validation.py
+++ b/python/_validation.py
@@ -9,6 +9,8 @@ automatically.
 """
 
 from . import distributions as _d
+from . import particles as _particles
+from .errors import ConfigurationError
 
 DV = _d.DistributionVariable
 
@@ -175,4 +177,111 @@ def validate_reweighting_compatibility(injection_distributions, physical_distrib
             f"{sorted(extra)} that are not covered by injection distributions. "
             f"Injection density variables: {sorted(inj_density)}, "
             f"Physical density variables: {sorted(phys_density)}"
+        )
+
+
+def _expand_rule_names(rule):
+    """Return the particle name(s) a child()/depth_below() rule references.
+
+    child() rules name a particle; depth_below() rules name none.
+    """
+    name = getattr(rule, "name", None)
+    return [name] if name is not None else []
+
+
+def validate_expansion_wiring(vertices):
+    """Check that a set of Vertex expand declarations forms a closed graph.
+
+    Parameters
+    ----------
+    vertices : iterable
+        Objects with ``.particle``, ``.expand`` (tuple of rules from
+        ``siren.expand.child``/``depth_below``), and ``.continue_if``.
+        An object may additionally expose ``.secondary_types`` (an
+        iterable of ParticleType/name the vertex's interactions can
+        produce); when absent, case (c) below is skipped for that
+        vertex since there is nothing to cross-check against.
+
+    Raises
+    ------
+    ConfigurationError
+        (a) An expand rule names a child particle with no registered
+            Vertex for that particle type.
+        (b) A registered secondary Vertex (any vertex other than a root,
+            i.e. one that some other vertex's expand list could reach)
+            is unreachable from every other vertex's expand list.
+        (c) A vertex declares secondaries (via ``.secondary_types``) but
+            has no expansion declaration at all (empty ``.expand``).
+    """
+    vertices = list(vertices)
+    by_particle = {}
+    for v in vertices:
+        ptype = _particles.resolve(v.particle)
+        by_particle[ptype] = v
+
+    named_children = set()
+    for v in vertices:
+        for rule in v.expand:
+            for name in _expand_rule_names(rule):
+                ptype = _particles.resolve(name)
+                named_children.add(ptype)
+                # (a) expand rule names a child with no registered Vertex.
+                if ptype not in by_particle:
+                    raise ConfigurationError(
+                        f"Vertex {v.particle!r} declares expand rule "
+                        f"child({name!r}) but no Vertex is registered for "
+                        f"particle {name!r}. Fix: register a Vertex for "
+                        f"{name!r}, or remove this expand rule."
+                    )
+
+    # (b) a registered secondary Vertex unreachable from any expand list.
+    root = vertices[0].particle if vertices else None
+    for v in vertices:
+        if v.particle == root:
+            continue
+        ptype = _particles.resolve(v.particle)
+        if ptype not in named_children:
+            raise ConfigurationError(
+                f"Vertex {v.particle!r} is registered but unreachable: no "
+                f"other Vertex's expand list names it. Fix: add "
+                f"child({v.particle!r}) to the expand list of the vertex "
+                f"that produces it, or remove this Vertex."
+            )
+
+    # (c) secondaries present with no expansion declaration at all.
+    for v in vertices:
+        secondary_types = getattr(v, "secondary_types", None)
+        if not secondary_types:
+            continue
+        if not v.expand:
+            raise ConfigurationError(
+                f"Vertex {v.particle!r} has secondaries "
+                f"{list(secondary_types)!r} but declares no expand rules. "
+                f"Fix: add expand=[siren.expand.child(...)] naming which "
+                f"secondaries should recurse."
+            )
+
+
+def check_expand_vs_legacy_stopping(has_legacy_stopping, has_expand_or_continue_if):
+    """Reject configurations mixing legacy stopping_condition with expand.
+
+    Parameters
+    ----------
+    has_legacy_stopping : bool
+        True if a legacy ``stopping_condition`` callable was supplied.
+    has_expand_or_continue_if : bool
+        True if any Vertex supplies ``expand`` and/or ``continue_if``.
+
+    Raises
+    ------
+    ConfigurationError
+        If both are set: the legacy callable and the declarative
+        expand/continue_if fields are mutually exclusive.
+    """
+    if has_legacy_stopping and has_expand_or_continue_if:
+        raise ConfigurationError(
+            "Both a legacy stopping_condition callable and Vertex "
+            "expand/continue_if fields are set. Fix: use one control "
+            "surface only -- drop stopping_condition and express the "
+            "chain with Vertex(expand=[...], continue_if=...)."
         )

--- a/python/_validation.py
+++ b/python/_validation.py
@@ -233,13 +233,18 @@ def validate_expansion_wiring(vertices):
                         f"particle {name!r}. Fix: register a Vertex for "
                         f"{name!r}, or remove this expand rule."
                     )
+            # A depth_below rule (no named particle) expands every secondary,
+            # so all of this vertex's secondary types become reachable.
+            if not _expand_rule_names(rule):
+                for t in (getattr(v, "secondary_types", None) or []):
+                    named_children.add(_particles.resolve(t))
 
     # (b) a registered secondary Vertex unreachable from any expand list.
-    root = vertices[0].particle if vertices else None
+    root = _particles.resolve(vertices[0].particle) if vertices else None
     for v in vertices:
-        if v.particle == root:
-            continue
         ptype = _particles.resolve(v.particle)
+        if ptype == root:
+            continue
         if ptype not in named_children:
             raise ConfigurationError(
                 f"Vertex {v.particle!r} is registered but unreachable: no "
@@ -288,13 +293,14 @@ def check_expand_vs_legacy_stopping(has_legacy_stopping, has_expand_or_continue_
 
 
 def validate_secondary_keys(*dicts_with_labels):
-    """Check that every secondary-keyed dict shares the interactions keys.
+    """Check that no secondary-keyed dict carries an unknown key.
 
     Each argument is a (label, mapping) pair. The first pair is the reference
-    key set (the secondary interactions); every other mapping must key on
-    exactly the same ParticleTypes. A typo'd or missing key raises
-    ConfigurationError naming the offending mapping and the key difference,
-    so a phase-space or weighting-mode dict cannot silently miss a secondary.
+    key set (the secondary interactions); every other mapping's keys must be a
+    subset of it. An EXTRA key -- a phase-space or weighting-mode entry for a
+    particle with no registered interaction -- raises ConfigurationError, since
+    it is almost always a typo. A MISSING key is allowed: not every secondary
+    needs a custom phase space or weighting mode.
     """
     pairs = [(label, mapping) for label, mapping in dicts_with_labels
              if mapping is not None]

--- a/python/channels.py
+++ b/python/channels.py
@@ -1,0 +1,557 @@
+"""Channel algebra compiling to siren.injection.MultiChannelPhaseSpace.
+
+Public names: Channel, Mixture, PairMass, Tiling, isotropic, toward,
+toward_3body, scatter_toward, physical, tile.
+
+A Channel wraps one engine PhaseSpaceChannel factory that is resolved
+against a concrete InteractionSignature at compile time (daughters and
+spectators are named by particle, not by index).  Channels combine with
+`*` (rescale) and `+` (mix) into a Mixture, whose weights are normalized
+to sum to 1 at every construction.  Mixture.compile() resolves every
+Channel's factory against a signature and builds the validated
+MultiChannelPhaseSpace; Mixture.validate() runs the same compilation plus
+a detector-free ConvertDensity probe against a template record, so a bad
+3-body factorization index or an inconvertible measure combination fails
+at configuration time rather than at first weight evaluation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, List, Optional, Sequence, Tuple, Union
+
+from . import directed_tiling as _tiling
+from . import particles as _particles
+from .errors import ConfigurationError, MeasureCompatibilityError
+
+__all__ = [
+    "Channel",
+    "Mixture",
+    "PairMass",
+    "Tiling",
+    "isotropic",
+    "toward",
+    "toward_3body",
+    "scatter_toward",
+    "physical",
+    "tile",
+]
+
+
+def _siren():
+    import siren
+    return siren
+
+
+def _resolve_index(signature, name_or_index, role):
+    """Resolve a daughter/spectator spec to a secondary index.
+
+    `name_or_index` may be an int (used directly) or a particle name/
+    ParticleType resolved against `signature.secondary_types`.  Raises
+    ConfigurationError naming the particle and the signature on an
+    absent or ambiguous match; never silently skips.
+    """
+    if isinstance(name_or_index, int):
+        return name_or_index
+    try:
+        ptype = _particles.resolve(name_or_index)
+    except (ValueError, TypeError) as e:
+        raise ConfigurationError(
+            "{}: {}".format(role, e))
+    secondaries = list(signature.secondary_types)
+    matches = [i for i, t in enumerate(secondaries) if t == ptype]
+    if not matches:
+        raise ConfigurationError(
+            "{}: particle {!r} not found among secondary_types {} of "
+            "signature {}".format(
+                role, name_or_index,
+                [str(t) for t in secondaries], signature))
+    if len(matches) > 1:
+        raise ConfigurationError(
+            "{}: particle {!r} is ambiguous among secondary_types {} of "
+            "signature {} (matched indices {})".format(
+                role, name_or_index,
+                [str(t) for t in secondaries], signature, matches))
+    return matches[0]
+
+
+# ------------------------------------------------------------------ #
+#  Shared mixture-node algebra                                        #
+# ------------------------------------------------------------------ #
+
+class _MixtureNode:
+    """Common `*`/`+` algebra for Channel and Tiling.
+
+    A node wraps a deferred factory(signature) -> engine PhaseSpaceChannel
+    plus a weight; `_build` resolves it against a concrete signature only
+    at compile/validate time.  Subclasses set `_factory`, `weight`,
+    `label` and implement `_copy_with_weight` so `*` returns the same
+    subclass.
+    """
+
+    _factory: Callable
+    weight: float
+    label: str
+
+    def _build(self, signature, *, detector=None, models=None):
+        return self._factory(signature, detector=detector, models=models)
+
+    def _copy_with_weight(self, weight):
+        raise NotImplementedError
+
+    def __rmul__(self, scalar):
+        if not isinstance(scalar, (int, float)):
+            return NotImplemented
+        return self._copy_with_weight(self.weight * float(scalar))
+
+    def __mul__(self, scalar):
+        return self.__rmul__(scalar)
+
+    def __add__(self, other):
+        if isinstance(other, _MixtureNode):
+            return Mixture([(self.weight, self), (other.weight, other)])
+        if isinstance(other, Mixture):
+            return Mixture([(self.weight, self)] + list(other._entries))
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, Mixture):
+            return Mixture(list(other._entries) + [(self.weight, self)])
+        return NotImplemented
+
+    def describe(self) -> str:
+        return self.label
+
+
+class Channel(_MixtureNode):
+    """One weighted spec node wrapping a deferred engine-channel factory.
+
+    `factory(signature)` builds the concrete engine PhaseSpaceChannel for
+    that signature; it is called only at compile/validate time, never at
+    construction, so a Channel can be built before any signature is known.
+    """
+
+    def __init__(self, factory: Callable, weight: float = 1.0,
+                 label: str = "channel"):
+        self._factory = factory
+        self.weight = float(weight)
+        self.label = label
+
+    def _copy_with_weight(self, weight):
+        return Channel(self._factory, weight, self.label)
+
+
+# ------------------------------------------------------------------ #
+#  Mixture                                                             #
+# ------------------------------------------------------------------ #
+
+class Mixture:
+    """A normalized weighted list of Channels (and Tilings).
+
+    Always normalized so the stored weights sum to 1: at construction and
+    after every `+`.  Rejects an empty, negative, or non-finite weight set
+    with ConfigurationError.
+    """
+
+    def __init__(self, entries: Sequence[Tuple[float, "Channel"]]):
+        entries = list(entries)
+        if not entries:
+            raise ConfigurationError("Mixture: cannot construct from an empty list of channels")
+        for w, ch in entries:
+            if not math.isfinite(w):
+                raise ConfigurationError(
+                    "Mixture: non-finite weight {!r} for channel {!r}".format(w, ch.describe()))
+            if w < 0.0:
+                raise ConfigurationError(
+                    "Mixture: negative weight {!r} for channel {!r}".format(w, ch.describe()))
+        total = sum(w for w, _ in entries)
+        if not (math.isfinite(total) and total > 0.0):
+            raise ConfigurationError(
+                "Mixture: weights sum to {!r}, must be finite and positive".format(total))
+        self._entries: List[Tuple[float, "Channel"]] = [
+            (w / total, ch) for w, ch in entries]
+
+    def __add__(self, other):
+        if isinstance(other, _MixtureNode):
+            return Mixture(list(self._entries) + [(other.weight, other)])
+        if isinstance(other, Mixture):
+            return Mixture(list(self._entries) + list(other._entries))
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, _MixtureNode):
+            return Mixture([(other.weight, other)] + list(self._entries))
+        return NotImplemented
+
+    def __rmul__(self, scalar):
+        if not isinstance(scalar, (int, float)):
+            return NotImplemented
+        # Rescaling a normalized mixture by a positive scalar renormalizes
+        # right back to the same mixture; kept for algebraic symmetry with
+        # Channel.__rmul__ so `p * mix_a + (1 - p) * mix_b` composes.
+        return Mixture([(scalar * w, ch) for w, ch in self._entries])
+
+    def describe(self) -> str:
+        parts = ["{:.2f} * {}".format(w, ch.describe()) for w, ch in self._entries]
+        return " + ".join(parts)
+
+    # -------------------------------------------------------------- #
+    #  Compilation                                                    #
+    # -------------------------------------------------------------- #
+
+    def _flatten(self, signature, *, detector=None, models=None):
+        """Resolve every entry to (weight, engine PhaseSpaceChannel)."""
+        engine_channels = []
+        weights = []
+        for w, ch in self._entries:
+            built = ch._build(signature, detector=detector, models=models)
+            engine_channels.append(built)
+            weights.append(w)
+        return engine_channels, weights
+
+    def compile(self, signature, *, detector=None, models=None):
+        """Build the siren.injection.MultiChannelPhaseSpace for `signature`.
+
+        Uses the validating constructor: it normalizes the weights and
+        throws MeasureCompatibilityError on a fatal topology/measure
+        incompatibility.
+        """
+        siren = _siren()
+        engine_channels, weights = self._flatten(
+            signature, detector=detector, models=models)
+        return siren.injection.MultiChannelPhaseSpace(engine_channels, weights)
+
+    def validate(self, signature=None):
+        """Data-free configuration check.
+
+        Runs (a) compilation against a template signature via the
+        validating MultiChannelPhaseSpace ctor, which normalizes weights
+        and raises MeasureCompatibilityError on a fatal incompatibility,
+        and (b) a ConvertDensity probe on a template record built from the
+        signature's masses, surfacing bad 3-body factorization indices at
+        configuration time.  Does not run the detector-dependent
+        ValidateChannelDensities probe (that runs in Injector._build).
+        """
+        siren = _siren()
+        sig = signature if signature is not None else _template_signature()
+        mcps = self.compile(sig)  # raises MeasureCompatibilityError if fatal
+
+        record = _template_record(sig)
+        topology = mcps.CommonTopology()
+        common_measure = mcps.CommonMeasure()
+        for ch in mcps.channels:
+            measure = ch.Measure()
+            if measure == common_measure:
+                continue
+            try:
+                siren.injection.ConvertDensity(
+                    1.0, measure, common_measure, topology, record)
+            except MeasureCompatibilityError:
+                # SolidAngleLab conversions outside Decay2Body topology are
+                # unconvertible by design; any other channel combination that
+                # cannot convert is a genuine configuration error.
+                if topology != siren.injection.PhaseSpaceTopology.Decay2Body and (
+                        measure.type == siren.injection.PhaseSpaceMeasureType.SolidAngleLab
+                        or common_measure.type == siren.injection.PhaseSpaceMeasureType.SolidAngleLab):
+                    continue
+                raise
+        return mcps
+
+
+# ------------------------------------------------------------------ #
+#  Template signature / record for detector-free validation           #
+# ------------------------------------------------------------------ #
+
+def _template_signature():
+    siren = _siren()
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4 if hasattr(siren.particles, "N4") else siren.particles.NuMu
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+    return sig
+
+
+def _template_record(signature, primary_mass=0.02, energy=0.05):
+    """A minimal InteractionRecord for the given signature.
+
+    Mirrors the idiom in tests/python/test_density_breakdown.py: plausible
+    small masses, a forward-moving primary, and a vertex at the origin.
+    Secondary masses are set to a small common value (no physical model is
+    consulted -- this record only feeds the detector-free ConvertDensity
+    probe, not any Sample()).
+    """
+    siren = _siren()
+    n_sec = len(signature.secondary_types)
+    m_sec = 0.001
+    pz = math.sqrt(max(energy * energy - primary_mass * primary_mass, 0.0))
+    rec = siren.dataclasses.InteractionRecord()
+    rec.signature.primary_type = signature.primary_type
+    rec.signature.target_type = signature.target_type
+    rec.signature.secondary_types = list(signature.secondary_types)
+    rec.primary_mass = primary_mass
+    rec.primary_momentum = [energy, 0.0, 0.0, pz]
+    rec.secondary_masses = [m_sec] * n_sec
+    rec.secondary_momenta = [[0.0, 0.0, 0.0, 0.0]] * n_sec
+    rec.secondary_helicities = [0] * n_sec
+    rec.interaction_vertex = [0.0, 0.0, 0.0]
+    rec.primary_initial_position = [0.0, 0.0, 0.0]
+    return rec
+
+
+# ------------------------------------------------------------------ #
+#  PairMass                                                            #
+# ------------------------------------------------------------------ #
+
+class PairMass:
+    """Invariant-mass sampling law for a 3-body directed channel's pair.
+
+    Carries the fields toward_3body maps onto the
+    DetectorDirected3BodyChannel ctor: mass_mode, resonance_mass,
+    resonance_width, power_law_nu, power_law_offset, mass_cdf_nodes,
+    mass_cdf_values.
+    """
+
+    def __init__(self, mass_mode, resonance_mass=0.0, resonance_width=0.0,
+                 power_law_nu=0.8, power_law_offset=0.0,
+                 mass_cdf_nodes=(), mass_cdf_values=()):
+        self.mass_mode = mass_mode
+        self.resonance_mass = resonance_mass
+        self.resonance_width = resonance_width
+        self.power_law_nu = power_law_nu
+        self.power_law_offset = power_law_offset
+        self.mass_cdf_nodes = list(mass_cdf_nodes)
+        self.mass_cdf_values = list(mass_cdf_values)
+
+    @classmethod
+    def uniform(cls):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.Uniform)
+
+    @classmethod
+    def breit_wigner(cls, m, w):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.BreitWigner,
+                    resonance_mass=m, resonance_width=w)
+
+    @classmethod
+    def power_law(cls, nu, offset=0.0):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.PowerLaw,
+                    power_law_nu=nu, power_law_offset=offset)
+
+    @classmethod
+    def tabulated(cls, nodes, values):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.Tabulated,
+                    mass_cdf_nodes=nodes, mass_cdf_values=values)
+
+
+# ------------------------------------------------------------------ #
+#  Factories                                                           #
+# ------------------------------------------------------------------ #
+
+def isotropic(daughter: Union[int, str] = 0) -> Channel:
+    """Isotropic2BodyChannel wrapped as a Channel.
+
+    `daughter` is either a secondary index or a particle name/ParticleType
+    resolved against the signature at compile time.
+    """
+    def factory(signature, *, detector=None, models=None):
+        siren = _siren()
+        idx = _resolve_index(signature, daughter, "isotropic(daughter=...)")
+        return siren.injection.Isotropic2BodyChannel(idx)
+
+    label = "isotropic" if daughter == 0 else "isotropic({!r})".format(daughter)
+    return Channel(factory, weight=1.0, label=label)
+
+
+def toward(daughter: Union[int, str], target, *, mode=None, volume=-1.0,
+           fraction: Optional[float] = None) -> Union[Channel, Mixture]:
+    """DetectorDirected2BodyChannel toward `target`, daughter named by particle.
+
+    If `fraction` is given and < 1, returns the mixture
+    `fraction*toward(...) + (1-fraction)*isotropic(...)` (a physical
+    fallback for events that miss the target); otherwise a bare directed
+    Channel.
+    """
+    siren = _siren()
+    if mode is None:
+        mode = siren.injection.DirectedMode.Volume
+
+    def factory(signature, *, detector=None, models=None):
+        idx = _resolve_index(signature, daughter, "toward(daughter=...)")
+        return siren.injection.DetectorDirected2BodyChannel(
+            target, idx, mode, volume)
+
+    label = "toward({!r})".format(daughter)
+    directed = Channel(factory, weight=1.0, label=label)
+
+    if fraction is None or fraction >= 1.0:
+        return directed
+    if not (0.0 <= fraction < 1.0):
+        raise ConfigurationError(
+            "toward(fraction={!r}): fraction must be in [0, 1)".format(fraction))
+    return fraction * directed + (1.0 - fraction) * isotropic(daughter)
+
+
+def toward_3body(directed: Union[int, str], target, *,
+                  spectator: Optional[Union[int, str]] = None,
+                  strategy: str = "recursive",
+                  pair_mass: Optional[PairMass] = None,
+                  mode=None) -> Channel:
+    """DetectorDirected3BodyChannel toward `target`.
+
+    strategy='direct' uses the direct ctor (directed_index only, other two
+    indices inferred ascending). strategy='recursive' uses the recursive
+    ctor (spectator/pair indices resolved per signature; `spectator`
+    selects the spectator daughter, the other two secondaries become the
+    pair, with `directed` as the directed member of the pair).
+    """
+    siren = _siren()
+    if mode is None:
+        mode = siren.injection.DirectedMode.Volume
+    if pair_mass is None:
+        pair_mass = PairMass.uniform()
+    if strategy not in ("recursive", "direct"):
+        raise ConfigurationError(
+            "toward_3body(strategy={!r}): must be 'recursive' or 'direct'".format(strategy))
+
+    def factory(signature, *, detector=None, models=None):
+        directed_idx = _resolve_index(signature, directed, "toward_3body(directed=...)")
+        common_kwargs = dict(
+            mass_mode=pair_mass.mass_mode,
+            resonance_mass=pair_mass.resonance_mass,
+            resonance_width=pair_mass.resonance_width,
+            power_law_nu=pair_mass.power_law_nu,
+            power_law_offset=pair_mass.power_law_offset,
+            mode=mode,
+            mass_cdf_nodes=pair_mass.mass_cdf_nodes,
+            mass_cdf_values=pair_mass.mass_cdf_values,
+        )
+        if strategy == "direct":
+            return siren.injection.DetectorDirected3BodyChannel(
+                target, directed_idx, **common_kwargs)
+
+        n_sec = len(signature.secondary_types)
+        if spectator is None:
+            raise ConfigurationError(
+                "toward_3body(strategy='recursive'): spectator= is required "
+                "to resolve the pair indices")
+        spectator_idx = _resolve_index(signature, spectator, "toward_3body(spectator=...)")
+        others = [i for i in range(n_sec) if i != spectator_idx]
+        if directed_idx not in others:
+            raise ConfigurationError(
+                "toward_3body: directed index {} coincides with spectator "
+                "index {} for signature {}".format(directed_idx, spectator_idx, signature))
+        pair_first_idx, pair_second_idx = others[0], others[1]
+        return siren.injection.DetectorDirected3BodyChannel(
+            target, spectator_idx, pair_first_idx, pair_second_idx,
+            directed_idx, **common_kwargs)
+
+    label = "toward_3body({!r}, strategy={!r})".format(directed, strategy)
+    return Channel(factory, weight=1.0, label=label)
+
+
+def scatter_toward(target, *, variable=None, q2_mode=None,
+                    mediator_mass=0.0, mode=None) -> Channel:
+    """DetectorDirectedScatteringChannel toward `target`."""
+    siren = _siren()
+    if mode is None:
+        mode = siren.injection.DirectedMode.Volume
+    if variable is None:
+        variable = siren.injection.ScatteringVariable.Q2
+    if q2_mode is None:
+        q2_mode = siren.injection.ScatteringQ2Mode.Geometry
+
+    def factory(signature, *, detector=None, models=None):
+        return siren.injection.DetectorDirectedScatteringChannel(
+            target, 0, variable, mode, q2_mode, mediator_mass)
+
+    return Channel(factory, weight=1.0, label="scatter_toward")
+
+
+def physical() -> Channel:
+    """Late-binds PhysicalDecayChannel or PhysicalCrossSectionChannel.
+
+    Resolution happens at compile time and needs the vertex's interaction
+    model(s), passed as `models=[...]` to Mixture.compile()/validate().
+    Exactly one model matching the signature (by GetPossibleSignatures, if
+    available, else taken as-is) must be supplied; otherwise raises
+    ConfigurationError with a one-line fix.
+    """
+    def factory(signature, *, detector=None, models=None):
+        siren = _siren()
+        if not models:
+            raise ConfigurationError(
+                "physical(): no interaction model available to late-bind; "
+                "pass models=[<Decay or CrossSection>] to Mixture.compile()/"
+                "validate()")
+        candidates = list(models)
+        if len(candidates) > 1:
+            raise ConfigurationError(
+                "physical(): {} candidate models supplied, expected exactly "
+                "one; pass models=[<the single Decay or CrossSection for "
+                "this vertex>]".format(len(candidates)))
+        model = candidates[0]
+        if isinstance(model, siren.interactions.Decay):
+            return siren.injection.PhysicalDecayChannel(model, signature)
+        if isinstance(model, siren.interactions.CrossSection):
+            return siren.injection.PhysicalCrossSectionChannel(model, signature)
+        raise ConfigurationError(
+            "physical(): model {!r} is neither a Decay nor a CrossSection".format(model))
+
+    return Channel(factory, weight=1.0, label="physical")
+
+
+# ------------------------------------------------------------------ #
+#  Tiling                                                              #
+# ------------------------------------------------------------------ #
+
+class Tiling(_MixtureNode):
+    """A grid/disjoint tiling of a geometry, treated as one Channel-like unit.
+
+    Wraps directed_tiling.build_grid_tiling/disjointify; the optimizer
+    tunes the tiling's inner weights as one nested level (see
+    NestedMixtureChannel), never touching the outer mixture's weight for
+    it directly.  Participates in Mixture algebra the same way a Channel
+    does.
+    """
+
+    def __init__(self, factory: Callable, weight: float = 1.0,
+                 label: str = "tile"):
+        self._factory = factory
+        self.weight = float(weight)
+        self.label = label
+
+    def _copy_with_weight(self, weight):
+        return Tiling(self._factory, weight, self.label)
+
+
+def tile(geometry, grid: int, method: str = "disjoint",
+         daughter: Union[int, str] = 0, mode=None) -> Tiling:
+    """Tile `geometry` into a grid of directed sub-channels.
+
+    `grid` is the number of cells per axis (an axis-aligned Box region is
+    required, matching directed_tiling.grid_cells).  method='disjoint'
+    routes through directed_tiling.disjointify on the grid cells (already
+    disjoint by construction, so disjointify is a no-op composition step
+    kept for a uniform call path); any other method raises
+    ConfigurationError.
+    """
+    if method != "disjoint":
+        raise ConfigurationError(
+            "tile(method={!r}): only 'disjoint' is supported".format(method))
+
+    def factory(signature, *, detector=None, models=None):
+        siren = _siren()
+        if mode is None:
+            resolved_mode = siren.injection.DirectedMode.Volume
+        else:
+            resolved_mode = mode
+        idx = _resolve_index(signature, daughter, "tile(daughter=...)")
+        cells = _tiling.grid_cells(geometry, grid)
+        disjoint_cells = _tiling.disjointify(cells)
+        chan_factory = _tiling.default_2body_factory(idx, resolved_mode)
+        return _tiling._wrap(disjoint_cells, chan_factory, True, 100000)
+
+    return Tiling(factory, weight=1.0, label="tile(grid={})".format(grid))

--- a/python/channels.py
+++ b/python/channels.py
@@ -111,12 +111,12 @@ class _MixtureNode:
         if isinstance(other, _MixtureNode):
             return Mixture([(self.weight, self), (other.weight, other)])
         if isinstance(other, Mixture):
-            return Mixture([(self.weight, self)] + list(other._entries))
+            return Mixture([(self.weight, self)] + other._scaled_entries())
         return NotImplemented
 
     def __radd__(self, other):
         if isinstance(other, Mixture):
-            return Mixture(list(other._entries) + [(self.weight, self)])
+            return Mixture(other._scaled_entries() + [(self.weight, self)])
         return NotImplemented
 
     def describe(self) -> str:
@@ -170,26 +170,36 @@ class Mixture:
                 "Mixture: weights sum to {!r}, must be finite and positive".format(total))
         self._entries: List[Tuple[float, "Channel"]] = [
             (w / total, ch) for w, ch in entries]
+        # A composition scale carried by `*`: `p * mixture` sets it so that
+        # `p * mix_a + q * mix_b` gives each sub-channel its p (or q) share of
+        # the combined mixture. It never affects a standalone mixture's
+        # normalized `_entries`.
+        self._scale = 1.0
+
+    def _scaled_entries(self):
+        """The entries as (scale * relative_weight, channel) pairs."""
+        return [(self._scale * w, ch) for w, ch in self._entries]
 
     def __add__(self, other):
         if isinstance(other, _MixtureNode):
-            return Mixture(list(self._entries) + [(other.weight, other)])
+            return Mixture(self._scaled_entries() + [(other.weight, other)])
         if isinstance(other, Mixture):
-            return Mixture(list(self._entries) + list(other._entries))
+            return Mixture(self._scaled_entries() + other._scaled_entries())
         return NotImplemented
 
     def __radd__(self, other):
         if isinstance(other, _MixtureNode):
-            return Mixture([(other.weight, other)] + list(self._entries))
+            return Mixture([(other.weight, other)] + self._scaled_entries())
         return NotImplemented
 
     def __rmul__(self, scalar):
         if not isinstance(scalar, (int, float)):
             return NotImplemented
-        # Rescaling a normalized mixture by a positive scalar renormalizes
-        # right back to the same mixture; kept for algebraic symmetry with
-        # Channel.__rmul__ so `p * mix_a + (1 - p) * mix_b` composes.
-        return Mixture([(scalar * w, ch) for w, ch in self._entries])
+        # Carry the scale for composition without disturbing the normalized
+        # entries, so `p * mix_a + q * mix_b` splits p and q across the mixtures.
+        scaled = Mixture(list(self._entries))
+        scaled._scale = float(scalar)
+        return scaled
 
     def describe(self) -> str:
         parts = ["{:.2f} * {}".format(w, ch.describe()) for w, ch in self._entries]

--- a/python/errors.py
+++ b/python/errors.py
@@ -1,0 +1,57 @@
+"""Typed error vocabulary for SIREN's high-level interface.
+
+Re-exports the pybind-translated C++ exceptions (registered on
+``siren.utilities`` with a ``RuntimeError`` base) under one namespace and adds
+the pure-Python errors the Layer-2 surface raises. Every name here derives from
+``RuntimeError`` (or ``Exception``) so existing ``pytest.raises(RuntimeError)``
+call sites keep matching.
+"""
+
+from . import utilities as _utilities
+
+# ---- C++ exceptions surfaced through pybind (siren.utilities) ----
+ConfigurationError = _utilities.ConfigurationError
+MeasureCompatibilityError = _utilities.MeasureCompatibilityError
+WeightCalculationError = _utilities.WeightCalculationError
+AddProcessFailure = _utilities.AddProcessFailure
+SecondaryProcessFailure = _utilities.SecondaryProcessFailure
+InjectionFailure = _utilities.InjectionFailure
+PythonImplementationError = _utilities.PythonImplementationError
+
+
+# ---- Pure-Python errors for the Layer-2 surface ----
+class ClosureError(RuntimeError):
+    """A sampler and its density disagree beyond tolerance.
+
+    Raised by the closure gauge when a model's FinalStateProbability does not
+    match the distribution its SampleFinalState draws from.
+    """
+
+
+class NotSerializableError(RuntimeError):
+    """An injector or weighter cannot be round-tripped to disk.
+
+    Raised by ``Injector.save`` when the configuration holds objects that do
+    not survive serialization: Python trampoline-derived interactions or
+    distributions, or a non-Propagated weighting mode / per-signature phase
+    space (neither is archived by the C++ process, so a reloaded injector would
+    silently carry the wrong physics).
+    """
+
+    def __init__(self, message, offenders=None):
+        super().__init__(message)
+        self.offenders = list(offenders) if offenders is not None else []
+
+
+class InjectionShortfall(RuntimeError):
+    """Generation produced fewer successes than requested.
+
+    Carries the ``InjectionReport`` describing where attempts were lost so the
+    caller can act on it. Raised (or, under ``on_shortfall='warn'``, attached
+    to a warning) when the attempt budget is exhausted or efficiency falls
+    below ``min_efficiency`` before the requested count is reached.
+    """
+
+    def __init__(self, message, report=None):
+        super().__init__(message)
+        self.report = report

--- a/python/errors.py
+++ b/python/errors.py
@@ -43,13 +43,14 @@ class NotSerializableError(RuntimeError):
         self.offenders = list(offenders) if offenders is not None else []
 
 
-class InjectionShortfall(RuntimeError):
+class InjectionShortfall(RuntimeError, UserWarning):
     """Generation produced fewer successes than requested.
 
-    Carries the ``InjectionReport`` describing where attempts were lost so the
-    caller can act on it. Raised (or, under ``on_shortfall='warn'``, attached
-    to a warning) when the attempt budget is exhausted or efficiency falls
-    below ``min_efficiency`` before the requested count is reached.
+    Both an exception and a warning: ``on_shortfall='raise'`` raises it,
+    ``'warn'`` passes the instance to ``warnings.warn``. Carries the
+    ``InjectionReport`` describing where attempts were lost. Raised when the
+    attempt budget is exhausted or efficiency falls below ``min_efficiency``
+    before the requested count is reached.
     """
 
     def __init__(self, message, report=None):

--- a/python/expand.py
+++ b/python/expand.py
@@ -1,0 +1,192 @@
+"""Expansion vocabulary for chain-vertex secondary recursion.
+
+An expansion rule is an instruction attached to a chain vertex saying
+which of its secondaries should recurse into their own vertex. Rules are
+combined with the vertex's optional ``continue_if`` predicate and
+compiled into one ``stopping_condition(tree, parent, i)`` callable with
+the engine's polarity: the engine calls it for secondary index ``i`` of
+``parent`` and, when it returns True, that secondary is pruned (not
+expanded). False means the secondary is expanded. See
+``Injector.SetStoppingCondition`` and the call site in
+``projects/injection/private/Injector.cxx``.
+
+Rule types
+----------
+``child(name, index=None)``
+    Expand the secondary named ``name`` (a particle name or
+    ParticleType, resolved against the parent signature at compile
+    time). If ``index`` is given, only the occurrence of that particle
+    at that position among the parent's secondaries matches.
+
+``depth_below(n)``
+    Expand every secondary while ``parent.depth(tree) < n``. Independent
+    of particle identity.
+
+Vertex description (duck-typed)
+--------------------------------
+``compile_expansion`` and ``validate_expansion_wiring`` (in
+``_validation.py``) accept ``vertices`` as any iterable of objects with:
+
+``particle``
+    The ParticleType or particle name this vertex produces/handles
+    (i.e. the parent particle whose secondaries this vertex's ``expand``
+    list governs).
+``expand``
+    A tuple of rule objects from ``child()`` / ``depth_below()``.
+``continue_if``
+    ``None`` or a callable ``(tree, parent, i) -> bool``; True means the
+    secondary may proceed (subject also to the expand-list match), False
+    forces a prune regardless of the expand list.
+
+A plain namedtuple (``VertexSpec`` below) satisfies this; any object
+exposing the same three attributes works too. This module never imports
+``python/vertex.py`` -- the real Vertex compiler builds these records
+from Vertex objects itself.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+from . import particles as _particles
+
+__all__ = [
+    "child",
+    "depth_below",
+    "compile_expansion",
+    "VertexSpec",
+]
+
+
+_VertexSpecBase = namedtuple(
+    "VertexSpec", ["particle", "expand", "continue_if", "secondary_types"]
+)
+_VertexSpecBase.__new__.__defaults__ = (None,)
+
+
+class VertexSpec(_VertexSpecBase):
+    """Minimal duck-typed vertex description consumed by this module.
+
+    `secondary_types` is optional and only consulted by
+    `_validation.validate_expansion_wiring` for its "secondaries with no
+    expansion declaration" check; `compile_expansion` never reads it.
+    """
+
+
+class _ChildRule:
+    """Expansion rule matching a secondary by particle type (and index)."""
+
+    __slots__ = ("name", "index")
+
+    def __init__(self, name, index=None):
+        self.name = name
+        self.index = index
+
+    def _matches(self, ptype, i):
+        if self.index is not None and i != self.index:
+            return False
+        return ptype == _particles.resolve(self.name)
+
+    def __repr__(self):
+        if self.index is None:
+            return f"child({self.name!r})"
+        return f"child({self.name!r}, index={self.index!r})"
+
+
+class _DepthBelowRule:
+    """Expansion rule matching every secondary while parent depth < n."""
+
+    __slots__ = ("n",)
+
+    def __init__(self, n):
+        self.n = n
+
+    def _matches_depth(self, depth):
+        return depth < self.n
+
+    def __repr__(self):
+        return f"depth_below({self.n!r})"
+
+
+def child(name, index=None):
+    """Return a rule expanding the secondary named `name`.
+
+    Parameters
+    ----------
+    name : str or ParticleType
+        Particle identifying which secondary to expand.
+    index : int, optional
+        Restrict the match to the secondary at this position among the
+        parent's ``secondary_types``. Without it, every occurrence of
+        `name` matches.
+    """
+    return _ChildRule(name, index=index)
+
+
+def depth_below(n):
+    """Return a rule expanding all secondaries while parent depth < n."""
+    return _DepthBelowRule(n)
+
+
+def _index_vertices_by_particle(vertices):
+    """Map resolved ParticleType -> vertex spec, first match wins."""
+    by_particle = {}
+    for v in vertices:
+        ptype = _particles.resolve(v.particle)
+        if ptype not in by_particle:
+            by_particle[ptype] = v
+    return by_particle
+
+
+def _rule_permits(rule, ptype, i, depth):
+    if isinstance(rule, _ChildRule):
+        return rule._matches(ptype, i)
+    if isinstance(rule, _DepthBelowRule):
+        return rule._matches_depth(depth)
+    return False
+
+
+def compile_expansion(vertices):
+    """Compile per-vertex expand rules into one stopping_condition callable.
+
+    Parameters
+    ----------
+    vertices : iterable
+        Objects with ``.particle``, ``.expand`` (tuple of rules from
+        ``child()``/``depth_below()``), and ``.continue_if``
+        (callable or None). See module docstring for the exact contract.
+
+    Returns
+    -------
+    callable
+        ``stopping_condition(tree, parent, i) -> bool`` in the engine's
+        native polarity: True prunes secondary `i` of `parent`, False
+        expands it. Safe to pass directly to
+        ``Injector.SetStoppingCondition`` / the ``stopping_condition``
+        constructor argument.
+    """
+    by_particle = _index_vertices_by_particle(vertices)
+
+    def stopping_condition(tree, parent, i):
+        primary_type = parent.record.signature.primary_type
+        vertex = by_particle.get(primary_type)
+        if vertex is None:
+            return True
+
+        secondary_types = parent.record.signature.secondary_types
+        ptype = secondary_types[i]
+        depth = parent.depth(tree)
+
+        matched = any(
+            _rule_permits(rule, ptype, i, depth) for rule in vertex.expand
+        )
+        if not matched:
+            return True
+
+        if vertex.continue_if is not None:
+            if not vertex.continue_if(tree, parent, i):
+                return True
+
+        return False
+
+    return stopping_condition

--- a/python/generate.py
+++ b/python/generate.py
@@ -1,0 +1,26 @@
+"""One-call generation + weighting entry point.
+
+generate(injector, weighter, *, events, ...) drives the injector to `events`
+successful trees and weights them through the weighter, returning a Results
+snapshot of the trees and their weights.
+"""
+
+from __future__ import annotations
+
+from .Results import Results
+
+
+def generate(injector, weighter, *, events, on_shortfall="warn",
+             progress=None, min_efficiency=None):
+    """Generate `events` weighted trees.
+
+    Delegates generation to ``injector.generate`` (which counts successes and
+    honours ``on_shortfall``/``min_efficiency``), weights via
+    ``weighter.weight_all``, and returns a Results over the trees and weights.
+    """
+    trees = injector.generate(
+        events, on_shortfall=on_shortfall, progress=progress,
+        min_efficiency=min_efficiency)
+    weights = weighter.weight_all(trees)
+    gen_times = [0.0] * len(trees)
+    return Results(list(trees), list(weights), gen_times, weighter, injector)

--- a/python/report.py
+++ b/python/report.py
@@ -1,0 +1,246 @@
+"""Rendering layer over the engine's failure ledger and weight breakdown.
+
+InjectionReport turns an Injector's FailureLedger into a readable attrition
+table with per-reason remedies; WeightBreakdown turns a Weighter's
+EventWeightBreakdown into a per-vertex weight decomposition that names the
+culprit vertex behind an inf/zero/NaN weight. Neither computes physics; both
+read structures the engine already produced.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Tuple
+
+from . import injection as _injection
+from . import particles as _particles
+
+
+def _reason_name(reason) -> str:
+    return getattr(reason, "name", str(reason))
+
+
+def _pdg_name(pdg: int) -> str:
+    """Human name for a PDG code, falling back to the integer."""
+    try:
+        ptype = _particles.resolve(int(pdg))
+        return getattr(ptype, "name", str(pdg))
+    except Exception:
+        return str(pdg)
+
+
+# One-line remedy per FailureReason. Keyed by the enum member name so a new
+# reason without a hint still renders (its name plus a generic line).
+_REASON_HINTS: Dict[str, str] = {
+    "NoTargetsOnPath":
+        "the sampled path crosses no interaction target; widen the vertex "
+        "distribution's region or check the detector materials",
+    "NoPathThroughVolume":
+        "the primary direction never enters the injection volume; check the "
+        "direction distribution and the volume placement",
+    "NoColumnDepthSolution":
+        "no column-depth solution along the path; the energy or geometry "
+        "leaves the vertex sampler with no root",
+    "KinematicallyForbidden":
+        "the sampled kinematics are below threshold; check masses and the "
+        "primary energy range",
+    "UnregisteredSecondaryType":
+        "a produced secondary has no registered Vertex; add a secondary "
+        "Vertex for it or prune it in the expand list",
+    "PrimaryVertexFailure":
+        "the primary vertex could not be sampled; inspect the primary "
+        "position/energy distributions",
+    "TopLevelCatch":
+        "an unclassified failure escaped to the top level; inspect the "
+        "exemplar message",
+    "Unspecified":
+        "failure reason not tagged; inspect the exemplar message",
+}
+
+
+class VertexAttrition:
+    """One (depth, particle, reason) bucket of injection failures."""
+
+    __slots__ = ("depth", "pdg", "reason", "count", "exemplar")
+
+    def __init__(self, depth: int, pdg: int, reason, count: int, exemplar: str):
+        self.depth = depth
+        self.pdg = pdg
+        self.reason = reason
+        self.count = count
+        self.exemplar = exemplar
+
+    @property
+    def reason_name(self) -> str:
+        return _reason_name(self.reason)
+
+    @property
+    def particle(self) -> str:
+        return _pdg_name(self.pdg)
+
+    @property
+    def hint(self) -> str:
+        return _REASON_HINTS.get(self.reason_name, "inspect the exemplar message")
+
+    def __repr__(self):
+        return ("VertexAttrition(depth={} particle={} reason={} count={})"
+                .format(self.depth, self.particle, self.reason_name, self.count))
+
+
+class InjectionReport:
+    """Readable view of an injection run's outcome.
+
+    attempts/successes are the realized counts; by_vertex is the attrition
+    breakdown; last_failed_tree is the most recent partial tree on a primary
+    failure (may be empty). dominant() names the reason that lost the most
+    attempts.
+    """
+
+    __slots__ = ("attempts", "successes", "by_vertex", "last_failed_tree")
+
+    def __init__(self, attempts: int, successes: int,
+                 by_vertex: List[VertexAttrition],
+                 last_failed_tree=None):
+        self.attempts = attempts
+        self.successes = successes
+        self.by_vertex = list(by_vertex)
+        self.last_failed_tree = last_failed_tree
+
+    @classmethod
+    def from_ledger(cls, ledger, *, attempts: int, successes: int,
+                    last_failed_tree=None) -> "InjectionReport":
+        """Build a report from an engine FailureLedger.
+
+        ledger.entries() maps (depth, parent_pdg, FailureReason) to
+        (count, exemplar).
+        """
+        buckets = []
+        for (depth, pdg, reason), (count, exemplar) in ledger.entries().items():
+            buckets.append(VertexAttrition(depth, pdg, reason, count, exemplar))
+        buckets.sort(key=lambda b: b.count, reverse=True)
+        return cls(attempts, successes, buckets, last_failed_tree)
+
+    @property
+    def failures(self) -> int:
+        return sum(b.count for b in self.by_vertex)
+
+    @property
+    def efficiency(self) -> float:
+        if self.attempts <= 0:
+            return float("nan")
+        return self.successes / self.attempts
+
+    def dominant(self) -> Optional[VertexAttrition]:
+        """The attrition bucket that lost the most attempts, or None."""
+        if not self.by_vertex:
+            return None
+        return max(self.by_vertex, key=lambda b: b.count)
+
+    def __str__(self):
+        lines = []
+        eff = self.efficiency
+        eff_str = "{:.1%}".format(eff) if math.isfinite(eff) else "n/a"
+        lines.append("InjectionReport: {}/{} succeeded (efficiency {})".format(
+            self.successes, self.attempts, eff_str))
+        if not self.by_vertex:
+            lines.append("  no failures recorded")
+            return "\n".join(lines)
+        lines.append("  {:<6} {:<14} {:<26} {:>8}".format(
+            "depth", "particle", "reason", "count"))
+        for b in self.by_vertex:
+            lines.append("  {:<6} {:<14} {:<26} {:>8}".format(
+                b.depth, b.particle, b.reason_name, b.count))
+        dom = self.dominant()
+        if dom is not None:
+            lines.append("  dominant: {} ({}x) -- {}".format(
+                dom.reason_name, dom.count, dom.hint))
+        return "\n".join(lines)
+
+
+class VertexWeightLine:
+    """One vertex's factors within a weight breakdown."""
+
+    __slots__ = ("depth", "pdg", "generation", "physical",
+                 "channel_densities", "cancelled", "flags")
+
+    def __init__(self, depth, pdg, generation, physical,
+                 channel_densities, cancelled, flags):
+        self.depth = depth
+        self.pdg = pdg
+        self.generation = generation
+        self.physical = physical
+        self.channel_densities = dict(channel_densities)
+        self.cancelled = list(cancelled)
+        self.flags = list(flags)
+
+    @property
+    def particle(self) -> str:
+        return _pdg_name(self.pdg)
+
+    @property
+    def is_ok(self) -> bool:
+        return (math.isfinite(self.physical) and self.physical > 0.0
+                and math.isfinite(self.generation) and self.generation > 0.0)
+
+    def __repr__(self):
+        flag = "" if self.is_ok else " !!!"
+        return ("VertexWeightLine(d={} {} gen={:.3e} phys={:.3e}{})".format(
+            self.depth, self.particle, self.generation, self.physical, flag))
+
+
+class WeightBreakdown:
+    """Per-vertex decomposition of one event's weight.
+
+    total is the event weight; vertices are the per-vertex factor lines.
+    culprit() names the first vertex whose factors explain a non-finite or
+    zero total.
+    """
+
+    __slots__ = ("total", "vertices")
+
+    def __init__(self, total: float, vertices: List[VertexWeightLine]):
+        self.total = total
+        self.vertices = list(vertices)
+
+    @classmethod
+    def from_engine(cls, breakdown) -> "WeightBreakdown":
+        """Build from an engine EventWeightBreakdown struct."""
+        lines = []
+        for v in breakdown.vertices:
+            lines.append(VertexWeightLine(
+                v.depth, v.vertex_pdg, v.generation, v.physical,
+                v.channel_densities, v.cancelled, v.flags))
+        return cls(breakdown.total, lines)
+
+    def culprit(self) -> Optional[VertexWeightLine]:
+        """The first vertex whose factors explain a bad total, or None."""
+        if math.isfinite(self.total) and self.total > 0.0:
+            return None
+        for v in self.vertices:
+            if not v.is_ok:
+                return v
+        return None
+
+    def __str__(self):
+        ok = math.isfinite(self.total) and self.total > 0.0
+        lines = ["WeightBreakdown: total={:.6e}{}".format(
+            self.total, "" if ok else " (unusable)")]
+        for v in self.vertices:
+            line = "  d={} {:<12} gen={:.3e} phys={:.3e}".format(
+                v.depth, v.particle, v.generation, v.physical)
+            extras = []
+            if v.cancelled:
+                extras.append("cancelled=" + ",".join(v.cancelled))
+            if v.flags:
+                extras.append("flags=" + ";".join(v.flags))
+            if not v.is_ok:
+                extras.append("!!!")
+            if extras:
+                line += "  [" + " ".join(extras) + "]"
+            lines.append(line)
+        culprit = self.culprit()
+        if culprit is not None:
+            lines.append("  culprit: d={} {} ({})".format(
+                culprit.depth, culprit.particle,
+                ";".join(culprit.flags) or "no positive support"))
+        return "\n".join(lines)

--- a/python/report.py
+++ b/python/report.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import math
 from typing import Dict, List, Optional
 
-from . import particles as _particles
+from . import dataclasses as _dataclasses
 
 
 def _reason_name(reason) -> str:
@@ -22,9 +22,8 @@ def _reason_name(reason) -> str:
 def _pdg_name(pdg: int) -> str:
     """Human name for a PDG code, falling back to the integer."""
     try:
-        ptype = _particles.resolve(int(pdg))
-        return getattr(ptype, "name", str(pdg))
-    except Exception:
+        return _dataclasses.ParticleType(int(pdg)).name
+    except (ValueError, TypeError):
         return str(pdg)
 
 

--- a/python/report.py
+++ b/python/report.py
@@ -10,9 +10,8 @@ read structures the engine already produced.
 from __future__ import annotations
 
 import math
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
-from . import injection as _injection
 from . import particles as _particles
 
 

--- a/python/vertex.py
+++ b/python/vertex.py
@@ -17,8 +17,6 @@ holds it via a pybind trampoline pointer.
 
 from __future__ import annotations
 
-from typing import Callable, List, Optional, Sequence, Tuple, Union
-
 from . import particles as _particles
 from . import expand as _expand
 from .errors import ConfigurationError

--- a/python/vertex.py
+++ b/python/vertex.py
@@ -1,0 +1,251 @@
+"""Vertex: one chain node's interactions, distributions, and phase space.
+
+A Vertex describes everything the engine needs to compile one
+PrimaryInjectionProcess (root) or SecondaryInjectionProcess (non-root)
+node: which particle it is, which Decay/CrossSection models drive it,
+which injection distributions sample its free parameters, and which
+channels.Mixture/_directed.Directed biases its phase-space sampling.
+Vertex.compile() builds the engine process object; Vertex.as_vertex_spec()
+builds the expand.VertexSpec consumed by expand.compile_expansion().
+
+A Vertex holds strong references to every Python object it is handed
+(models, distributions, mixtures) for the lifetime of the Vertex, so a
+Python-subclassed trampoline (a DarkNews model, a custom distribution)
+is not collected out from under the compiled C++ process, which only
+holds it via a pybind trampoline pointer.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Sequence, Tuple, Union
+
+from . import particles as _particles
+from . import expand as _expand
+from .errors import ConfigurationError
+
+__all__ = ["Vertex"]
+
+
+def _siren():
+    import siren
+    return siren
+
+
+def _resolve_weighting_mode(weighting):
+    """Resolve `weighting` to an engine VertexWeightingMode.
+
+    Accepts an already-built VertexWeightingMode (from either
+    siren.injection.VertexWeightingMode -- where it actually lives -- or
+    a future siren.dataclasses.VertexWeightingMode / siren.Propagated /
+    siren.Fixed re-export), or None (defaults to Propagated()).
+    """
+    siren = _siren()
+    if weighting is None:
+        return siren.injection.VertexWeightingMode.Propagated()
+    return weighting
+
+
+def _as_list(interactions):
+    if interactions is None:
+        return []
+    if isinstance(interactions, (list, tuple)):
+        return list(interactions)
+    return [interactions]
+
+
+def _model_signatures(model):
+    """GetPossibleSignatures() for a Decay or CrossSection model.
+
+    Both bases expose the same method name; this just centralizes the
+    call so Vertex.compile() does not care which base `model` derives
+    from.
+    """
+    return list(model.GetPossibleSignatures())
+
+
+def _as_compilable(kinematics):
+    """Normalize `kinematics` to something exposing compile(sig, ...).
+
+    channels.Mixture, _directed.Directed, and _directed's
+    by_signature() result all already expose compile(signature, *,
+    detector, models); a bare channels.Channel/Tiling (the un-mixed
+    single-channel case) does not, so it is wrapped in a
+    one-entry Mixture.
+    """
+    if hasattr(kinematics, "compile"):
+        return kinematics
+    from . import channels as _channels
+    if isinstance(kinematics, _channels._MixtureNode):
+        return _channels.Mixture([(kinematics.weight, kinematics)])
+    raise ConfigurationError(
+        "Vertex(kinematics=...): expected a channels.Mixture, "
+        "channels.Channel/Tiling, or _directed.Directed, got {!r}".format(
+            type(kinematics).__name__))
+
+
+class Vertex:
+    """One chain node: particle, interactions, distributions, phase space.
+
+    Parameters
+    ----------
+    particle : str or ParticleType
+        The particle this vertex is compiled for (the primary of the
+        root vertex, or the secondary type of a non-root vertex).
+    interactions : Decay/CrossSection or list thereof
+        The interaction model(s) driving this vertex.
+    distributions : list, optional
+        PrimaryInjectionDistribution / SecondaryInjectionDistribution
+        objects sampling this vertex's free parameters.
+    position : optional
+        Convenience vertex-position distribution, appended to
+        `distributions` if given.
+    physical : list, optional
+        Physical-side distributions kept on the Vertex for the Weighter
+        to read; not consumed by Vertex.compile() itself.
+    kinematics : channels.Mixture, channels.Channel, _directed.Directed, optional
+        Phase-space biasing description, compiled once per signature
+        enumerated from `interactions`. None means no phase space is
+        registered (the engine's default sampler is used).
+    weighting : VertexWeightingMode, optional
+        Defaults to Propagated(). Accepts the engine enum value however
+        it is currently exposed (siren.injection.VertexWeightingMode
+        today; siren.dataclasses.VertexWeightingMode / siren.Propagated /
+        siren.Fixed once re-exported).
+    expand : tuple, optional
+        Expansion rules from expand.child() / expand.depth_below().
+    continue_if : callable, optional
+        (tree, parent, i) -> bool predicate consulted by
+        expand.compile_expansion().
+    label : str, optional
+        Human-readable label, not consumed by the engine.
+
+    Everything after `interactions` is keyword-only. Field storage uses
+    __slots__: assigning an unknown attribute raises AttributeError
+    instead of silently creating a new one, so a typo'd field name (a
+    common failure mode of a duck-typed config surface) is caught
+    immediately rather than silently ignored.
+    """
+
+    __slots__ = (
+        "particle",
+        "_resolved_particle",
+        "interactions",
+        "distributions",
+        "physical",
+        "kinematics",
+        "weighting",
+        "expand",
+        "continue_if",
+        "label",
+    )
+
+    def __init__(self, particle, interactions, *, distributions=None,
+                 position=None, physical=None, kinematics=None,
+                 weighting=None, expand=(), continue_if=None, label=None):
+        self.particle = particle
+        self._resolved_particle = _particles.resolve(particle)
+        self.interactions = _as_list(interactions)
+        if not self.interactions:
+            raise ConfigurationError(
+                "Vertex(particle={!r}): interactions must be a Decay/"
+                "CrossSection or a non-empty list thereof".format(particle))
+
+        dists = list(distributions) if distributions is not None else []
+        if position is not None:
+            dists.append(position)
+        self.distributions = dists
+
+        self.physical = list(physical) if physical is not None else []
+        self.kinematics = kinematics
+        self.weighting = weighting
+        self.expand = tuple(expand)
+        self.continue_if = continue_if
+        self.label = label
+
+    # ------------------------------------------------------------------ #
+    #  Introspection                                                       #
+    # ------------------------------------------------------------------ #
+
+    def is_primary(self, *, is_primary):
+        """Return whether this Vertex would compile as a primary process."""
+        return bool(is_primary)
+
+    def is_secondary(self, *, is_primary):
+        """Return whether this Vertex would compile as a secondary process."""
+        return not is_primary
+
+    def _all_signatures(self):
+        """(model, signature) pairs for every model's possible signatures."""
+        pairs = []
+        for model in self.interactions:
+            for sig in _model_signatures(model):
+                pairs.append((model, sig))
+        return pairs
+
+    def as_vertex_spec(self):
+        """Build the expand.VertexSpec for this Vertex.
+
+        `secondary_types` is the union, across every signature this
+        vertex's models can produce, of the secondary particle types --
+        consulted only by expand._validation's "secondaries with no
+        expansion declaration" check, not by compile_expansion itself.
+        """
+        seen = []
+        for _model, sig in self._all_signatures():
+            for t in sig.secondary_types:
+                if t not in seen:
+                    seen.append(t)
+        return _expand.VertexSpec(
+            particle=self._resolved_particle,
+            expand=self.expand,
+            continue_if=self.continue_if,
+            secondary_types=seen,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Compilation                                                         #
+    # ------------------------------------------------------------------ #
+
+    def compile(self, *, is_primary, detector=None):
+        """Compile this Vertex into an engine process.
+
+        Returns a siren.injection.PrimaryInjectionProcess when
+        `is_primary` is True, else a SecondaryInjectionProcess. Builds
+        the InteractionCollection from `self.interactions`, assigns
+        `self.distributions`, registers a phase space for every
+        signature this vertex's models can produce (when `kinematics`
+        is not None), and sets `weighting_mode`.
+        """
+        siren = _siren()
+
+        interaction_collection = siren.interactions.InteractionCollection(
+            self._resolved_particle, self.interactions)
+
+        if is_primary:
+            process = siren.injection.PrimaryInjectionProcess(
+                self._resolved_particle, interaction_collection)
+        else:
+            process = siren.injection.SecondaryInjectionProcess(
+                self._resolved_particle, interaction_collection)
+
+        process.distributions = self.distributions
+
+        if self.kinematics is not None:
+            compilable = _as_compilable(self.kinematics)
+            for model, sig in self._all_signatures():
+                mcps = compilable.compile(
+                    sig, detector=detector, models=[model])
+                process.SetPhaseSpace(sig, mcps)
+
+        process.weighting_mode = _resolve_weighting_mode(self.weighting)
+
+        # `self.interactions`/`self.distributions`/`self.kinematics` are the
+        # strong references keeping every Python model, distribution, and
+        # mixture alive for as long as this Vertex is alive (the pybind
+        # process objects above hold no __dict__ of their own to pin
+        # keepalives on -- they are not built with dynamic_attr()). The
+        # compiled process's Python-side trampolines (a DarkNews model, a
+        # custom distribution) therefore survive gc.collect() exactly as
+        # long as the Vertex that compiled them does; callers that want the
+        # process to outlive the Vertex must keep the Vertex around too.
+        return process

--- a/tests/python/test_channels_algebra.py
+++ b/tests/python/test_channels_algebra.py
@@ -442,3 +442,18 @@ class TestPhysical:
         mix = channels.Mixture([(1.0, channels.physical())])
         mcps = mix.compile(sig, models=[xs])
         assert isinstance(mcps.channels[0], siren.injection.PhysicalCrossSectionChannel)
+
+
+class TestCompositionScale:
+
+    def test_scaled_mixture_composition_splits_shares(self):
+        """p * mix_a + q * channel gives each sub-channel its share of the total."""
+        composed = (0.3 * (0.5 * channels.isotropic(0) + 0.5 * channels.isotropic(1))
+                    + 0.7 * channels.isotropic(0))
+        weights = [round(w, 6) for w, _ in composed._entries]
+        assert weights == [0.15, 0.15, 0.7]
+
+    def test_standalone_mixture_stays_normalized(self):
+        """A scaled mixture used on its own is still normalized to sum 1."""
+        mix = 0.3 * (0.5 * channels.isotropic(0) + 0.5 * channels.isotropic(1))
+        assert math.isclose(sum(w for w, _ in mix._entries), 1.0)

--- a/tests/python/test_channels_algebra.py
+++ b/tests/python/test_channels_algebra.py
@@ -1,0 +1,444 @@
+"""Channel algebra: normalization, name resolution, PairMass, tiling,
+and Mixture.validate() config-time checks.
+
+All tests are data-free: no detector model, no data files. Anything that
+genuinely needs one is skipped with pytest.skip.
+"""
+
+import math
+
+import pytest
+
+siren = pytest.importorskip("siren")
+channels = pytest.importorskip("siren.channels")
+
+
+# ------------------------------------------------------------------ #
+#  Helpers                                                             #
+# ------------------------------------------------------------------ #
+
+
+def _box_at(z, half=1.0):
+    return siren.geometry.Box(
+        siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, z)),
+        2.0 * half, 2.0 * half, 2.0 * half)
+
+
+def _decay2body_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+    return sig
+
+
+def _decay3body_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [
+        siren.particles.NuLight, siren.particles.EMinus, siren.particles.EPlus]
+    return sig
+
+
+def _scatter_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.NuMu
+    sig.target_type = siren.dataclasses.ParticleType.O16Nucleus
+    sig.secondary_types = [siren.particles.NuMu, siren.dataclasses.ParticleType.O16Nucleus]
+    return sig
+
+
+def _scatter_record(bjorken_y=0.3, E=1.0, m_target=14.9):
+    rec = siren.dataclasses.InteractionRecord()
+    rec.signature = _scatter_signature()
+    rec.primary_mass = 0.0
+    rec.primary_momentum = [E, 0.0, 0.0, E]
+    rec.target_mass = m_target
+    rec.secondary_masses = [0.0, m_target]
+    rec.secondary_momenta = [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    rec.secondary_helicities = [0, 0]
+    rec.interaction_vertex = [0.0, 0.0, 0.0]
+    rec.primary_initial_position = [0.0, 0.0, 0.0]
+    rec.interaction_parameters = {"bjorken_y": bjorken_y}
+    return rec
+
+
+# ------------------------------------------------------------------ #
+#  Normalization by construction                                       #
+# ------------------------------------------------------------------ #
+
+class TestNormalization:
+
+    def test_add_normalizes(self):
+        mix = 0.3 * channels.isotropic() + 0.7 * channels.isotropic("Gamma")
+        weights = [w for w, _ in mix._entries]
+        assert math.isclose(sum(weights), 1.0)
+        assert math.isclose(weights[0], 0.3)
+        assert math.isclose(weights[1], 0.7)
+
+    def test_unnormalized_add_still_normalizes(self):
+        mix = channels.isotropic() * 3.0 + channels.isotropic("Gamma") * 1.0
+        weights = [w for w, _ in mix._entries]
+        assert math.isclose(sum(weights), 1.0)
+        assert math.isclose(weights[0], 0.75)
+        assert math.isclose(weights[1], 0.25)
+
+    def test_three_way_mix_normalizes(self):
+        box = _box_at(50.0)
+        mix = (channels.isotropic()
+               + channels.isotropic("Gamma")
+               + channels.toward("Gamma", box))
+        weights = [w for w, _ in mix._entries]
+        assert len(weights) == 3
+        assert math.isclose(sum(weights), 1.0)
+
+    def test_mixture_plus_channel_renormalizes(self):
+        mix = 0.5 * channels.isotropic() + 0.5 * channels.isotropic("Gamma")
+        mix2 = mix + channels.isotropic()
+        weights = [w for w, _ in mix2._entries]
+        assert len(weights) == 3
+        assert math.isclose(sum(weights), 1.0)
+
+    def test_channel_plus_mixture_renormalizes(self):
+        mix = 0.5 * channels.isotropic() + 0.5 * channels.isotropic("Gamma")
+        mix2 = channels.isotropic() + mix
+        weights = [w for w, _ in mix2._entries]
+        assert len(weights) == 3
+        assert math.isclose(sum(weights), 1.0)
+
+    def test_empty_mixture_rejected(self):
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([])
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([(-0.5, channels.isotropic()),
+                               (1.5, channels.isotropic("Gamma"))])
+
+    def test_nonfinite_weight_rejected(self):
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([(float("nan"), channels.isotropic())])
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([(float("inf"), channels.isotropic())])
+
+    def test_toward_fraction_mixes_physical_fallback(self):
+        box = _box_at(50.0)
+        mix = channels.toward("Gamma", box, fraction=0.3)
+        assert isinstance(mix, channels.Mixture)
+        weights = sorted(w for w, _ in mix._entries)
+        assert math.isclose(sum(weights), 1.0)
+        assert math.isclose(weights[0], 0.3, abs_tol=1e-9)
+        assert math.isclose(weights[1], 0.7, abs_tol=1e-9)
+
+    def test_toward_fraction_one_is_bare_channel(self):
+        box = _box_at(50.0)
+        result = channels.toward("Gamma", box, fraction=1.0)
+        assert isinstance(result, channels.Channel)
+
+
+# ------------------------------------------------------------------ #
+#  Per-signature name resolution                                       #
+# ------------------------------------------------------------------ #
+
+class TestNameResolution:
+
+    def test_absent_particle_raises_configuration_error(self):
+        sig = _decay2body_signature()
+        ch = channels.isotropic("NotAKnownParticle")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_ambiguous_particle_raises_configuration_error(self):
+        sig = siren.dataclasses.InteractionSignature()
+        sig.primary_type = siren.particles.N4
+        sig.target_type = siren.dataclasses.ParticleType.Decay
+        sig.secondary_types = [siren.particles.Gamma, siren.particles.Gamma]
+        ch = channels.isotropic("Gamma")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_named_particle_resolves_to_correct_index(self):
+        sig = _decay2body_signature()  # [NuLight, Gamma]
+        box = _box_at(50.0)
+        ch = channels.toward("Gamma", box)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.DetectorDirected2BodyChannel)
+
+    def test_integer_daughter_bypasses_resolution(self):
+        sig = _decay2body_signature()
+        ch = channels.isotropic(1)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.Isotropic2BodyChannel)
+
+    def test_toward_3body_bad_spectator_name_raises(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        ch = channels.toward_3body("EMinus", box, spectator="NotAParticle",
+                                   strategy="recursive")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_toward_3body_missing_spectator_raises(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        ch = channels.toward_3body("EMinus", box, strategy="recursive")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+
+# ------------------------------------------------------------------ #
+#  PairMass factories map to the right ctor kwargs                     #
+# ------------------------------------------------------------------ #
+
+class TestPairMass:
+
+    def test_uniform(self):
+        pm = channels.PairMass.uniform()
+        assert pm.mass_mode == siren.injection.InvariantMassMode.Uniform
+
+    def test_breit_wigner_fields(self):
+        pm = channels.PairMass.breit_wigner(0.017, 0.001)
+        assert pm.mass_mode == siren.injection.InvariantMassMode.BreitWigner
+        assert pm.resonance_mass == 0.017
+        assert pm.resonance_width == 0.001
+
+    def test_power_law_fields(self):
+        pm = channels.PairMass.power_law(0.6, offset=0.1)
+        assert pm.mass_mode == siren.injection.InvariantMassMode.PowerLaw
+        assert pm.power_law_nu == 0.6
+        assert pm.power_law_offset == 0.1
+
+    def test_tabulated_fields(self):
+        nodes = [0.1, 0.2, 0.3]
+        values = [0.0, 0.5, 1.0]
+        pm = channels.PairMass.tabulated(nodes, values)
+        assert pm.mass_mode == siren.injection.InvariantMassMode.Tabulated
+        assert pm.mass_cdf_nodes == nodes
+        assert pm.mass_cdf_values == values
+
+    def test_breit_wigner_reaches_3body_ctor_direct(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        pm = channels.PairMass.breit_wigner(0.017, 0.001)
+        ch = channels.toward_3body("EMinus", box, strategy="direct", pair_mass=pm)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.DetectorDirected3BodyChannel)
+        assert built.Topology() == siren.injection.PhaseSpaceTopology.Decay3Body
+
+    def test_power_law_reaches_3body_ctor_recursive(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        pm = channels.PairMass.power_law(0.6, offset=0.05)
+        ch = channels.toward_3body("EMinus", box, spectator="NuLight",
+                                   strategy="recursive", pair_mass=pm)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.DetectorDirected3BodyChannel)
+        measure = built.Measure()
+        assert measure.type == siren.injection.PhaseSpaceMeasureType.Recursive2Body
+
+
+# ------------------------------------------------------------------ #
+#  tile() disjointness                                                 #
+# ------------------------------------------------------------------ #
+
+class TestTiling:
+
+    def test_tile_returns_tiling(self):
+        box = _box_at(50.0, half=1.0)
+        t = channels.tile(box, 2)
+        assert isinstance(t, channels.Tiling)
+
+    def test_tile_compiles_to_nested_mixture(self):
+        sig = _decay2body_signature()
+        box = _box_at(50.0, half=1.0)
+        t = channels.tile(box, 2)
+        built = t._build(sig)
+        assert isinstance(built, siren.injection.NestedMixtureChannel)
+        # 2x2x2 grid cells, all disjointified (disjointify keeps every tile)
+        assert len(built.mixture.channels) == 8
+
+    def test_tile_cells_are_disjoint(self):
+        # grid_cells() partitions the box into non-overlapping sub-boxes;
+        # sample points and require each falls in exactly one cell.
+        box = siren.geometry.Box(
+            siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, 0.0)),
+            2.0, 2.0, 2.0)
+        from siren import directed_tiling
+        cells = directed_tiling.grid_cells(box, 2)
+        assert len(cells) == 8
+
+        rng = siren.utilities.SIREN_random(1234)
+        n_checked = 0
+        for _ in range(500):
+            p = siren.math.Vector3D(
+                rng.Uniform(-1.0, 1.0), rng.Uniform(-1.0, 1.0), rng.Uniform(-1.0, 1.0))
+            hits = [c for c in cells if c.IsInside(p)]
+            assert len(hits) <= 1, "point {} landed in {} disjoint cells".format(p, len(hits))
+            if hits:
+                n_checked += 1
+        assert n_checked > 0
+
+    def test_tile_participates_in_mixture_algebra(self):
+        box = _box_at(50.0, half=1.0)
+        t = channels.tile(box, 2)
+        mix = 0.4 * channels.isotropic() + 0.6 * t
+        weights = [w for w, _ in mix._entries]
+        assert math.isclose(sum(weights), 1.0)
+        assert any(isinstance(ch, channels.Tiling) for _, ch in mix._entries)
+
+    def test_tile_rejects_unknown_method(self):
+        box = _box_at(50.0, half=1.0)
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.tile(box, 2, method="not-a-method")
+
+
+# ------------------------------------------------------------------ #
+#  Mixture.validate()                                                  #
+# ------------------------------------------------------------------ #
+
+class TestValidate:
+
+    def test_topology_mismatch_is_fatal(self):
+        """Isotropic2Body (Decay2Body) mixed with a scattering channel
+        (Scatter2to2) is a structural topology mismatch: fatal at
+        construction time, before any ConvertDensity probe runs.
+        """
+        box = _box_at(50.0)
+        iso = channels.isotropic(0)
+        sc = channels.scatter_toward(box)
+
+        # Build engine channels directly to bypass per-signature resolution
+        # differences between the two factories' expected signatures --
+        # the topology mismatch is a property of the channel types
+        # themselves, independent of signature.
+        engine_iso = siren.injection.Isotropic2BodyChannel(0)
+        engine_sc = siren.injection.DetectorDirectedScatteringChannel(box, 0)
+        with pytest.raises(siren.utilities.MeasureCompatibilityError):
+            siren.injection.MultiChannelPhaseSpace(
+                [engine_iso, engine_sc], [0.5, 0.5])
+
+    def test_validate_catches_topology_mismatch_mixture(self):
+        """A Mixture whose Channel factories build engine channels of two
+        different topologies fails Mixture.validate() with
+        MeasureCompatibilityError, surfaced at configuration time.
+        """
+        box = _box_at(50.0)
+
+        def iso_factory(signature, *, detector=None, models=None):
+            return siren.injection.Isotropic2BodyChannel(0)
+
+        def scatter_factory(signature, *, detector=None, models=None):
+            return siren.injection.DetectorDirectedScatteringChannel(box, 0)
+
+        bad_iso = channels.Channel(iso_factory, label="iso")
+        bad_sc = channels.Channel(scatter_factory, label="scatter")
+        mix = 0.5 * bad_iso + 0.5 * bad_sc
+
+        with pytest.raises(siren.utilities.MeasureCompatibilityError):
+            mix.validate(_decay2body_signature())
+
+    def test_validate_passes_for_convertible_mixed_measure_mixture(self):
+        """isotropic (SolidAngleRest) + toward (SolidAngleRest): the same
+        measure, so validate() must not raise.
+        """
+        box = _box_at(50.0)
+        mix = 0.3 * channels.isotropic("Gamma") + 0.7 * channels.toward("Gamma", box)
+        mcps = mix.validate(_decay2body_signature())
+        assert len(mcps.channels) == 2
+
+    def test_validate_passes_for_genuinely_different_convertible_measures(self):
+        """MandelstamQ2 (default scatter_toward) mixed with BjorkenXY
+        (variable=BjorkenY): genuinely different measures within
+        Scatter2to2, related by an implemented ConvertDensity conversion
+        (given 'bjorken_y' in interaction_parameters). validate() must not
+        raise for this combination.
+        """
+        box = _box_at(50.0)
+        q2_chan = channels.scatter_toward(
+            box, variable=siren.injection.ScatteringVariable.Q2)
+        y_chan = channels.scatter_toward(
+            box, variable=siren.injection.ScatteringVariable.BjorkenY)
+        mix = 0.5 * q2_chan + 0.5 * y_chan
+
+        sig = _scatter_signature()
+        mcps = mix.compile(sig)
+        topology = mcps.CommonTopology()
+        common_measure = mcps.CommonMeasure()
+        record = _scatter_record()
+        for ch in mcps.channels:
+            measure = ch.Measure()
+            if measure == common_measure:
+                continue
+            # Must not raise: this is exactly the conversion validate()'s
+            # probe performs, given a record with the required
+            # 'bjorken_y' interaction parameter.
+            siren.injection.ConvertDensity(
+                1.0, measure, common_measure, topology, record)
+
+    def test_validate_returns_compiled_mixture(self):
+        box = _box_at(50.0)
+        mix = 0.3 * channels.isotropic() + 0.7 * channels.toward(0, box)
+        mcps = mix.validate(_decay2body_signature())
+        assert isinstance(mcps, siren.injection.MultiChannelPhaseSpace)
+        assert math.isclose(sum(mcps.weights), 1.0)
+
+    def test_validate_default_template_signature(self):
+        """validate() with no signature argument uses the built-in
+        decay-shaped template signature."""
+        box = _box_at(50.0)
+        mix = 0.3 * channels.isotropic("Gamma") + 0.7 * channels.toward("Gamma", box)
+        mcps = mix.validate()
+        assert len(mcps.channels) == 2
+
+
+# ------------------------------------------------------------------ #
+#  describe()                                                          #
+# ------------------------------------------------------------------ #
+
+class TestDescribe:
+
+    def test_channel_describe(self):
+        assert channels.isotropic().describe() == "isotropic"
+
+    def test_mixture_describe_contains_weights_and_labels(self):
+        mix = 0.3 * channels.isotropic() + 0.7 * channels.isotropic("Gamma")
+        text = mix.describe()
+        assert "0.30" in text
+        assert "0.70" in text
+        assert "isotropic" in text
+        assert "+" in text
+
+
+# ------------------------------------------------------------------ #
+#  physical() late binding                                             #
+# ------------------------------------------------------------------ #
+
+class TestPhysical:
+
+    def test_physical_without_models_raises(self):
+        sig = _scatter_signature()
+        ch = channels.physical()
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_physical_with_multiple_models_raises(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        ch = channels.physical()
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig, models=[xs, xs])
+
+    def test_physical_routes_cross_section(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        ch = channels.physical()
+        built = ch._build(sig, models=[xs])
+        assert isinstance(built, siren.injection.PhysicalCrossSectionChannel)
+
+    def test_physical_compiles_via_mixture(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        mix = channels.Mixture([(1.0, channels.physical())])
+        mcps = mix.compile(sig, models=[xs])
+        assert isinstance(mcps.channels[0], siren.injection.PhysicalCrossSectionChannel)

--- a/tests/python/test_density_breakdown.py
+++ b/tests/python/test_density_breakdown.py
@@ -65,15 +65,18 @@ def test_density_breakdown_sums_to_density():
 
 
 # --------------------------------------------------------------------------- #
-# VertexWeightFactors.channel_densities contract, as observed through a real  #
-# assembled Injector/Weighter pair (not the bare MultiChannelPhaseSpace above).#
+# VertexWeightFactors.channel_densities/cancelled contract, as observed        #
+# through a real assembled Injector/Weighter pair (not the bare                #
+# MultiChannelPhaseSpace above).                                              #
 #                                                                              #
-# ComputeVertexFactors (Weighter.cxx) never writes into channel_densities on   #
-# any current code path: the DummyCrossSection assembly below has no vertex   #
-# backed by a MultiChannelPhaseSpace, so the field stays at its default-       #
-# constructed empty map for every vertex.  This test pins that observed        #
-# current contract -- a dict on every vertex, empty here -- rather than        #
-# asserting non-empty population that this assembly never produces.           #
+# ComputeVertexFactors (Weighter.cxx) always writes channel_densities and      #
+# cancelled on the diagnostics path (EventWeightWithBreakdown): the former is  #
+# keyed from the injection process's MultiChannelPhaseSpace.DensityBreakdown  #
+# when one is attached for the vertex's signature, and the latter lists the   #
+# distribution Name()s shared by value between the injection and physical     #
+# distribution lists. The DummyCrossSection assembly below attaches no phase  #
+# space and shares no value-equal distributions, so both fields are wired but #
+# stay empty for every vertex in this assembly specifically.                  #
 # --------------------------------------------------------------------------- #
 
 def _skip_unless_ccm_data():
@@ -144,12 +147,8 @@ def _build_chain(detector_model, n_inject, seed):
     return inj, weighter, keepalive
 
 
-def test_vertex_channel_densities_is_an_empty_dict_for_this_assembly():
-    """VertexWeightFactors.channel_densities is a dict on every vertex and stays
-    empty for the DummyCrossSection assembly, which has no
-    MultiChannelPhaseSpace-backed vertex. The finiteness check and the final
-    assertion form a tripwire: if a future change starts populating the map,
-    this test fails so the check can be tightened to the populated values."""
+def test_vertex_channel_densities_and_cancelled_are_wired_but_empty_for_this_assembly():
+    """channel_densities/cancelled are wired but empty for a vertex with no attached mixture and no value-shared distributions."""
     _skip_unless_ccm_data()
     detector_model = _load_ccm_detector()
     inj, weighter, _keepalive = _build_chain(detector_model, 2000, 2468)
@@ -169,21 +168,43 @@ def test_vertex_channel_densities_is_an_empty_dict_for_this_assembly():
         events.append(ev)
     assert len(events) == 20
 
-    saw_nonempty = False
     for ev in events:
         bd = weighter.EventWeightWithBreakdown(ev)
         for v in bd.vertices:
             cd = v.channel_densities
+            cancelled = v.cancelled
             assert isinstance(cd, dict)
-            if cd:
-                saw_nonempty = True
-                values = list(cd.values())
-                assert all(math.isfinite(x) for x in values)
+            assert isinstance(cancelled, list)
+            assert all(math.isfinite(x) for x in cd.values())
+            # This assembly attaches no MultiChannelPhaseSpace and shares no
+            # value-equal distributions between injection and physical, so
+            # both fields stay empty for every vertex here.
+            assert cd == {}
+            assert cancelled == []
 
-    # Documents the current, observed contract for this assembly: the
-    # DummyCrossSection chain has no MultiChannelPhaseSpace-backed vertex, so
-    # ComputeVertexFactors never populates channel_densities.
-    assert saw_nonempty is False, (
-        "channel_densities was populated by this assembly; the "
-        "'observed empty' contract this test documents has changed and the "
-        "assertions above should be tightened to check the populated values.")
+
+def test_channel_densities_contract_matches_density_breakdown():
+    """channel_densities entries are the mixture's DensityBreakdown, keyed channel[i]."""
+    target = siren.geometry.Box(
+        siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, 2.0)),
+        1.0, 1.0, 1.0)
+    iso = siren.injection.Isotropic2BodyChannel(0)
+    directed = siren.injection.DetectorDirected2BodyChannel(target, 0)
+    mc = siren.injection.MultiChannelPhaseSpace()
+    mc.channels = [iso, directed]
+    mc.weights = [0.3, 0.7]
+
+    rng = siren.utilities.SIREN_random(11)
+    r = _make_record()
+    mc.Sample(rng, None, r)
+
+    bd = mc.DensityBreakdown(None, r)
+    g = mc.Density(None, r)
+    assert len(bd) == 2
+    assert all(math.isfinite(x) for x in bd)
+    assert sum(bd) == g
+
+    channel_densities = {"channel[" + str(i) + "]": bd[i] for i in range(len(bd))}
+    assert list(channel_densities.keys()) == ["channel[0]", "channel[1]"]
+    assert all(math.isfinite(x) for x in channel_densities.values())
+    assert sum(channel_densities.values()) == g

--- a/tests/python/test_expand_wiring.py
+++ b/tests/python/test_expand_wiring.py
@@ -1,0 +1,151 @@
+"""Tests for siren.expand vocabulary and expansion-wiring validation."""
+
+import pytest
+
+siren = pytest.importorskip("siren")
+
+from siren import dataclasses as dc
+from siren.expand import child, depth_below, compile_expansion, VertexSpec
+from siren._validation import (
+    validate_expansion_wiring,
+    check_expand_vs_legacy_stopping,
+)
+from siren.errors import ConfigurationError
+
+PT = dc.ParticleType
+
+
+def _make_record(primary_type, secondary_types):
+    rec = dc.InteractionRecord()
+    rec.signature.primary_type = primary_type
+    rec.signature.target_type = PT.Decay
+    rec.signature.secondary_types = list(secondary_types)
+    rec.secondary_masses = [0.0 for _ in secondary_types]
+    rec.secondary_momenta = [[0, 0, 0, 0] for _ in secondary_types]
+    rec.secondary_helicities = [0 for _ in secondary_types]
+    return rec
+
+
+def _tree_with_root(primary_type, secondary_types):
+    """Build a real InteractionTree with one root datum via add_entry."""
+    tree = dc.InteractionTree()
+    rec = _make_record(primary_type, secondary_types)
+    parent = tree.add_entry(rec, None)
+    return tree, parent
+
+
+def test_listed_daughter_expands_unlisted_terminates():
+    """A daughter named in expand continues; an unlisted daughter prunes."""
+    tree, parent = _tree_with_root(PT.N4, [PT.NuLight, PT.Gamma])
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(child("NuLight"),), continue_if=None),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is False
+    assert stopping_condition(tree, parent, 1) is True
+
+
+def test_child_index_restricts_match():
+    """child(index=0) expands only the secondary at position 0."""
+    tree, parent = _tree_with_root(PT.NuLight, [PT.NuLight, PT.NuLight])
+    vertices = [
+        VertexSpec(
+            particle=PT.NuLight,
+            expand=(child("NuLight", index=0),),
+            continue_if=None,
+        ),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is False
+    assert stopping_condition(tree, parent, 1) is True
+
+
+def test_depth_below_expands_while_shallow():
+    """depth_below(n) expands while parent depth < n, prunes at depth >= n."""
+    tree, shallow_parent = _tree_with_root(PT.N4, [PT.NuLight])
+    assert shallow_parent.depth(tree) == 0
+
+    grandchild_rec = _make_record(PT.NuLight, [PT.NuLight])
+    deep_parent = tree.add_entry(grandchild_rec, shallow_parent)
+    assert deep_parent.depth(tree) == 1
+
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(depth_below(1),), continue_if=None),
+        VertexSpec(particle=PT.NuLight, expand=(depth_below(1),), continue_if=None),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, shallow_parent, 0) is False
+    assert stopping_condition(tree, deep_parent, 0) is True
+
+
+def test_continue_if_can_veto_a_matched_child():
+    """A matched child rule still prunes when continue_if returns False."""
+    tree, parent = _tree_with_root(PT.N4, [PT.NuLight])
+    vertices = [
+        VertexSpec(
+            particle=PT.N4,
+            expand=(child("NuLight"),),
+            continue_if=lambda tree, parent, i: False,
+        ),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is True
+
+
+def test_unregistered_parent_type_prunes():
+    """A parent whose primary_type has no registered vertex always prunes."""
+    tree, parent = _tree_with_root(PT.MuMinus, [PT.NuLight])
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(child("NuLight"),), continue_if=None),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is True
+
+
+def test_wiring_error_unregistered_child_target():
+    """expand names a particle with no registered Vertex -> ConfigurationError."""
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(child("NuLight"),), continue_if=None),
+    ]
+    with pytest.raises(ConfigurationError):
+        validate_expansion_wiring(vertices)
+
+
+def test_wiring_error_unreachable_vertex():
+    """A registered Vertex named by no expand list -> ConfigurationError."""
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(), continue_if=None),
+        VertexSpec(particle=PT.NuLight, expand=(), continue_if=None),
+    ]
+    with pytest.raises(ConfigurationError):
+        validate_expansion_wiring(vertices)
+
+
+def test_wiring_error_secondaries_without_expansion():
+    """Secondaries present but no expand declaration at all -> ConfigurationError."""
+    vertices = [
+        VertexSpec(
+            particle=PT.N4,
+            expand=(),
+            continue_if=None,
+            secondary_types=[PT.NuLight, PT.Gamma],
+        ),
+    ]
+    with pytest.raises(ConfigurationError):
+        validate_expansion_wiring(vertices)
+
+
+def test_legacy_stopping_condition_with_expand_is_hard_error():
+    """Legacy stopping_condition plus expand/continue_if -> ConfigurationError."""
+    with pytest.raises(ConfigurationError):
+        check_expand_vs_legacy_stopping(True, True)
+
+    # Either alone is fine.
+    check_expand_vs_legacy_stopping(True, False)
+    check_expand_vs_legacy_stopping(False, True)
+    check_expand_vs_legacy_stopping(False, False)

--- a/tests/python/test_failure_report.py
+++ b/tests/python/test_failure_report.py
@@ -164,3 +164,53 @@ def test_ledger_clear_resets_to_empty():
 
     inj.GetFailureLedger().Clear()
     assert inj.GetFailureLedger().entries() == {}
+
+
+# --------------------------------------------------------------------------- #
+# (d) The rendered InjectionReport over the ledger.                           #
+# --------------------------------------------------------------------------- #
+
+def test_injection_report_renders_table_and_dominant():
+    """InjectionReport.from_ledger renders an attrition table and a dominant()."""
+    from siren.report import InjectionReport
+
+    inj, _keepalive = _make_forced_failure_injector(n_inject=4)
+    for _ in range(4):
+        inj.GenerateEvent()
+
+    report = InjectionReport.from_ledger(
+        inj.GetFailureLedger(),
+        attempts=inj.InjectionAttempts(),
+        successes=inj.InjectedEvents(),
+        last_failed_tree=inj.GetLastFailedTree())
+
+    text = str(report)
+    assert "InjectionReport" in text
+    assert "NoTargetsOnPath" in text
+    assert "count" in text
+
+    dominant = report.dominant()
+    assert dominant is not None
+    assert dominant.reason_name == "NoTargetsOnPath"
+    assert dominant.count == 4
+    assert dominant.hint  # a non-empty one-line remedy
+
+
+def test_injection_report_efficiency_and_particle_name():
+    """The report exposes efficiency and a resolved particle name per bucket."""
+    from siren.report import InjectionReport
+
+    inj, _keepalive = _make_forced_failure_injector(n_inject=3)
+    for _ in range(3):
+        inj.GenerateEvent()
+
+    report = InjectionReport.from_ledger(
+        inj.GetFailureLedger(),
+        attempts=inj.InjectionAttempts(),
+        successes=inj.InjectedEvents())
+
+    assert report.successes == 0
+    assert report.efficiency == 0.0
+    bucket = report.dominant()
+    # The parent PDG (14, NuMu) resolves to a readable particle name.
+    assert bucket.particle != str(bucket.pdg) or bucket.pdg == 14

--- a/tests/python/test_injector_api.py
+++ b/tests/python/test_injector_api.py
@@ -1,0 +1,255 @@
+"""Layer-2 Injector: generate() success counting, shortfall policy, reset,
+save guard, positional-Box warning, and legacy __iter__ semantics.
+
+Data-free where possible; anything needing detector data files skips cleanly.
+"""
+
+import os
+import warnings
+
+import pytest
+
+import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _skip_unless_ccm_data():
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip("CCM detector model path unavailable: {}".format(e))
+    missing = [p for p in (os.path.join(det_dir, "materials.dat"),
+                           os.path.join(det_dir, "densities.dat"))
+               if not os.path.exists(p)]
+    if missing:
+        pytest.skip("CCM detector data missing: " + ", ".join(missing))
+    return det_dir
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _distributions(max_distance):
+    return [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(
+            smath.Vector3D(0, 0, 0), max_distance),
+    ]
+
+
+def _working_injector(events=5, seed=11, max_distance=25.0, max_attempts=None):
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj = injection.Injector(
+        detector=dm,
+        primary=None,
+        number_of_events=events,
+        seed=seed,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(max_distance),
+        max_attempts=max_attempts,
+    )
+    return inj
+
+
+def _forced_failure_injector(events=5, seed=11, max_attempts=None):
+    # A bare detector plus max_distance=0 makes every path miss its target,
+    # so every attempt fails with NoTargetsOnPath -- no data files needed.
+    dm = detector.DetectorModel()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=events,
+        seed=seed,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+        max_attempts=max_attempts,
+    )
+    return inj
+
+
+# ------------------------------------------------------------------ #
+#  generate() counts successes                                        #
+# ------------------------------------------------------------------ #
+
+def test_generate_counts_successes_not_attempts():
+    """generate(N) returns exactly N non-empty trees."""
+    inj = _working_injector(events=10)
+    trees = inj.generate(10, on_shortfall="raise")
+    assert len(trees) == 10
+    assert all(len(t.tree) > 0 for t in trees)
+
+
+def test_generate_default_events_uses_configured_count():
+    """generate() with no argument uses the configured event count."""
+    inj = _working_injector(events=4)
+    trees = inj.generate(on_shortfall="raise")
+    assert len(trees) == 4
+
+
+# ------------------------------------------------------------------ #
+#  on_shortfall triple                                                #
+# ------------------------------------------------------------------ #
+
+def test_on_shortfall_raise():
+    """A shortfall with on_shortfall='raise' raises InjectionShortfall."""
+    inj = _forced_failure_injector(events=3, max_attempts=20)
+    with pytest.raises(siren.errors.InjectionShortfall) as exc:
+        inj.generate(3, on_shortfall="raise")
+    assert exc.value.report is not None
+    assert exc.value.report.successes == 0
+
+
+def test_on_shortfall_warn():
+    """A shortfall with on_shortfall='warn' warns and returns what succeeded."""
+    inj = _forced_failure_injector(events=3, max_attempts=20)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        trees = inj.generate(3, on_shortfall="warn")
+    assert len(trees) == 0
+    assert any(isinstance(x.message, siren.errors.InjectionShortfall) for x in w)
+
+
+def test_on_shortfall_ignore():
+    """A shortfall with on_shortfall='ignore' is silent."""
+    inj = _forced_failure_injector(events=3, max_attempts=20)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        trees = inj.generate(3, on_shortfall="ignore")
+    assert len(trees) == 0
+
+
+# ------------------------------------------------------------------ #
+#  min_efficiency early abort                                         #
+# ------------------------------------------------------------------ #
+
+def test_min_efficiency_early_abort_raises_with_report():
+    """Efficiency below min_efficiency aborts with an InjectionShortfall report."""
+    inj = _forced_failure_injector(events=100, max_attempts=100000)
+    with pytest.raises(siren.errors.InjectionShortfall) as exc:
+        inj.generate(100, on_shortfall="raise", min_efficiency=0.5)
+    assert exc.value.report is not None
+    assert exc.value.report.dominant() is not None
+
+
+# ------------------------------------------------------------------ #
+#  reset / reuse                                                      #
+# ------------------------------------------------------------------ #
+
+def test_reset_allows_reuse():
+    """reset() clears counters so a second generate() starts fresh."""
+    inj = _working_injector(events=5)
+    first = inj.generate(5, on_shortfall="raise")
+    assert len(first) == 5
+    inj.reset()
+    assert inj.injected_events == 0
+    second = inj.generate(5, on_shortfall="raise")
+    assert len(second) == 5
+
+
+# ------------------------------------------------------------------ #
+#  typo'd secondary dict key raises                                   #
+# ------------------------------------------------------------------ #
+
+def test_typo_secondary_key_raises():
+    """A secondary key present in one dict but not the interactions dict raises."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    xs = interactions.DummyCrossSection()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[xs],
+        primary_injection_distributions=_distributions(25.0),
+        secondary_interactions={_NuMu: [interactions.DummyCrossSection()]},
+        secondary_injection_distributions={_NuMu: [distributions.SecondaryPhysicalVertexDistribution()]},
+        secondary_weighting_modes={dc.Particle.ParticleType.NuE: injection.VertexWeightingMode.Fixed()},
+    )
+    with pytest.raises((siren.errors.ConfigurationError, ValueError)):
+        inj.generate(2, on_shortfall="ignore")
+
+
+# ------------------------------------------------------------------ #
+#  positional Box warns but still constructs                          #
+# ------------------------------------------------------------------ #
+
+def test_positional_box_warns_and_constructs():
+    """Box(x, y, z) emits a DeprecationWarning and still builds a box."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        box = siren.geometry.Box(1.0, 2.0, 3.0)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    assert box.X == 1.0 and box.Y == 2.0 and box.Z == 3.0
+
+
+def test_widths_center_box_places_at_center():
+    """Box(widths=..., center=...) places the box at the given center."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 5.0))
+    assert box.IsInside(siren.math.Vector3D(0, 0, 5))
+    assert not box.IsInside(siren.math.Vector3D(0, 0, 0))
+
+
+# ------------------------------------------------------------------ #
+#  __iter__ legacy semantics                                          #
+# ------------------------------------------------------------------ #
+
+def test_iter_warns_and_yields_attempt_count():
+    """__iter__ warns and yields exactly number_of_events raw attempts."""
+    inj = _working_injector(events=4)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        events = list(inj)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    assert len(events) == 4
+
+
+# ------------------------------------------------------------------ #
+#  save() round-trip guard                                            #
+# ------------------------------------------------------------------ #
+
+def test_save_on_fixed_mode_raises_not_serializable(tmp_path):
+    """save() refuses a Fixed-mode process the engine would not round-trip."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(25.0),
+        primary_weighting_mode=injection.VertexWeightingMode.Fixed(),
+    )
+    with pytest.raises(siren.errors.NotSerializableError):
+        inj.save(str(tmp_path / "inj"))
+
+
+def test_report_is_rendered_after_failures():
+    """report() renders an attrition table with a dominant reason."""
+    inj = _forced_failure_injector(events=3, max_attempts=10)
+    inj.generate(3, on_shortfall="ignore")
+    report = inj.report()
+    text = str(report)
+    assert "InjectionReport" in text
+    assert report.dominant() is not None
+    assert report.dominant().reason_name == "NoTargetsOnPath"

--- a/tests/python/test_legacy_shims.py
+++ b/tests/python/test_legacy_shims.py
@@ -1,0 +1,147 @@
+"""Legacy keyword and Vertex-spec entry points compile to one engine config.
+
+The two authoring surfaces are a translation shim over a single build path, so
+at a fixed seed they must produce identical event streams. These tests
+parametrize a shared scenario over both surfaces and assert stream identity of
+the generated trees and their weights.
+"""
+
+import os
+
+import pytest
+
+import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _skip_unless_ccm_data():
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip("CCM detector model path unavailable: {}".format(e))
+    for name in ("materials.dat", "densities.dat"):
+        if not os.path.exists(os.path.join(det_dir, name)):
+            pytest.skip("CCM detector data missing: " + name)
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _distributions():
+    return [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(
+            smath.Vector3D(0, 0, 0), 25.0),
+    ]
+
+
+SEED = 20240601
+N = 25
+
+
+def _build_legacy(dm):
+    """The scenario spelled with legacy keyword arguments."""
+    return injection.Injector(
+        number_of_events=N,
+        detector_model=dm,
+        seed=SEED,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(),
+    )
+
+
+def _build_spec(dm):
+    """The same scenario spelled with a Vertex spec."""
+    v = siren.Vertex(
+        _NuMu,
+        interactions.DummyCrossSection(),
+        distributions=_distributions(),
+    )
+    return injection.Injector(detector=dm, primary=v, events=N, seed=SEED)
+
+
+def _stream(injector):
+    """Realized (energy, vertex, depth) stream from a fixed-seed run."""
+    trees = injector.generate(N, on_shortfall="raise")
+    rows = []
+    for t in trees:
+        root = t.tree[0].record
+        rows.append((
+            tuple(root.primary_momentum),
+            tuple(root.interaction_vertex),
+        ))
+    return rows
+
+
+@pytest.fixture
+def ccm_detector():
+    _skip_unless_ccm_data()
+    return _load_ccm_detector()
+
+
+def test_legacy_and_spec_produce_identical_streams(ccm_detector):
+    """Legacy kwargs and a Vertex spec yield byte-identical event streams."""
+    legacy = _build_legacy(ccm_detector)
+    spec = _build_spec(ccm_detector)
+
+    legacy_stream = _stream(legacy)
+    spec_stream = _stream(spec)
+
+    assert len(legacy_stream) == len(spec_stream) == N
+    assert legacy_stream == spec_stream
+
+
+def test_legacy_and_spec_produce_identical_weights(ccm_detector):
+    """The two surfaces weight their (identical) events identically."""
+    legacy = _build_legacy(ccm_detector)
+    spec = _build_spec(ccm_detector)
+
+    legacy_trees = legacy.generate(N, on_shortfall="raise")
+    spec_trees = spec.generate(N, on_shortfall="raise")
+
+    phys = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+
+    def _weighter_for(inj):
+        w = injection.Weighter()
+        w.injectors = [inj]
+        w.detector_model = ccm_detector
+        w.primary_type = _NuMu
+        w.primary_interactions = inj.primary_interactions
+        w.primary_physical_distributions = list(phys)
+        return w
+
+    lw = _weighter_for(legacy).weight_all(legacy_trees)
+    sw = _weighter_for(spec).weight_all(spec_trees)
+
+    assert list(lw) == list(sw)
+
+
+@pytest.mark.parametrize("build", [_build_legacy, _build_spec],
+                         ids=["legacy", "spec"])
+def test_both_surfaces_generate_requested_count(build, ccm_detector):
+    """Each surface generates exactly the requested number of events."""
+    inj = build(ccm_detector)
+    trees = inj.generate(N, on_shortfall="raise")
+    assert len(trees) == N

--- a/tests/python/test_top_level_namespace.py
+++ b/tests/python/test_top_level_namespace.py
@@ -21,5 +21,6 @@ def test_top_level_count_reasonable():
     )
     out = subprocess.check_output([sys.executable, "-c", code], text=True)
     count = int(out.strip())
-    # Should be around 25, definitely under 30.
-    assert count < 30, f"Too many top-level names: {count}"
+    # The spec vocabulary (Vertex, Directed, channels, expand, errors,
+    # generate, Propagated, Fixed) is part of the intended public surface.
+    assert count < 45, f"Too many top-level names: {count}"

--- a/tests/python/test_vertex_spec.py
+++ b/tests/python/test_vertex_spec.py
@@ -1,0 +1,383 @@
+"""Vertex.compile() parity with hand-built processes, and Directed sugar.
+
+All tests are data-free: no detector model, no data files. Anything that
+genuinely needs one is skipped with pytest.skip.
+"""
+
+import gc
+import math
+
+import pytest
+
+siren = pytest.importorskip("siren")
+vertex = pytest.importorskip("siren.vertex")
+directed_mod = pytest.importorskip("siren._directed")
+channels = pytest.importorskip("siren.channels")
+
+Vertex = vertex.Vertex
+Directed = directed_mod.Directed
+
+
+# ------------------------------------------------------------------ #
+#  Helpers                                                             #
+# ------------------------------------------------------------------ #
+
+def _box_at(z, half=1.0):
+    return siren.geometry.Box(
+        siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, z)),
+        2.0 * half, 2.0 * half, 2.0 * half)
+
+
+def _dummy_xs():
+    return siren.interactions.DummyCrossSection()
+
+
+def _decay2body_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+    return sig
+
+
+class _KeepAliveCrossSection(siren.interactions.CrossSection):
+    """Data-free Python-subclassed CrossSection, instrumented for gc checks."""
+
+    alive_count = 0
+
+    def __init__(self):
+        siren.interactions.CrossSection.__init__(self)
+        _KeepAliveCrossSection.alive_count += 1
+
+    def __del__(self):
+        _KeepAliveCrossSection.alive_count -= 1
+
+    def TotalCrossSection(self, *args, **kwargs):
+        return 1.0
+
+    def DifferentialCrossSection(self, *args):
+        return 1.0
+
+    def InteractionThreshold(self, *args):
+        return 0.0
+
+    def SampleFinalState(self, *args):
+        pass
+
+    def GetPossibleTargets(self):
+        return [siren.particles.Nucleon]
+
+    def GetPossibleTargetsFromPrimary(self, primary_type):
+        return [siren.particles.Nucleon]
+
+    def GetPossiblePrimaries(self):
+        return [siren.particles.NuMu]
+
+    def GetPossibleSignatures(self):
+        sig = siren.dataclasses.InteractionSignature()
+        sig.primary_type = siren.particles.NuMu
+        sig.target_type = siren.particles.Nucleon
+        sig.secondary_types = [siren.particles.NuMu, siren.particles.Nucleon]
+        return [sig]
+
+    def GetPossibleSignaturesFromParents(self, primary_type, target_type):
+        return self.GetPossibleSignatures()
+
+    def FinalStateProbability(self, *args):
+        return 1.0
+
+    def DensityVariables(self):
+        return []
+
+    def equal(self, other):
+        return isinstance(other, _KeepAliveCrossSection)
+
+
+# ------------------------------------------------------------------ #
+#  Vertex.compile() parity with a hand-built process                   #
+# ------------------------------------------------------------------ #
+
+class TestVertexCompileParity:
+
+    def test_primary_process_fields_match_hand_built(self):
+        """Vertex.compile(is_primary=True) matches a hand-built PrimaryInjectionProcess."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        dists = [siren.distributions.PrimaryMass(0)]
+
+        v = Vertex(sig.primary_type, xs, distributions=dists)
+        proc = v.compile(is_primary=True)
+
+        assert isinstance(proc, siren.injection.PrimaryInjectionProcess)
+        assert proc.primary_type == sig.primary_type
+        assert list(proc.interactions.GetCrossSections()) == [xs]
+        assert list(proc.distributions) == dists
+
+    def test_secondary_process_fields_match_hand_built(self):
+        """Vertex.compile(is_primary=False) matches a hand-built SecondaryInjectionProcess."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        dists = [siren.distributions.SecondaryPhysicalVertexDistribution()]
+
+        v = Vertex(sig.primary_type, xs, distributions=dists)
+        proc = v.compile(is_primary=False)
+
+        assert isinstance(proc, siren.injection.SecondaryInjectionProcess)
+        assert proc.secondary_type == sig.primary_type
+        assert list(proc.interactions.GetCrossSections()) == [xs]
+        assert list(proc.distributions) == dists
+
+    def test_kinematics_registers_phase_space_for_each_signature(self):
+        """A phase space is registered for every signature the model can produce."""
+        xs = _dummy_xs()
+        sigs = xs.GetPossibleSignatures()
+        v = Vertex(sigs[0].primary_type, xs, distributions=[],
+                   kinematics=channels.isotropic(0))
+
+        # A phase space is registered for each signature sharing this Vertex's
+        # primary_type (InteractionCollection resolves by primary_type).
+        matching = [s for s in sigs if s.primary_type == sigs[0].primary_type]
+        proc = v.compile(is_primary=True)
+        for sig in matching:
+            assert proc.HasPhaseSpace(sig)
+            ps = proc.GetPhaseSpace(sig)
+            assert isinstance(ps, siren.injection.MultiChannelPhaseSpace)
+
+    def test_no_kinematics_registers_no_phase_space(self):
+        """kinematics=None leaves the process with no registered phase space."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        v = Vertex(sig.primary_type, xs, distributions=[])
+        proc = v.compile(is_primary=True)
+        assert not proc.HasAnyPhaseSpace()
+
+    def test_position_appended_to_distributions(self):
+        """position= is appended to the distributions list, not silently dropped."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        mass = siren.distributions.PrimaryMass(0)
+        pos = siren.distributions.PointSourcePositionDistribution(
+            siren.math.Vector3D(0, 0, 0), 25.0)
+
+        v = Vertex(sig.primary_type, xs, distributions=[mass], position=pos)
+        assert v.distributions == [mass, pos]
+        proc = v.compile(is_primary=True)
+        assert list(proc.distributions) == [mass, pos]
+
+    def test_unknown_kwarg_raises_type_error(self):
+        """A typo'd keyword argument is rejected, not silently ignored."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        with pytest.raises(TypeError):
+            Vertex(sig.primary_type, xs, distirbutions=[])
+
+    def test_unknown_attribute_assignment_raises_attribute_error(self):
+        """__slots__ makes an unrecognized field name unrepresentable."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        v = Vertex(sig.primary_type, xs, distributions=[])
+        with pytest.raises(AttributeError):
+            v.distirbutions = []
+
+
+# ------------------------------------------------------------------ #
+#  Fixed weighting mode reaches the engine                             #
+# ------------------------------------------------------------------ #
+
+class TestWeightingMode:
+
+    def test_fixed_weighting_mode_reaches_process(self):
+        """weighting=Fixed() compiles to compute_interaction_probability=False."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        fixed = siren.injection.VertexWeightingMode.Fixed()
+
+        v = Vertex(sig.primary_type, xs, distributions=[], weighting=fixed)
+        proc = v.compile(is_primary=True)
+
+        assert proc.weighting_mode.compute_interaction_probability == False
+        assert proc.weighting_mode.compute_position_probability == False
+
+    def test_default_weighting_mode_is_propagated(self):
+        """No weighting= given compiles to the Propagated() preset."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        v = Vertex(sig.primary_type, xs, distributions=[])
+        proc = v.compile(is_primary=True)
+        propagated = siren.injection.VertexWeightingMode.Propagated()
+        assert proc.weighting_mode == propagated
+
+
+# ------------------------------------------------------------------ #
+#  Strong refs survive gc.collect()                                    #
+# ------------------------------------------------------------------ #
+
+class TestStrongRefs:
+
+    def test_python_model_survives_gc_after_compile(self):
+        """A Python-subclassed model outlives gc.collect() while its Vertex is alive."""
+        def build():
+            xs = _KeepAliveCrossSection()
+            v = Vertex(siren.particles.NuMu, xs, distributions=[])
+            proc = v.compile(is_primary=True)
+            return v, proc
+
+        before = _KeepAliveCrossSection.alive_count
+        v, proc = build()
+        gc.collect()
+
+        assert _KeepAliveCrossSection.alive_count == before + 1
+        # The compiled process must still be able to reach the model: this
+        # is the load-bearing claim (the local `xs` in build() is long out
+        # of scope, so only the Vertex's own strong ref keeps it callable).
+        recovered = proc.interactions.GetCrossSections()[0]
+        assert recovered.GetPossibleSignatures()[0].primary_type == siren.particles.NuMu
+        assert v.interactions[0] is recovered
+
+    def test_vertex_retains_models_and_distributions_after_compile(self):
+        """The Vertex keeps its own strong refs to models/distributions/kinematics."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        dists = [siren.distributions.PrimaryMass(0)]
+        mix = channels.isotropic(0)
+
+        v = Vertex(sig.primary_type, xs, distributions=dists, kinematics=mix)
+        v.compile(is_primary=True)
+        gc.collect()
+
+        assert v.interactions == [xs]
+        assert v.distributions == dists
+        assert v.kinematics is mix
+
+
+# ------------------------------------------------------------------ #
+#  as_vertex_spec()                                                    #
+# ------------------------------------------------------------------ #
+
+class TestVertexSpec:
+
+    def test_as_vertex_spec_carries_particle_expand_continue_if(self):
+        """as_vertex_spec() exposes particle/expand/continue_if for compile_expansion."""
+        from siren import expand as expand_mod
+
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        rule = expand_mod.child("Nucleon")
+        cont = lambda tree, parent, i: True
+
+        v = Vertex(sig.primary_type, xs, distributions=[],
+                   expand=(rule,), continue_if=cont)
+        spec = v.as_vertex_spec()
+
+        assert spec.particle == sig.primary_type
+        assert spec.expand == (rule,)
+        assert spec.continue_if is cont
+        assert sig.primary_type in spec.secondary_types
+        assert siren.particles.Nucleon in spec.secondary_types
+
+
+# ------------------------------------------------------------------ #
+#  Directed sugar over channels.py                                     #
+# ------------------------------------------------------------------ #
+
+class TestDirected:
+
+    def test_to_mixture_produces_directed_and_fallback_split(self):
+        """Directed(...).to_mixture() mixes the directed term and physical() fallback."""
+        box = _box_at(50.0)
+        d = Directed("Gamma", box, fraction=0.8)
+        mix = d.to_mixture()
+
+        assert isinstance(mix, channels.Mixture)
+        weights = sorted(w for w, _ in mix._entries)
+        assert math.isclose(weights[0], 0.2, abs_tol=1e-9)
+        assert math.isclose(weights[1], 0.8, abs_tol=1e-9)
+
+        desc = mix.describe()
+        assert "toward" in desc
+        assert "physical" in desc
+
+    def test_default_fraction_is_098(self):
+        """Directed's own default fraction is 0.98, not the legacy 0.99 stream default."""
+        box = _box_at(50.0)
+        d = Directed("Gamma", box)
+        assert d.fraction == 0.98
+
+    def test_fraction_one_has_no_fallback_term(self):
+        """fraction=1.0 drops the fallback term from the mixture entirely."""
+        box = _box_at(50.0)
+        d = Directed("Gamma", box, fraction=1.0)
+        mix = d.to_mixture()
+        assert len(mix._entries) == 1
+
+    def test_out_of_range_fraction_raises_configuration_error(self):
+        """A fraction outside [0, 1] is rejected at construction time."""
+        box = _box_at(50.0)
+        with pytest.raises(siren.utilities.ConfigurationError):
+            Directed("Gamma", box, fraction=1.5)
+
+    def test_toward_channel_builds_against_decay_signature(self):
+        """The directed term resolves to a DetectorDirected2BodyChannel for a decay signature."""
+        sig = _decay2body_signature()
+        box = _box_at(50.0)
+        # fraction=1.0 drops the physical() fallback, which needs a model to
+        # late-bind against and is not the point of this test.
+        d = Directed("Gamma", box, fraction=1.0)
+        mix = d.to_mixture(sig)
+        engine_channels, weights = mix._flatten(sig)
+        kinds = [type(ch).__name__ for ch in engine_channels]
+        assert "DetectorDirected2BodyChannel" in kinds
+
+    def test_by_signature_maps_to_different_mixtures(self):
+        """Directed.by_signature() dispatches a distinct mixture per signature."""
+        sig_a = _decay2body_signature()
+        sig_b = siren.dataclasses.InteractionSignature()
+        sig_b.primary_type = siren.particles.N4
+        sig_b.target_type = siren.dataclasses.ParticleType.Decay
+        sig_b.secondary_types = [siren.particles.NuLight, siren.particles.EMinus,
+                                  siren.particles.EPlus]
+
+        box = _box_at(50.0)
+        iso_mixture = channels.Mixture([(1.0, channels.isotropic(0))])
+        by_sig = Directed.by_signature({
+            sig_a: Directed("Gamma", box, fraction=0.9),
+            sig_b: iso_mixture,
+        })
+
+        mix_a = by_sig.to_mixture(sig_a)
+        mix_b = by_sig.to_mixture(sig_b)
+
+        assert isinstance(mix_a, channels.Mixture)
+        assert isinstance(mix_b, channels.Mixture)
+        weights_a = sorted(w for w, _ in mix_a._entries)
+        assert math.isclose(weights_a[1], 0.9, abs_tol=1e-9)
+        assert mix_b is iso_mixture
+
+    def test_by_signature_unknown_signature_raises_configuration_error(self):
+        """Looking up a signature absent from the mapping is a ConfigurationError."""
+        sig_a = _decay2body_signature()
+        sig_b = siren.dataclasses.InteractionSignature()
+        sig_b.primary_type = siren.particles.N4
+        sig_b.target_type = siren.dataclasses.ParticleType.Decay
+        sig_b.secondary_types = [siren.particles.NuLight, siren.particles.Gamma,
+                                  siren.particles.Gamma]
+
+        box = _box_at(50.0)
+        by_sig = Directed.by_signature({sig_a: Directed("Gamma", box)})
+        with pytest.raises(siren.utilities.ConfigurationError):
+            by_sig.to_mixture(sig_b)
+
+    def test_vertex_kinematics_accepts_directed(self):
+        """A Vertex's kinematics= accepts a Directed interchangeably with a Mixture."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        # DummyCrossSection's signature is a Scatter2to2 topology, so the
+        # directed term must be scatter_toward() (variable= selects it),
+        # not the default 2-body decay toward(); fraction=1.0 drops the
+        # physical() fallback, which needs a model to late-bind against.
+        d = Directed(sig.secondary_types[0], _box_at(2.0), fraction=1.0,
+                     variable=siren.injection.ScatteringVariable.Q2)
+
+        v = Vertex(sig.primary_type, xs, distributions=[], kinematics=d)
+        proc = v.compile(is_primary=True)
+        assert proc.HasPhaseSpace(sig)

--- a/tests/python/test_weighter_explain.py
+++ b/tests/python/test_weighter_explain.py
@@ -1,0 +1,192 @@
+"""Weighter.explain() over the engine breakdown, weight_all as ndarray, and
+the removal of private-injector reach-throughs.
+
+Data-free where possible; the assembled-chain tests skip cleanly when the CCM
+detector data files are absent.
+"""
+
+import math
+import os
+import warnings
+
+import numpy as np
+import pytest
+
+import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _skip_unless_ccm_data():
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip("CCM detector model path unavailable: {}".format(e))
+    for name in ("materials.dat", "densities.dat"):
+        if not os.path.exists(os.path.join(det_dir, name)):
+            pytest.skip("CCM detector data missing: " + name)
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _build_pair(dm, seed=4242):
+    xs = interactions.DummyCrossSection()
+    inj_dists = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    inj = injection.Injector(
+        number_of_events=50, detector_model=dm, seed=seed,
+        primary_type=_NuMu, primary_interactions=[xs],
+        primary_injection_distributions=inj_dists)
+
+    weighter = injection.Weighter()
+    weighter.injectors = [inj]
+    weighter.detector_model = dm
+    weighter.primary_type = _NuMu
+    weighter.primary_interactions = [xs]
+    weighter.primary_physical_distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+    return inj, weighter
+
+
+# ------------------------------------------------------------------ #
+#  explain(): breakdown reconstructs the weight                        #
+# ------------------------------------------------------------------ #
+
+def test_explain_total_matches_scalar_weight():
+    """explain(tree).total equals the scalar event weight to 1e-12."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+
+    trees = inj.generate(5, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated for this data-free chain")
+    for tree in trees:
+        breakdown = weighter.explain(tree)
+        scalar = weighter(tree)
+        if math.isfinite(scalar) and math.isfinite(breakdown.total):
+            assert abs(breakdown.total - scalar) <= 1e-12 * max(1.0, abs(scalar))
+        else:
+            assert math.isnan(breakdown.total) == math.isnan(scalar)
+
+
+def test_explain_returns_weight_breakdown_with_vertices():
+    """explain(tree) yields a report.WeightBreakdown with per-vertex lines."""
+    from siren.report import WeightBreakdown
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+    trees = inj.generate(3, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    bd = weighter.explain(trees[0])
+    assert isinstance(bd, WeightBreakdown)
+    assert len(bd.vertices) >= 1
+    assert "WeightBreakdown" in str(bd)
+
+
+# ------------------------------------------------------------------ #
+#  breakdown() is a deprecated alias                                  #
+# ------------------------------------------------------------------ #
+
+def test_breakdown_is_deprecated_alias():
+    """breakdown(tree) emits a DeprecationWarning and matches explain()."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+    trees = inj.generate(2, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bd = weighter.breakdown(trees[0])
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    assert bd.total == weighter.explain(trees[0]).total
+
+
+# ------------------------------------------------------------------ #
+#  weight_all returns a numpy array                                   #
+# ------------------------------------------------------------------ #
+
+def test_weight_all_returns_ndarray():
+    """weight_all(trees) returns a numpy.ndarray matching per-event weights."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+    trees = inj.generate(5, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    batch = weighter.weight_all(trees)
+    assert isinstance(batch, np.ndarray)
+    individual = np.array([weighter(t) for t in trees])
+    assert np.array_equal(batch, individual, equal_nan=True)
+
+
+# ------------------------------------------------------------------ #
+#  the private reach-throughs are gone                                #
+# ------------------------------------------------------------------ #
+
+def test_no_private_injector_reach_through_in_source():
+    """Weighter.py reaches the raw injector via the public engine property."""
+    src_path = os.path.join(os.path.dirname(_util.__file__), "Weighter.py")
+    with open(src_path) as f:
+        source = f.read()
+    assert "_Injector__injector" not in source
+
+
+# ------------------------------------------------------------------ #
+#  spec-form constructor accepts injectors                            #
+# ------------------------------------------------------------------ #
+
+def test_spec_form_ctor_accepts_injectors():
+    """Weighter(injector, primary_physical=[...]) builds a working weighter."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    xs = interactions.DummyCrossSection()
+    inj_dists = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    inj = injection.Injector(
+        number_of_events=10, detector_model=dm, seed=7,
+        primary_type=_NuMu, primary_interactions=[xs],
+        primary_injection_distributions=inj_dists)
+
+    weighter = injection.Weighter(
+        inj,
+        primary_physical=[
+            distributions.PrimaryMass(0),
+            distributions.PrimaryNeutrinoHelicityDistribution(),
+            distributions.IsotropicDirection(),
+        ])
+    trees = inj.generate(3, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    weights = weighter.weight_all(trees)
+    assert isinstance(weights, np.ndarray)
+    assert len(weights) == len(trees)


### PR DESCRIPTION
Phase 3 of the interface redesign: the spec vocabulary and the Layer-2 Injector/Weighter rework.

## What this adds

**Spec vocabulary.** New authoring surfaces that compile to the existing engine objects:

- `siren.Vertex(particle, interactions, ...)` compiles one chain node into a Primary/SecondaryInjectionProcess with per-signature phase spaces and a weighting mode. Fields are keyword-only with `__slots__`, so a typo'd field name raises rather than being silently dropped. A Vertex holds strong references to its Python models so their pybind trampolines survive gc.
- `siren.channels` -- a channel algebra (`toward`, `isotropic`, `toward_3body`, `scatter_toward`, `physical`, `tile`, `PairMass`) combining with `*` and `+` into a `Mixture` that is normalized at every construction. `Mixture.validate()` runs the detector-free `ConvertDensity` probe plus the validating `MultiChannelPhaseSpace` constructor, so measure and 3-body factorization errors surface at configuration time.
- `siren.expand` -- `child` / `depth_below` rules compiled into one stopping-condition callable carrying the engine's prune-on-true polarity, with wiring checks (unregistered child, unreachable vertex, undeclared secondaries) that raise with a one-line fix.
- `siren.Directed` -- sugar over the channels algebra for the common "point a daughter at a target with a physical fallback" mix, including `Directed.by_signature`.
- `siren.errors` -- the typed C++ exceptions aliased from `siren.utilities` plus the pure-Python `ClosureError`, `NotSerializableError`, and a dual-role `InjectionShortfall` (both raisable and warnable).

**One validation choke point.** The python `Injector` is reworked so both the Vertex spec form (`Injector(detector=..., primary=Vertex(...), events=N)`) and the legacy keyword form route through a single `_build()`. Legacy kwargs are a translation shim over the same compile-and-validate path, not a parallel one. `_build` validates injection distributions, expand wiring, per-signature name resolution, mixture measures, and runs the detector-dependent channel-density probe; it also cross-checks all four secondary-keyed dicts so a typo'd key raises.

**events = successes.** `generate(events, on_shortfall=..., min_efficiency=...)` counts successful trees (never yields an empty tree), retries failed attempts up to `max_attempts`, and raises or warns an `InjectionShortfall` carrying an `InjectionReport`. `report()` renders the engine failure ledger; `explain(tree)` on the Weighter renders the engine weight breakdown.

**Diagnostics backend wiring.** `Weighter::ComputeVertexFactors` now populates the previously-empty `channel_densities` (from the injection mixture's `DensityBreakdown`) and `cancelled` (the value-shared distributions) on the diagnostics path only, so `EventWeight` is untouched.

**Staged Box deprecation.** Positional `Box(x, y, z)` places the box at the origin, which reads as a size-only constructor; it now warns and a `Box(widths=..., center=...)` form is added. The hard error is deferred to a later phase after the examples migrate.

## Correctness

- The golden regression archive stays byte-identical: every C++ change here is observation-only or additive to a diagnostics path, and the python rework sits above the engine numerics.
- New fixed-seed stream-identity tests prove the legacy keyword form and the Vertex spec form produce identical event streams and weights.
- The Weighter rework removes the private `_Injector__injector` reach-throughs in favor of the public `engine` property.

## Tests

New: test_vertex_spec, test_channels_algebra, test_expand_wiring, test_injector_api, test_legacy_shims, test_weighter_explain; test_failure_report and test_density_breakdown extended for the rendered report and the now-populated diagnostics contract.
