### PR TITLE
Naming and deprecation edges, channel docstrings, user docs

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,73 @@
+# Error reference
+
+SIREN error messages that originate from the C++ engine end with a tag like
+`[siren-docs: errors#configuration]`. Find the token after `errors#` in the
+message, then read the matching section below.
+
+## errors#configuration
+
+**What raises it.** Injector/Weighter process configuration mismatches,
+raised as `ConfigurationError`:
+
+- the `Weighter`'s primary physical process does not match the `Injector`'s
+  primary process ("does not match the injector primary process");
+- a secondary physical process does not match its injector's secondary
+  process, or has no matching injector secondary process at all
+  ("has no matching injector secondary process");
+- the injector's secondary processes and the weighter's secondary processes
+  are not in one-to-one correspondence ("no one-to-one mapping between
+  injection ... and physical ... secondary processes");
+- a `MultiChannelPhaseSpace` has a `weights` list whose size does not match
+  its `channels` list, has a weight that is not finite and non-negative, has
+  weights that do not sum to 1, or has no channels at all
+  ("call Normalize() or use the validating constructor" /
+  "MultiChannelPhaseSpace has no channels").
+
+**The fix.** Ensure the physical processes passed to the `Weighter` mirror
+the `Injector`'s processes exactly (same primary type, same set of secondary
+types, matching collections). For a hand-built channel mixture, call
+`MultiChannelPhaseSpace.Normalize()` (or use the validating constructor)
+before using it -- do not assign `weights` and `channels` separately without
+normalizing. See `docs/quickstart.md`'s closure check and this repository's
+config/closure gauges for a way to catch this before a full run.
+
+## errors#measure-compat
+
+**What raises it.** A `MeasureCompatibilityError` when mixing phase-space
+channels in a `MultiChannelPhaseSpace`:
+
+- channel topologies disagree ("Topology mismatch: channel 0 ... is
+  `<Topology>` but channel `i` ... is `<Topology>`");
+- a channel's `Measure` cannot be converted to the mixture's common measure
+  within the shared topology ("Measure incompatibility: channel `i` ... uses
+  `<Measure>` which is not convertible to `<Measure>` within `<Topology>`
+  topology").
+
+A channel whose measure differs from the common measure but IS convertible
+within the topology is not an error -- it auto-converts silently.
+
+**The fix.** Give every channel in a mixture the same `Topology()` and a
+mutually convertible `Measure()` (see `docs/units_conventions.md` for the
+rest-frame-vs-lab-frame distinction between `SolidAngleRest` and
+`SolidAngleLab`, one common source of an inconvertible pairing). Check each
+channel's `.Topology()` and `.Measure()` before assembling the mixture.
+
+## errors#weight-calc
+
+**What raises it.** A `WeightCalculationError` when `Weighter::EventWeight`
+cannot form a usable weight for an event: the accumulated
+`generation_probability` is `<= 0` or non-finite, or the accumulated
+`physical_probability` is non-finite ("unusable probabilities for injector
+... generation_probability=..., physical_probability=...").
+
+An event with `physical_probability == 0` (out-of-physical-support kinematics)
+is NOT an error: it weights to exactly `0.0` by design, since that drives the
+weight reciprocal to `+inf` correctly. Only a non-finite or non-positive
+generation probability, or a non-finite physical probability, raises.
+
+**The fix.** If you see this for an event that should be in-support, check
+the offending injector's distributions and the event's kinematics: a
+distribution returning a non-finite or negative density anywhere in its
+support will surface here the first time that region is sampled. Run
+`siren.check_closure` (`docs/quickstart.md`) on the model responsible for the
+vertex to find which distribution's density disagrees with its sampler.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,116 @@
+# Quickstart
+
+SIREN is a two-phase Monte Carlo framework: injection draws biased samples of
+rare event topologies, and weighting computes the importance weight that maps
+each sample back to the physical distribution it represents. This page is the
+smallest end-to-end taste of both phases: define a model, verify its sampler
+and its density agree, then see the shape of a full simulation run.
+
+## Define a model
+
+A physics model is a small Python class: declare the particles and the
+phase-space measure, then implement the width (or cross section) as two
+hooks. Here is a two-body decay with an isotropic angular distribution in the
+parent rest frame:
+
+```python
+import math, siren
+
+class IsoDecay(siren.DecayModel):
+    parent = "N4"
+    daughters = ("NuLight", "Gamma")
+    measure = siren.Measure.SolidAngleRest()
+
+    def total_width(self):
+        return 1.0
+
+    def differential_width(self, record):
+        return 1.0 / (4.0 * math.pi)
+
+    def density_variables(self):
+        return "cost"
+```
+
+`siren.DecayModel` derives the interaction signature, the topology, and
+`FinalStateProbability` (differential over total) from these hooks. Because
+the declared measure (`SolidAngleRest`) has a self-contained default sampler,
+you get a working `SampleFinalState` for free -- you only had to describe the
+physics.
+
+## Check it closes
+
+Every weight in SIREN is `PhysicalProbability / GenerationProbability`. That
+ratio is only meaningful if the sampler's distribution and the model's own
+density (`FinalStateProbability`) describe the same thing. `check_closure`
+quantifies whether they do:
+
+```python
+report = siren.check_closure(IsoDecay())
+print(report)
+print(report.ok)
+```
+
+Actual output from this exact model:
+
+```
+Closure report: PASS
+  normalization (absolute) E[f/g_ref] = 1.0000 +/- 0.0000 (expect 1.0)
+  flatness (shape only) = 1.0000 +/- 0.0224 (self-normalized bin ratios; blind to a uniform scale error)
+  moment z-scores:
+    cost: z=0.00
+  worst region: costheta_secondary0_rest in [-0.40, -0.30): ratio 1.19 (z=1.7)
+True
+```
+
+Closure means the biased sampler and the physical density agree, so weights
+computed against this model are unbiased -- no hidden shape or normalization
+error that statistics alone would never reveal.
+
+## Run a simulation
+
+The `Simulation` facade wires a detector, a primary particle, an interaction
+model, and injection/physical distributions into one object that runs both
+phases:
+
+```python
+import siren
+
+sim = siren.Simulation(
+    events=100_000,
+    detector="IceCube",
+    primary="NuMu",
+    interactions="CSMSDISSplines",
+    target="Nucleon",
+    process="CC",
+    energy=siren.dist.PowerLaw(2, 1e3, 1e6),
+    direction=siren.dist.IsotropicDirection(),
+    position=siren.dist.ColumnDepth(
+        600, 600.0, siren.distributions.LeptonDepthFunction()),
+)
+results = sim.run()
+len(results)                       # number of generated events
+for event, weight in results:
+    pass                          # event: InteractionTree, weight: float
+sim.describe()                     # human-readable summary of the pipeline
+```
+
+This snippet needs a detector model and cross-section splines to run (both
+loaded from `resources/`), so it is shown here but not executed on this page.
+See `docs/quickstart.md`'s companion tests (`tests/python/test_simulation_api.py`)
+for a runnable version against the `IceCube` detector and `CSMSDISSplines`.
+
+`results` is a `siren.Results`: iterate it for `(event, weight)` pairs, index
+or slice it, and call `results.summary()` for a weight-quality report.
+
+## Which layer do I use?
+
+Use the `Simulation` facade for standard runs. Drop to the Layer-2
+`Injector`/`Weighter` objects (`sim.injector`, `sim.weighter`) only when you
+need to customize distributions or phase-space channels directly -- both are
+built lazily and are the same objects `sim.run()` uses internally.
+
+## Next steps
+
+- `docs/units_conventions.md` -- units, geometry argument conventions, frames,
+  and the RNG reproducibility contract.
+- `docs/errors.md` -- what each SIREN error message means and how to fix it.

--- a/docs/units_conventions.md
+++ b/docs/units_conventions.md
@@ -1,0 +1,84 @@
+# Units and conventions
+
+## Units
+
+Energies and masses are in GeV, lengths are in meters, and times are in
+nanoseconds (ns). Internally, SIREN fixes `meter = 1` and `second = 1e9`, so a
+time value of `1.0` is 1 ns; this is the convention HepMC3 export also uses
+for vertex/particle times.
+
+## Geometry arguments are FULL widths
+
+`Box` and similar geometry constructors take FULL side lengths, not
+half-widths:
+
+```python
+box = siren.geometry.Box(widths=(x, y, z), center=(cx, cy, cz))
+```
+
+Here `x`, `y`, `z` are the full extents of the box along each axis (a cube
+with `widths=(2.0, 2.0, 2.0)` spans from -1.0 to +1.0 on each side of its
+center). GDML `<box>` `x`/`y`/`z` attributes are also full lengths, not half
+lengths.
+
+This is a known footgun: reading a full-width value as a half-width silently
+doubles a volume's size. Always use `widths=`/`center=` and confirm which
+convention a given geometry constructor documents; do not assume it matches
+GDML's `<box>` (some GDML solids, like `<trd>`/`<trap>`, are natively defined
+in terms of half lengths, and SIREN's GDML parser halves those on read -- see
+the parser's per-solid handling, not this page, for the authoritative list).
+
+The positional form `Box(x, y, z)` is deprecated: it places the box at the
+ORIGIN, silently dropping any intended center. It still constructs (with a
+`DeprecationWarning`), but always prefer the explicit form:
+
+```python
+# Deprecated: places the box at (0, 0, 0), ignores any intended offset.
+box = siren.geometry.Box(1.0, 2.0, 3.0)
+
+# Correct: explicit widths and center.
+box = siren.geometry.Box(widths=(1.0, 2.0, 3.0), center=(0.0, 0.0, 5.0))
+```
+
+## Frames and coordinates
+
+Positions stored in `InteractionRecord` are in DETECTOR coordinates (the
+detector model's local frame), not a beamline or geocentric frame. Loaders
+such as `siren.utilities.load_detector` handle the transform from a beamline
+frame (e.g. BNB) into detector-local coordinates when composing geometry.
+
+Phase-space measures name the frame a solid angle is defined in:
+`Measure.SolidAngleRest()` is uniform solid angle in the parent's rest frame;
+`Measure.SolidAngleLab()` is uniform solid angle in the lab frame. These are
+not interchangeable -- a sampler built for one and checked (or weighted)
+against the other will show a systematic angular bias. `check_closure`'s
+frame heuristic flags exactly this: a declared `SolidAngleRest` measure whose
+samples actually look isotropic in the lab frame (or vice versa).
+
+## RNG and reproducibility (two-stream contract)
+
+SIREN maintains two independent RNG streams:
+
+- a GENERATION stream, which drives event sampling (the `Injector`'s seed);
+- a VALIDATION stream, which drives gauges, probes, and diagnostics (for
+  example `check_closure`'s `seed` argument, which defaults to `seed=0` and
+  is entirely separate from any generation seed).
+
+Adding or running a diagnostic only draws from the validation stream, so it
+can never shift a generation-stream result -- running `check_closure` on a
+model, or probing a phase-space mixture, does not perturb any event stream
+produced by an `Injector` with the same seed. Fixing a seed makes a
+generation run reproducible: same seed, same configuration, same SIREN
+version implies an identical event stream.
+
+## Environment variables
+
+`SIREN_STRICT=1` is the only supported environment toggle. Setting it
+escalates SIREN's `DeprecationWarning`s (emitted for deprecated aliases like
+positional `Box(x, y, z)` or `Simulation(n_events=...)`) to hard errors,
+which is useful for finding remaining legacy call sites in a codebase before
+a deprecated form is removed. This is implemented in `siren`'s package
+`__init__`.
+
+`SIREN_QUIET` is not a supported toggle: nothing in the library reads it.
+Setting it has no effect; do not rely on it to suppress warnings or errors.

--- a/projects/geometry/private/pybindings/geometry.cxx
+++ b/projects/geometry/private/pybindings/geometry.cxx
@@ -23,6 +23,8 @@
 #include "../../public/SIREN/geometry/Para.h"
 #include "../../public/SIREN/geometry/GeometryMesh.h"
 
+#include "../../../utilities/public/SIREN/utilities/Errors.h"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -93,16 +95,12 @@ PYBIND11_MODULE(geometry,m) {
 
     class_<Box, std::shared_ptr<Box>, Geometry>(m, "Box")
         .def(init<>())
-        // Positional Box(x, y, z) places the box at the ORIGIN, which reads as
-        // a size-only constructor and silently drops the intended center. Warn
-        // and keep the origin placement; the hard error lands once callers move
-        // to the widths/center form.
-        .def(init([](double x, double y, double z) {
-            PyErr_WarnEx(PyExc_DeprecationWarning,
+        // Positional Box(x, y, z) reads as size-only and silently drops the
+        // intended center, so it raises with the keyword fix-it.
+        .def(init([](double x, double y, double z) -> std::shared_ptr<Box> {
+            throw siren::utilities::ConfigurationError(
                 "Box(x, y, z) places the box at the ORIGIN; pass "
-                "Box(widths=(x, y, z), center=(cx, cy, cz))",
-                1);
-            return std::make_shared<Box>(x, y, z);
+                "Box(widths=(x, y, z), center=(cx, cy, cz))");
         }))
         .def(init([](std::array<double, 3> widths, std::array<double, 3> center) {
             Placement placement(siren::math::Vector3D(center[0], center[1], center[2]));

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -83,12 +83,18 @@ PYBIND11_MODULE(injection,m) {
 
   // New topology/measure enums
   enum_<PhaseSpaceTopology>(m, "PhaseSpaceTopology")
-    .value("Decay2Body", PhaseSpaceTopology::Decay2Body)
-    .value("Decay3Body", PhaseSpaceTopology::Decay3Body)
-    .value("DecayNBody", PhaseSpaceTopology::DecayNBody)
-    .value("Scatter2to2", PhaseSpaceTopology::Scatter2to2)
-    .value("Scatter2to3", PhaseSpaceTopology::Scatter2to3)
-    .value("Unspecified", PhaseSpaceTopology::Unspecified);
+    .value("Decay2Body", PhaseSpaceTopology::Decay2Body,
+           "Two-body final state from a single parent.")
+    .value("Decay3Body", PhaseSpaceTopology::Decay3Body,
+           "Three-body final state from a single parent.")
+    .value("DecayNBody", PhaseSpaceTopology::DecayNBody,
+           "N-body decay final state.")
+    .value("Scatter2to2", PhaseSpaceTopology::Scatter2to2,
+           "2->2 scattering (two incoming, two outgoing).")
+    .value("Scatter2to3", PhaseSpaceTopology::Scatter2to3,
+           "2->3 scattering.")
+    .value("Unspecified", PhaseSpaceTopology::Unspecified,
+           "Topology not declared; blocks mixing with typed channels.");
 
   enum_<siren::utilities::FailureReason>(m, "FailureReason")
     .value("Unspecified", siren::utilities::FailureReason::Unspecified)
@@ -101,14 +107,22 @@ PYBIND11_MODULE(injection,m) {
     .value("TopLevelCatch", siren::utilities::FailureReason::TopLevelCatch);
 
   enum_<PhaseSpaceMeasure::Type>(m, "PhaseSpaceMeasureType")
-    .value("SolidAngleRest", PhaseSpaceMeasure::Type::SolidAngleRest)
-    .value("SolidAngleLab", PhaseSpaceMeasure::Type::SolidAngleLab)
-    .value("Recursive2Body", PhaseSpaceMeasure::Type::Recursive2Body)
-    .value("DalitzPair", PhaseSpaceMeasure::Type::DalitzPair)
-    .value("HelicityAngles", PhaseSpaceMeasure::Type::HelicityAngles)
-    .value("MandelstamQ2", PhaseSpaceMeasure::Type::MandelstamQ2)
-    .value("BjorkenXY", PhaseSpaceMeasure::Type::BjorkenXY)
-    .value("Unspecified", PhaseSpaceMeasure::Type::Unspecified);
+    .value("SolidAngleRest", PhaseSpaceMeasure::Type::SolidAngleRest,
+           "Rest-frame solid angle.")
+    .value("SolidAngleLab", PhaseSpaceMeasure::Type::SolidAngleLab,
+           "Lab-frame solid angle.")
+    .value("Recursive2Body", PhaseSpaceMeasure::Type::Recursive2Body,
+           "Recursive two-body decomposition with spectator/pair indices.")
+    .value("DalitzPair", PhaseSpaceMeasure::Type::DalitzPair,
+           "Dalitz variables over a chosen pair.")
+    .value("HelicityAngles", PhaseSpaceMeasure::Type::HelicityAngles,
+           "Helicity-frame angles.")
+    .value("MandelstamQ2", PhaseSpaceMeasure::Type::MandelstamQ2,
+           "Momentum-transfer Q^2.")
+    .value("BjorkenXY", PhaseSpaceMeasure::Type::BjorkenXY,
+           "Bjorken x,y.")
+    .value("Unspecified", PhaseSpaceMeasure::Type::Unspecified,
+           "No measure declared.");
 
   class_<PhaseSpaceMeasure>(m, "PhaseSpaceMeasure")
     .def(init<>())
@@ -125,17 +139,25 @@ PYBIND11_MODULE(injection,m) {
         h ^= std::hash<int>()(m.pair_second) + 0x9e3779b9 + (h << 6) + (h >> 2);
         return h;
     })
-    .def_static("SolidAngleRest", &PhaseSpaceMeasure::SolidAngleRest)
-    .def_static("SolidAngleLab", &PhaseSpaceMeasure::SolidAngleLab)
+    .def_static("SolidAngleRest", &PhaseSpaceMeasure::SolidAngleRest,
+         "Rest-frame solid angle measure.")
+    .def_static("SolidAngleLab", &PhaseSpaceMeasure::SolidAngleLab,
+         "Lab-frame solid angle measure.")
     .def_static("Recursive2Body", &PhaseSpaceMeasure::Recursive2Body,
-         arg("spectator") = 0, arg("pair_first") = 1, arg("pair_second") = 2)
+         arg("spectator") = 0, arg("pair_first") = 1, arg("pair_second") = 2,
+         "Recursive two-body decomposition measure with spectator/pair indices.")
     .def_static("DalitzPair", &PhaseSpaceMeasure::DalitzPair,
-         arg("spectator") = 0, arg("pair_first") = 1, arg("pair_second") = 2)
+         arg("spectator") = 0, arg("pair_first") = 1, arg("pair_second") = 2,
+         "Dalitz-variable measure over the chosen pair.")
     .def_static("HelicityAngles", &PhaseSpaceMeasure::HelicityAngles,
-         arg("spectator") = 0, arg("pair_first") = 1, arg("pair_second") = 2)
-    .def_static("MandelstamQ2", &PhaseSpaceMeasure::MandelstamQ2)
-    .def_static("BjorkenXY", &PhaseSpaceMeasure::BjorkenXY)
-    .def_static("Unspecified", &PhaseSpaceMeasure::Unspecified)
+         arg("spectator") = 0, arg("pair_first") = 1, arg("pair_second") = 2,
+         "Helicity-frame angle measure.")
+    .def_static("MandelstamQ2", &PhaseSpaceMeasure::MandelstamQ2,
+         "Momentum-transfer Q^2 measure.")
+    .def_static("BjorkenXY", &PhaseSpaceMeasure::BjorkenXY,
+         "Bjorken x,y measure.")
+    .def_static("Unspecified", &PhaseSpaceMeasure::Unspecified,
+         "No measure declared.")
     ;
 
   m.def("PhaseSpaceTopologyName", &PhaseSpaceTopologyName);
@@ -150,8 +172,9 @@ PYBIND11_MODULE(injection,m) {
         arg("density"), arg("from_measure"), arg("to_measure"),
         arg("topology"), arg("record"));
 
-  // Legacy convention enum (kept for backward compatibility)
-  enum_<PhaseSpaceConvention>(m, "PhaseSpaceConvention")
+  // Legacy convention enum bound under a private name; the public PhaseSpaceConvention
+  // is a deprecation proxy installed in python/__init__.py.
+  enum_<PhaseSpaceConvention>(m, "_PhaseSpaceConvention")
     .value("RestFrameSolidAngle", PhaseSpaceConvention::RestFrameSolidAngle)
     .value("LabFrameSolidAngle", PhaseSpaceConvention::LabFrameSolidAngle)
     .value("Recursive2Body", PhaseSpaceConvention::Recursive2Body)
@@ -172,7 +195,15 @@ PYBIND11_MODULE(injection,m) {
     .def("Convention", &PhaseSpaceChannel::Convention)
     ;
 
-  class_<MultiChannelPhaseSpace, std::shared_ptr<MultiChannelPhaseSpace>> multi_channel_phase_space(m, "MultiChannelPhaseSpace");
+  class_<MultiChannelPhaseSpace, std::shared_ptr<MultiChannelPhaseSpace>> multi_channel_phase_space(m, "MultiChannelPhaseSpace",
+      R"pbdoc(
+      Weighted mixture of PhaseSpaceChannel objects sampled and evaluated as one
+      combined density g(x) = sum_i alpha_i g_i(x). Mixes physical and detector-
+      directed channels for importance sampling: each channel proposes candidate
+      kinematics and every channel's density is evaluated at whatever point was
+      drawn, so the combined density stays consistent regardless of which channel
+      produced the sample.
+      )pbdoc");
 
   // Severity-tagged compatibility diagnostic returned by ValidateChannelsDetailed,
   // bound as a nested type so the ValidateChannelsDetailed return type crosses.
@@ -192,23 +223,37 @@ PYBIND11_MODULE(injection,m) {
     .def(init<std::vector<std::shared_ptr<PhaseSpaceChannel>>, std::vector<double>, bool>(),
          arg("channels"), arg("weights") = std::vector<double>{},
          arg("allow_incompatible") = false)
-    .def_readwrite("channels", &MultiChannelPhaseSpace::channels)
-    .def_readwrite("weights", &MultiChannelPhaseSpace::weights)
-    .def("Normalize", &MultiChannelPhaseSpace::Normalize)
-    .def("Sample", &MultiChannelPhaseSpace::Sample)
-    .def("Density", &MultiChannelPhaseSpace::Density)
+    .def_readwrite("channels", &MultiChannelPhaseSpace::channels,
+         "The list of PhaseSpaceChannel objects making up the mixture.")
+    .def_readwrite("weights", &MultiChannelPhaseSpace::weights,
+         "Per-channel mixture weights alpha_i; need not be pre-normalized.")
+    .def("Normalize", &MultiChannelPhaseSpace::Normalize,
+         "Rescale weights in place so they sum to one.")
+    .def("Sample", &MultiChannelPhaseSpace::Sample,
+         "Pick a channel by weight and draw kinematics from it into record.")
+    .def("Density", &MultiChannelPhaseSpace::Density,
+         "Evaluate the combined mixture density g(x) = sum_i alpha_i g_i(x) at record.")
     .def("DensityBreakdown", &MultiChannelPhaseSpace::DensityBreakdown,
-         arg("detector_model"), arg("record"))
+         arg("detector_model"), arg("record"),
+         "Per-channel density contributions at record, for diagnosing which "
+         "channel dominates the mixture at a given point.")
     .def("Accumulate", &MultiChannelPhaseSpace::Accumulate,
          arg("detector_model"), arg("record"), arg("weight"),
-         arg("discount_fallback") = true, arg("recurse") = true)
+         arg("discount_fallback") = true, arg("recurse") = true,
+         "Feed one weighted sample into the per-channel statistics used by "
+         "UpdateWeights to retune the mixture weights.")
     .def("UpdateWeights", &MultiChannelPhaseSpace::UpdateWeights,
          arg("update_rule"), arg("damping"), arg("min_weight"),
-         arg("recurse") = true, arg("failure_mode") = "throughput")
+         arg("recurse") = true, arg("failure_mode") = "throughput",
+         "Retune channel weights from accumulated statistics using update_rule, "
+         "damping toward the previous weights and floored at min_weight.")
     .def("ResetAccumulators", &MultiChannelPhaseSpace::ResetAccumulators,
-         arg("recurse") = true)
+         arg("recurse") = true,
+         "Clear the statistics accumulated by Accumulate/AccumulateSelection.")
     .def("AccumulateSelection", &MultiChannelPhaseSpace::AccumulateSelection,
-         arg("detector_model"), arg("record"), arg("failed"))
+         arg("detector_model"), arg("record"), arg("failed"),
+         "Feed one selection outcome (pass/fail) into the per-channel "
+         "acceptance statistics used by UpdateWeights.")
     .def_readwrite("kp_accumulator", &MultiChannelPhaseSpace::kp_accumulator_)
     .def_readwrite("kp_count", &MultiChannelPhaseSpace::kp_count_)
     .def_readwrite("kp_succ_select", &MultiChannelPhaseSpace::kp_succ_select_)
@@ -232,27 +277,48 @@ PYBIND11_MODULE(injection,m) {
     .def("DirectingActive", &NestedMixtureChannel::DirectingActive, arg("record"))
     ;
 
-  class_<Isotropic2BodyChannel, std::shared_ptr<Isotropic2BodyChannel>, PhaseSpaceChannel>(m, "Isotropic2BodyChannel")
+  class_<Isotropic2BodyChannel, std::shared_ptr<Isotropic2BodyChannel>, PhaseSpaceChannel>(m, "Isotropic2BodyChannel",
+      "Samples a two-body decay isotropically in the parent rest frame, with no "
+      "detector direction bias. Topology Decay2Body, Measure SolidAngleRest. Use as "
+      "the physical/fallback channel for a 2-body decay with no directing bias.")
     .def(init<int>(), arg("daughter_index") = 0)
     ;
 
   enum_<DetectorDirected2BodyChannel::Mode>(m, "DirectedMode")
-    .value("Cone", DetectorDirected2BodyChannel::Mode::Cone)
-    .value("Volume", DetectorDirected2BodyChannel::Mode::Volume);
+    .value("Cone", DetectorDirected2BodyChannel::Mode::Cone,
+           "Bias into a fixed cone around the detector direction; simple but "
+           "leaves solid angle outside the cone unsampled.")
+    .value("Volume", DetectorDirected2BodyChannel::Mode::Volume,
+           "Bias toward the target volume's actual angular extent; adapts to "
+           "detector geometry.");
 
-  class_<DetectorDirected2BodyChannel, std::shared_ptr<DetectorDirected2BodyChannel>, PhaseSpaceChannel>(m, "DetectorDirected2BodyChannel")
+  class_<DetectorDirected2BodyChannel, std::shared_ptr<DetectorDirected2BodyChannel>, PhaseSpaceChannel>(m, "DetectorDirected2BodyChannel",
+      "Directs one daughter of a two-body decay toward a target volume. Topology "
+      "Decay2Body, Measure SolidAngleRest. Use for 2-body decays where one "
+      "daughter is the signal to point at the detector.")
     .def(init<std::shared_ptr<siren::geometry::Geometry const>, int, DetectorDirected2BodyChannel::Mode, double>(),
          arg("target"), arg("daughter_index") = 0,
          arg("mode") = DetectorDirected2BodyChannel::Mode::Volume,
-         arg("volume") = -1.0)
+         arg("volume") = -1.0,
+         "target: geometry to bias toward.\n"
+         "daughter_index: which of the two final-state particles is directed.\n"
+         "mode: DirectedMode.Cone or DirectedMode.Volume.\n"
+         "volume: fixed solid angle for Cone mode; -1 to derive it from geometry.")
     .def("SetVolume", &DetectorDirected2BodyChannel::SetVolume)
     .def("DirectingActive", &DetectorDirected2BodyChannel::DirectingActive, arg("record"))
     ;
 
-  class_<DetectorDirectedAngularSectorChannel, std::shared_ptr<DetectorDirectedAngularSectorChannel>, PhaseSpaceChannel>(m, "DetectorDirectedAngularSectorChannel")
+  class_<DetectorDirectedAngularSectorChannel, std::shared_ptr<DetectorDirectedAngularSectorChannel>, PhaseSpaceChannel>(m, "DetectorDirectedAngularSectorChannel",
+      "Directs a two-body daughter into one angular sector (u, phi bounds) of the "
+      "target, for disjoint tiling of the target's angular extent across channels. "
+      "Topology Decay2Body, Measure SolidAngleRest.")
     .def(init<std::shared_ptr<siren::geometry::Geometry const>, double, double, double, double, int>(),
          arg("target"), arg("u_lo"), arg("u_hi"), arg("phi_lo"), arg("phi_hi"),
-         arg("daughter_index") = 0)
+         arg("daughter_index") = 0,
+         "target: geometry the sector is defined against.\n"
+         "u_lo, u_hi: bounds in cos(theta) (u = cos theta) for this sector.\n"
+         "phi_lo, phi_hi: azimuthal bounds for this sector.\n"
+         "daughter_index: which of the two final-state particles is directed.")
     .def("DirectingActive", &DetectorDirectedAngularSectorChannel::DirectingActive, arg("record"))
     ;
 
@@ -261,46 +327,66 @@ PYBIND11_MODULE(injection,m) {
   // through a shared instance cannot let sampling and density drift apart
   // (Contract C1).  Models consume these; they do not subclass in Python,
   // so no trampoline is needed.
-  class_<Mapping1D, std::shared_ptr<Mapping1D>>(m, "Mapping1D")
+  class_<Mapping1D, std::shared_ptr<Mapping1D>>(m, "Mapping1D",
+      "Base interface for a 1-D importance map: one object provides both the draw "
+      "(Forward, from a uniform variate) and its own normalized density (Density) "
+      "over the same variable, so a model/channel routing both through a shared "
+      "instance cannot let sampling and density drift apart.")
     .def("Forward", &Mapping1D::Forward, arg("r"))
     .def("Inverse", &Mapping1D::Inverse, arg("x"))
     .def("Density", &Mapping1D::Density, arg("x"))
     .def("Accumulate", &Mapping1D::Accumulate, arg("x"), arg("weight"))
     .def("Refine", &Mapping1D::Refine);
 
-  class_<BreitWignerMapping, std::shared_ptr<BreitWignerMapping>, Mapping1D>(m, "BreitWignerMapping")
+  class_<BreitWignerMapping, std::shared_ptr<BreitWignerMapping>, Mapping1D>(m, "BreitWignerMapping",
+      "Breit-Wigner-shaped density in s over [s_min, s_max]; peaks at s = mass^2 "
+      "with width set by width.")
     .def(init<double, double, double, double>(),
          arg("mass"), arg("width"), arg("s_min"), arg("s_max"));
 
-  class_<PowerLawMapping, std::shared_ptr<PowerLawMapping>, Mapping1D>(m, "PowerLawMapping")
+  class_<PowerLawMapping, std::shared_ptr<PowerLawMapping>, Mapping1D>(m, "PowerLawMapping",
+      "Power-law-shaped density (index nu, offset m2) over [s_min, s_max]; use for "
+      "a heavy-tailed invariant-mass or Q^2 variable with no resonance.")
     .def(init<double, double, double, double>(),
          arg("nu"), arg("m2"), arg("s_min"), arg("s_max"));
 
-  class_<TabulatedMapping, std::shared_ptr<TabulatedMapping>, Mapping1D>(m, "TabulatedMapping")
+  class_<TabulatedMapping, std::shared_ptr<TabulatedMapping>, Mapping1D>(m, "TabulatedMapping",
+      "Density defined by a user-supplied cumulative table (s_nodes, cdf_nodes) "
+      "over [s_min, s_max]; use when the target density has no closed form.")
     .def(init<std::vector<double>, std::vector<double>, double, double>(),
          arg("s_nodes"), arg("cdf_nodes"), arg("s_min"), arg("s_max"));
 
-  class_<PropagatorMapping, std::shared_ptr<PropagatorMapping>, Mapping1D>(m, "PropagatorMapping")
+  class_<PropagatorMapping, std::shared_ptr<PropagatorMapping>, Mapping1D>(m, "PropagatorMapping",
+      "1/(x^2 + m2)-shaped density for propagator-peaked variables like off-shell "
+      "Q^2 or invariant mass.")
     .def(init<double, double, double>(),
          arg("m2"), arg("x_min"), arg("x_max"));
 
-  class_<UniformMapping, std::shared_ptr<UniformMapping>, Mapping1D>(m, "UniformMapping")
+  class_<UniformMapping, std::shared_ptr<UniformMapping>, Mapping1D>(m, "UniformMapping",
+      "Flat density over [s_min, s_max].")
     .def(init<double, double>(),
          arg("s_min"), arg("s_max"));
 
-  class_<LogMapping, std::shared_ptr<LogMapping>, Mapping1D>(m, "LogMapping")
+  class_<LogMapping, std::shared_ptr<LogMapping>, Mapping1D>(m, "LogMapping",
+      "Log-uniform density over [x_min, x_max]; use for a variable spanning "
+      "multiple orders of magnitude.")
     .def(init<double, double>(),
          arg("x_min"), arg("x_max"));
 
-  class_<ExponentialMapping, std::shared_ptr<ExponentialMapping>, Mapping1D>(m, "ExponentialMapping")
+  class_<ExponentialMapping, std::shared_ptr<ExponentialMapping>, Mapping1D>(m, "ExponentialMapping",
+      "Exponential density with mean tau over [x_min, x_max].")
     .def(init<double, double, double>(),
          arg("tau"), arg("x_min"), arg("x_max"));
 
-  class_<GaussianMapping, std::shared_ptr<GaussianMapping>, Mapping1D>(m, "GaussianMapping")
+  class_<GaussianMapping, std::shared_ptr<GaussianMapping>, Mapping1D>(m, "GaussianMapping",
+      "Gaussian density (mean mu, width sigma) over [x_min, x_max].")
     .def(init<double, double, double, double>(),
          arg("mu"), arg("sigma"), arg("x_min"), arg("x_max"));
 
-  class_<AdaptiveMapping, std::shared_ptr<AdaptiveMapping>, Mapping1D>(m, "AdaptiveMapping")
+  class_<AdaptiveMapping, std::shared_ptr<AdaptiveMapping>, Mapping1D>(m, "AdaptiveMapping",
+      "Piecewise-constant density over [x_min, x_max] in n_bins bins, refined "
+      "toward accumulated samples via Refine; use when no analytic shape fits "
+      "and the density should self-tune during generation.")
     .def(init<double, double, int, double, double>(),
          arg("x_min"), arg("x_max"), arg("n_bins") = 32,
          arg("damping") = 0.5, arg("floor_frac") = 1e-3)
@@ -308,17 +394,123 @@ PYBIND11_MODULE(injection,m) {
     .def_readonly("n_bins", &AdaptiveMapping::n_bins);
 
   enum_<DetectorDirected3BodyChannel::InvariantMassMode>(m, "InvariantMassMode")
-    .value("Uniform", DetectorDirected3BodyChannel::InvariantMassMode::Uniform)
-    .value("BreitWigner", DetectorDirected3BodyChannel::InvariantMassMode::BreitWigner)
-    .value("PowerLaw", DetectorDirected3BodyChannel::InvariantMassMode::PowerLaw)
-    .value("Tabulated", DetectorDirected3BodyChannel::InvariantMassMode::Tabulated);
+    .value("Uniform", DetectorDirected3BodyChannel::InvariantMassMode::Uniform,
+           "Flat invariant-mass sampling.")
+    .value("BreitWigner", DetectorDirected3BodyChannel::InvariantMassMode::BreitWigner,
+           "Breit-Wigner resonance shape (needs resonance_mass, resonance_width).")
+    .value("PowerLaw", DetectorDirected3BodyChannel::InvariantMassMode::PowerLaw,
+           "Power-law tail (needs power_law_nu, power_law_offset).")
+    .value("Tabulated", DetectorDirected3BodyChannel::InvariantMassMode::Tabulated,
+           "User-supplied cumulative table (mass_cdf_nodes/values).");
 
-  class_<DetectorDirected3BodyChannel, std::shared_ptr<DetectorDirected3BodyChannel>, PhaseSpaceChannel>(m, "DetectorDirected3BodyChannel")
+  enum_<DetectorDirected3BodyChannel::Factorization>(m, "ThreeBodyMode")
+    .value("Direct", DetectorDirected3BodyChannel::Factorization::Direct,
+           "Bias one daughter directly toward the detector; the invariant mass "
+           "pairs the other two. Best when the biased daughter is the signal "
+           "and the spectator pair has no resonance.")
+    .value("Recursive", DetectorDirected3BodyChannel::Factorization::Recursive,
+           "Bias a two-body sub-decay (a resonance pair) toward the detector, "
+           "then decay the pair internally. Best when the pair has resonance "
+           "structure (e.g. an off-shell mediator sampled with Breit-Wigner).");
+
+  class_<DetectorDirected3BodyChannel, std::shared_ptr<DetectorDirected3BodyChannel>, PhaseSpaceChannel>(m, "DetectorDirected3BodyChannel",
+      "Directs a three-body decay toward a target volume, factorized per "
+      "ThreeBodyMode. Topology Decay3Body, Measure Recursive2Body. Use for "
+      "3-body BSM decays where a signal daughter or resonance pair should "
+      "point at the detector.")
+    // Keyword ctor: factorization selects Direct vs Recursive explicitly, so
+    // pybind disambiguates on the leading Factorization-typed argument rather
+    // than on argument count. Constructs via the underlying Direct/Recursive
+    // C++ ctors, so objects built here are byte-identical to ones built there.
+    .def(init(
+        [](DetectorDirected3BodyChannel::Factorization factorization,
+           std::shared_ptr<siren::geometry::Geometry const> target,
+           int directed_index,
+           int spectator_index,
+           int pair_first_index,
+           int pair_second_index,
+           DetectorDirected3BodyChannel::InvariantMassMode mass_mode,
+           double resonance_mass,
+           double resonance_width,
+           double power_law_nu,
+           double power_law_offset,
+           DetectorDirected2BodyChannel::Mode mode,
+           PhaseSpaceTopology topology,
+           std::vector<double> mass_cdf_nodes,
+           std::vector<double> mass_cdf_values) {
+          if (factorization == DetectorDirected3BodyChannel::Factorization::Direct) {
+            return std::make_shared<DetectorDirected3BodyChannel>(
+                target, directed_index,
+                mass_mode, resonance_mass, resonance_width,
+                power_law_nu, power_law_offset,
+                mode, topology, mass_cdf_nodes, mass_cdf_values);
+          }
+          if (spectator_index < 0 || pair_first_index < 0 || pair_second_index < 0) {
+            throw siren::utilities::ConfigurationError(
+                "factorization=ThreeBodyMode.Recursive requires spectator_index, "
+                "pair_first_index, and pair_second_index");
+          }
+          int directed_pair_index =
+              (directed_index == pair_first_index || directed_index == pair_second_index)
+                  ? directed_index : pair_first_index;
+          return std::make_shared<DetectorDirected3BodyChannel>(
+              target, spectator_index, pair_first_index, pair_second_index,
+              directed_pair_index,
+              mass_mode, resonance_mass, resonance_width,
+              power_law_nu, power_law_offset,
+              mode, topology, mass_cdf_nodes, mass_cdf_values);
+        }),
+        arg("factorization"), arg("target"),
+        arg("directed_index") = 0,
+        arg("spectator_index") = -1,
+        arg("pair_first_index") = -1,
+        arg("pair_second_index") = -1,
+        arg("mass_mode") = DetectorDirected3BodyChannel::InvariantMassMode::Uniform,
+        arg("resonance_mass") = 0.0, arg("resonance_width") = 0.0,
+        arg("power_law_nu") = 0.8, arg("power_law_offset") = 0.0,
+        arg("mode") = DetectorDirected2BodyChannel::Mode::Volume,
+        arg("topology") = PhaseSpaceTopology::Decay3Body,
+        arg("mass_cdf_nodes") = std::vector<double>{},
+        arg("mass_cdf_values") = std::vector<double>{},
+        "Keyword constructor selecting the factorization explicitly via "
+        "factorization=ThreeBodyMode.Direct or ThreeBodyMode.Recursive.\n"
+        "factorization: ThreeBodyMode.Direct or ThreeBodyMode.Recursive.\n"
+        "target: geometry to bias toward.\n"
+        "directed_index: (Direct) which daughter is biased toward target; "
+        "(Recursive) which member of the pair is biased, defaulting to "
+        "pair_first_index if not one of the pair indices.\n"
+        "spectator_index, pair_first_index, pair_second_index: (Recursive only) "
+        "indices of the spectator daughter and the resonance-pair daughters.\n"
+        "mass_mode: InvariantMassMode governing the paired/spectator invariant mass.\n"
+        "resonance_mass, resonance_width: used when mass_mode is BreitWigner.\n"
+        "power_law_nu, power_law_offset: used when mass_mode is PowerLaw.\n"
+        "mode: DirectedMode.Cone or DirectedMode.Volume for the directed sub-step.\n"
+        "topology: PhaseSpaceTopology tag carried by the channel.\n"
+        "mass_cdf_nodes, mass_cdf_values: used when mass_mode is Tabulated.")
     // Direct mode: specify which daughter to bias, others inferred.
-    .def(init<std::shared_ptr<siren::geometry::Geometry const>, int,
-              DetectorDirected3BodyChannel::InvariantMassMode, double, double, double, double,
-              DetectorDirected2BodyChannel::Mode, PhaseSpaceTopology,
-              std::vector<double>, std::vector<double>>(),
+    // Deprecated: superseded by the factorization= keyword constructor.
+    .def(init(
+        [](std::shared_ptr<siren::geometry::Geometry const> target,
+           int directed_index,
+           DetectorDirected3BodyChannel::InvariantMassMode mass_mode,
+           double resonance_mass,
+           double resonance_width,
+           double power_law_nu,
+           double power_law_offset,
+           DetectorDirected2BodyChannel::Mode mode,
+           PhaseSpaceTopology topology,
+           std::vector<double> mass_cdf_nodes,
+           std::vector<double> mass_cdf_values) {
+          PyErr_WarnEx(PyExc_DeprecationWarning,
+              "Positional DetectorDirected3BodyChannel(target, directed_index, ...) "
+              "is deprecated; pass factorization=ThreeBodyMode.Direct with keyword "
+              "indices.", 1);
+          return std::make_shared<DetectorDirected3BodyChannel>(
+              target, directed_index,
+              mass_mode, resonance_mass, resonance_width,
+              power_law_nu, power_law_offset,
+              mode, topology, mass_cdf_nodes, mass_cdf_values);
+        }),
          arg("target"), arg("directed_index"),
          arg("mass_mode") = DetectorDirected3BodyChannel::InvariantMassMode::Uniform,
          arg("resonance_mass") = 0.0, arg("resonance_width") = 0.0,
@@ -328,10 +520,34 @@ PYBIND11_MODULE(injection,m) {
          arg("mass_cdf_nodes") = std::vector<double>{},
          arg("mass_cdf_values") = std::vector<double>{})
     // Recursive mode: specify all indices (backward compatible).
-    .def(init<std::shared_ptr<siren::geometry::Geometry const>, int, int, int, int,
-              DetectorDirected3BodyChannel::InvariantMassMode, double, double, double, double,
-              DetectorDirected2BodyChannel::Mode, PhaseSpaceTopology,
-              std::vector<double>, std::vector<double>>(),
+    // Deprecated: superseded by the factorization= keyword constructor.
+    .def(init(
+        [](std::shared_ptr<siren::geometry::Geometry const> target,
+           int spectator_index,
+           int pair_first_index,
+           int pair_second_index,
+           int directed_pair_index,
+           DetectorDirected3BodyChannel::InvariantMassMode mass_mode,
+           double resonance_mass,
+           double resonance_width,
+           double power_law_nu,
+           double power_law_offset,
+           DetectorDirected2BodyChannel::Mode mode,
+           PhaseSpaceTopology topology,
+           std::vector<double> mass_cdf_nodes,
+           std::vector<double> mass_cdf_values) {
+          PyErr_WarnEx(PyExc_DeprecationWarning,
+              "Positional DetectorDirected3BodyChannel(target, spectator_index, "
+              "pair_first_index, pair_second_index, directed_pair_index, ...) is "
+              "deprecated; pass factorization=ThreeBodyMode.Recursive with keyword "
+              "indices.", 1);
+          return std::make_shared<DetectorDirected3BodyChannel>(
+              target, spectator_index, pair_first_index, pair_second_index,
+              directed_pair_index,
+              mass_mode, resonance_mass, resonance_width,
+              power_law_nu, power_law_offset,
+              mode, topology, mass_cdf_nodes, mass_cdf_values);
+        }),
          arg("target"), arg("spectator_index"),
          arg("pair_first_index"), arg("pair_second_index"),
          arg("directed_pair_index"),
@@ -347,16 +563,26 @@ PYBIND11_MODULE(injection,m) {
     ;
 
   enum_<DetectorDirectedScatteringChannel::Variable>(m, "ScatteringVariable")
-    .value("Q2", DetectorDirectedScatteringChannel::Variable::Q2)
-    .value("BjorkenY", DetectorDirectedScatteringChannel::Variable::BjorkenY)
-    .value("RecoilY", DetectorDirectedScatteringChannel::Variable::RecoilY);
+    .value("Q2", DetectorDirectedScatteringChannel::Variable::Q2,
+           "Sample in momentum transfer Q^2.")
+    .value("BjorkenY", DetectorDirectedScatteringChannel::Variable::BjorkenY,
+           "Sample in inelasticity y.")
+    .value("RecoilY", DetectorDirectedScatteringChannel::Variable::RecoilY,
+           "Sample in recoil-energy fraction.");
 
   enum_<DetectorDirectedScatteringChannel::Q2Mode>(m, "ScatteringQ2Mode")
-    .value("Geometry", DetectorDirectedScatteringChannel::Q2Mode::Geometry)
-    .value("Propagator", DetectorDirectedScatteringChannel::Q2Mode::Propagator)
-    .value("Tabulated", DetectorDirectedScatteringChannel::Q2Mode::Tabulated);
+    .value("Geometry", DetectorDirectedScatteringChannel::Q2Mode::Geometry,
+           "Q^2 range set by detector geometry (preserves current behavior).")
+    .value("Propagator", DetectorDirectedScatteringChannel::Q2Mode::Propagator,
+           "Q^2 sampled from the propagator peak (lower variance when the "
+           "density is propagator-peaked).")
+    .value("Tabulated", DetectorDirectedScatteringChannel::Q2Mode::Tabulated,
+           "Q^2 from a user CDF table (q2_cdf_nodes/values).");
 
-  class_<DetectorDirectedScatteringChannel, std::shared_ptr<DetectorDirectedScatteringChannel>, PhaseSpaceChannel>(m, "DetectorDirectedScatteringChannel")
+  class_<DetectorDirectedScatteringChannel, std::shared_ptr<DetectorDirectedScatteringChannel>, PhaseSpaceChannel>(m, "DetectorDirectedScatteringChannel",
+      "Directs the recoil of a 2->2 scatter toward a target volume. Topology "
+      "Scatter2to2, Measure MandelstamQ2. Use for upscattering where the "
+      "outgoing state should point at the detector.")
     .def(init<std::shared_ptr<siren::geometry::Geometry const>, int,
               DetectorDirectedScatteringChannel::Variable,
               DetectorDirected2BodyChannel::Mode,
@@ -368,13 +594,24 @@ PYBIND11_MODULE(injection,m) {
          arg("q2_mode") = DetectorDirectedScatteringChannel::Q2Mode::Geometry,
          arg("mediator_mass") = 0.0,
          arg("q2_cdf_nodes") = std::vector<double>{},
-         arg("q2_cdf_values") = std::vector<double>{})
+         arg("q2_cdf_values") = std::vector<double>{},
+         "target: geometry to bias the recoil toward.\n"
+         "directed_index: which outgoing particle is directed.\n"
+         "variable: ScatteringVariable sampled (Q2, BjorkenY, or RecoilY).\n"
+         "mode: DirectedMode.Cone or DirectedMode.Volume for the directed sub-step.\n"
+         "q2_mode: ScatteringQ2Mode governing how the Q^2 range/density is chosen.\n"
+         "mediator_mass: propagator mass used when q2_mode is Propagator.\n"
+         "q2_cdf_nodes, q2_cdf_values: used when q2_mode is Tabulated.")
     .def("SetVolume", &DetectorDirectedScatteringChannel::SetVolume)
     ;
 
   // Physical channel adapters
 
-  class_<PhysicalDecayChannel, std::shared_ptr<PhysicalDecayChannel>, PhaseSpaceChannel>(m, "PhysicalDecayChannel")
+  class_<PhysicalDecayChannel, std::shared_ptr<PhysicalDecayChannel>, PhaseSpaceChannel>(m, "PhysicalDecayChannel",
+      "Samples the unbiased physical final state of a Decay (no detector "
+      "direction). Serves as the fallback channel in a mixture so events that "
+      "miss the target are still represented. Topology/Measure follow the "
+      "underlying interaction.")
     .def(init<std::shared_ptr<siren::interactions::Decay>>())
     .def(init<std::shared_ptr<siren::interactions::Decay>,
               siren::dataclasses::InteractionSignature const &>())
@@ -382,7 +619,11 @@ PYBIND11_MODULE(injection,m) {
     .def("GetDecay", &PhysicalDecayChannel::GetDecay)
     ;
 
-  class_<PhysicalCrossSectionChannel, std::shared_ptr<PhysicalCrossSectionChannel>, PhaseSpaceChannel>(m, "PhysicalCrossSectionChannel")
+  class_<PhysicalCrossSectionChannel, std::shared_ptr<PhysicalCrossSectionChannel>, PhaseSpaceChannel>(m, "PhysicalCrossSectionChannel",
+      "Samples the unbiased physical final state of a CrossSection (no detector "
+      "direction). Serves as the fallback channel in a mixture so events that "
+      "miss the target are still represented. Topology/Measure follow the "
+      "underlying interaction.")
     .def(init<std::shared_ptr<siren::interactions::CrossSection>>())
     .def(init<std::shared_ptr<siren::interactions::CrossSection>,
               siren::dataclasses::InteractionSignature const &>())

--- a/python/Simulation.py
+++ b/python/Simulation.py
@@ -701,18 +701,13 @@ class Simulation:
 
             channels.append(
                 _injection.DetectorDirected3BodyChannel(
-                    target,
-                    spectator_idx,
-                    pair_indices[0],
-                    pair_indices[1],
-                    directed_pair_idx,
+                    factorization=_injection.ThreeBodyMode.Recursive,
+                    target=target,
+                    spectator_index=spectator_idx,
+                    pair_first_index=pair_indices[0],
+                    pair_second_index=pair_indices[1],
+                    directed_index=directed_pair_idx,
                 ))
-            weights.append(fraction)
-
-        elif isinstance(interaction, _interactions.CrossSection):
-            channels.append(
-                _injection.DetectorDirectedScatteringChannel(
-                    target, daughter_idx))
             weights.append(fraction)
 
         # Normalize

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -51,6 +51,36 @@ from . import Weighter
 injection.Weighter = Weighter.Weighter
 del Weighter
 
+# The proxy exists so legacy PhaseSpaceConvention enum-value access warns once
+# while still returning the real _PhaseSpaceConvention enum member, which C++
+# signatures and channel-value comparisons continue to accept.
+import warnings as _psc_warnings
+
+
+class _PhaseSpaceConventionProxy:
+    _MSG = (
+        "PhaseSpaceConvention is deprecated; use PhaseSpaceMeasure (siren.Measure). "
+        "Mapping: RestFrameSolidAngle -> Measure.SolidAngleRest(), "
+        "LabFrameSolidAngle -> Measure.SolidAngleLab(), "
+        "Recursive2Body -> Measure.Recursive2Body(), "
+        "Dalitz -> Measure.DalitzPair(), "
+        "HelicityAngles -> Measure.HelicityAngles(), "
+        "MandelstamST -> Measure.MandelstamQ2(), "
+        "BjorkenXY -> Measure.BjorkenXY(), "
+        "Custom -> a declared PhaseSpaceMeasure."
+    )
+
+    def __getattr__(self, name):
+        value = getattr(injection._PhaseSpaceConvention, name)
+        _psc_warnings.warn(self._MSG, DeprecationWarning, stacklevel=2)
+        return value
+
+    def __repr__(self):
+        return "<deprecated PhaseSpaceConvention proxy; use siren.Measure>"
+
+
+injection.PhaseSpaceConvention = _PhaseSpaceConventionProxy()
+
 dataclasses.Particle.ParticleType = dataclasses.ParticleType
 
 def darknews_version():

--- a/python/channels.py
+++ b/python/channels.py
@@ -440,7 +440,8 @@ def toward_3body(directed: Union[int, str], target, *,
         )
         if strategy == "direct":
             return siren.injection.DetectorDirected3BodyChannel(
-                target, directed_idx, **common_kwargs)
+                factorization=siren.injection.ThreeBodyMode.Direct,
+                target=target, directed_index=directed_idx, **common_kwargs)
 
         n_sec = len(signature.secondary_types)
         if spectator is None:
@@ -455,8 +456,10 @@ def toward_3body(directed: Union[int, str], target, *,
                 "index {} for signature {}".format(directed_idx, spectator_idx, signature))
         pair_first_idx, pair_second_idx = others[0], others[1]
         return siren.injection.DetectorDirected3BodyChannel(
-            target, spectator_idx, pair_first_idx, pair_second_idx,
-            directed_idx, **common_kwargs)
+            factorization=siren.injection.ThreeBodyMode.Recursive,
+            target=target, spectator_index=spectator_idx,
+            pair_first_index=pair_first_idx, pair_second_index=pair_second_idx,
+            directed_index=directed_idx, **common_kwargs)
 
     label = "toward_3body({!r}, strategy={!r})".format(directed, strategy)
     return Channel(factory, weight=1.0, label=label)

--- a/tests/python/test_directed_regimes.py
+++ b/tests/python/test_directed_regimes.py
@@ -687,3 +687,92 @@ def test_builder_tiles_optimize_and_stay_unbiased():
         if g > 0 and math.isfinite(g):
             ws.append(f / g)
     assert 0.9 <= np.mean(ws) <= 1.1
+
+
+# ------------------------------------------------------------------ #
+#  3-body ctor: keyword form is byte-identical to positional forms    #
+# ------------------------------------------------------------------ #
+
+import warnings  # noqa: E402
+
+
+def _make_3body_record(M=1.0, E=3.0, masses=(0.1, 0.05, 0.1)):
+    pz = math.sqrt(max(E * E - M * M, 0.0))
+    rec = siren.dataclasses.InteractionRecord()
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.dataclasses.ParticleType(211)
+    sig.secondary_types = [
+        siren.dataclasses.ParticleType(-13),
+        siren.dataclasses.ParticleType(14),
+        siren.dataclasses.ParticleType(5922),
+    ]
+    rec.signature = sig
+    rec.primary_mass = M
+    rec.primary_momentum = [E, 0.0, 0.0, pz]
+    rec.secondary_masses = list(masses)
+    rec.secondary_momenta = [[0, 0, 0, 0]] * 3
+    rec.secondary_helicities = [0, 0, 0]
+    rec.interaction_vertex = [0, 0, 0]
+    rec.primary_initial_position = [0, 0, 0]
+    return rec
+
+
+def _assert_sample_identity(old, new):
+    ra = siren.utilities.SIREN_random(1234)
+    rb = siren.utilities.SIREN_random(1234)
+    r_old = _make_3body_record()
+    r_new = _make_3body_record()
+    old.Sample(ra, None, r_old)
+    new.Sample(rb, None, r_new)
+    assert r_old.secondary_momenta == r_new.secondary_momenta
+    assert old.Density(None, r_old) == new.Density(None, r_new)
+    assert old.Measure() == new.Measure()
+    assert old.Topology() == new.Topology()
+
+
+def test_3body_direct_keyword_matches_positional():
+    """Direct keyword ctor samples identically to the positional Direct form."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        old = siren.injection.DetectorDirected3BodyChannel(box, 2)
+    new = siren.injection.DetectorDirected3BodyChannel(
+        factorization=siren.injection.ThreeBodyMode.Direct, target=box,
+        directed_index=2)
+    _assert_sample_identity(old, new)
+
+
+def test_3body_recursive_keyword_matches_positional():
+    """Recursive keyword ctor samples identically to the positional Recursive form."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        old = siren.injection.DetectorDirected3BodyChannel(box, 0, 1, 2, 1)
+    new = siren.injection.DetectorDirected3BodyChannel(
+        factorization=siren.injection.ThreeBodyMode.Recursive, target=box,
+        spectator_index=0, pair_first_index=1, pair_second_index=2,
+        directed_index=1)
+    _assert_sample_identity(old, new)
+
+
+def test_3body_recursive_without_indices_raises():
+    """Recursive factorization without spectator/pair indices raises ConfigurationError."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+    with pytest.raises(siren.errors.ConfigurationError):
+        siren.injection.DetectorDirected3BodyChannel(
+            factorization=siren.injection.ThreeBodyMode.Recursive, target=box,
+            directed_index=1)
+
+
+def test_3body_positional_direct_warns():
+    """Positional Direct form emits a DeprecationWarning naming the keyword ctor."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+    with pytest.warns(DeprecationWarning, match="factorization=ThreeBodyMode"):
+        siren.injection.DetectorDirected3BodyChannel(box, 2)
+
+
+def test_3body_positional_recursive_warns():
+    """Positional Recursive form emits a DeprecationWarning naming the keyword ctor."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+    with pytest.warns(DeprecationWarning, match="factorization=ThreeBodyMode"):
+        siren.injection.DetectorDirected3BodyChannel(box, 0, 1, 2, 1)

--- a/tests/python/test_injector_api.py
+++ b/tests/python/test_injector_api.py
@@ -190,16 +190,13 @@ def test_typo_secondary_key_raises():
 
 
 # ------------------------------------------------------------------ #
-#  positional Box warns but still constructs                          #
+#  positional Box raises                                              #
 # ------------------------------------------------------------------ #
 
-def test_positional_box_warns_and_constructs():
-    """Box(x, y, z) emits a DeprecationWarning and still builds a box."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        box = siren.geometry.Box(1.0, 2.0, 3.0)
-    assert any(issubclass(x.category, DeprecationWarning) for x in w)
-    assert box.X == 1.0 and box.Y == 2.0 and box.Z == 3.0
+def test_positional_box_raises():
+    """Box(x, y, z) raises with the widths=/center= fix-it."""
+    with pytest.raises(siren.errors.ConfigurationError, match="widths="):
+        siren.geometry.Box(1.0, 2.0, 3.0)
 
 
 def test_widths_center_box_places_at_center():

--- a/tests/python/test_package_import.py
+++ b/tests/python/test_package_import.py
@@ -47,3 +47,67 @@ def test_resources_public_helpers():
         assert callable(getattr(resources, name)), f"siren.resources.{name} not callable"
     for name in ("fluxes", "detectors", "processes"):
         assert hasattr(resources, name), f"siren.resources missing {name}"
+
+
+def test_phase_space_convention_proxy_warns_and_forwards():
+    """PhaseSpaceConvention proxy warns and forwards the real enum member."""
+    import siren
+    from siren.injection import PhaseSpaceConvention
+    with pytest.warns(DeprecationWarning, match="Measure.DalitzPair"):
+        v = PhaseSpaceConvention.Dalitz
+    assert v == siren.injection._PhaseSpaceConvention.Dalitz
+    assert v is siren.injection._PhaseSpaceConvention.Dalitz
+
+
+def test_phase_space_convention_proxy_value_accepted_by_cpp():
+    """A forwarded proxy value is accepted by the C++ PhaseSpaceConventionName."""
+    import siren
+    from siren.injection import PhaseSpaceConvention
+    with pytest.warns(DeprecationWarning):
+        v = PhaseSpaceConvention.Dalitz
+    assert "Dalitz" in siren.injection.PhaseSpaceConventionName(v)
+
+
+def test_phase_space_convention_proxy_channel_roundtrip():
+    """A channel's Convention() compares equal to the forwarded proxy value."""
+    import siren
+    from siren.injection import PhaseSpaceConvention
+    ch = siren.injection.Isotropic2BodyChannel(0)
+    with pytest.warns(DeprecationWarning):
+        assert ch.Convention() == PhaseSpaceConvention.RestFrameSolidAngle
+
+
+def test_phase_space_convention_proxy_unknown_attr_no_warning():
+    """Unknown proxy attribute raises AttributeError without warning."""
+    import warnings
+    from siren.injection import PhaseSpaceConvention
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        with pytest.raises(AttributeError):
+            PhaseSpaceConvention.NotAConvention
+
+
+def test_three_body_mode_bound():
+    """siren.injection.ThreeBodyMode exposes Direct and Recursive."""
+    import siren
+    assert hasattr(siren.injection.ThreeBodyMode, "Direct")
+    assert hasattr(siren.injection.ThreeBodyMode, "Recursive")
+
+
+def test_interaction_signature_eq_hash():
+    """InteractionSignature binds value == / hash consistently."""
+    import siren
+
+    def _sig(secs):
+        s = siren.dataclasses.InteractionSignature()
+        s.primary_type = siren.particles.N4
+        s.target_type = siren.dataclasses.ParticleType.Decay
+        s.secondary_types = secs
+        return s
+
+    a = _sig([siren.particles.NuLight, siren.particles.Gamma])
+    b = _sig([siren.particles.NuLight, siren.particles.Gamma])
+    c = _sig([siren.particles.NuLight, siren.particles.EMinus])
+    assert a == b
+    assert hash(a) == hash(b)
+    assert a != c

--- a/tests/python/test_simulation_api.py
+++ b/tests/python/test_simulation_api.py
@@ -638,11 +638,12 @@ class TestSecondaryBiasing:
         import siren
         fid = siren.get_fiducial_volume("IceCube")
         ch = siren.injection.DetectorDirected3BodyChannel(
-            fid,
+            factorization=siren.injection.ThreeBodyMode.Recursive,
+            target=fid,
             spectator_index=0,
             pair_first_index=1,
             pair_second_index=2,
-            directed_pair_index=1,
+            directed_index=1,
             mass_mode=siren.injection.InvariantMassMode.Uniform,
         )
         assert ch.Name() == "DetectorDirected3Body"
@@ -651,7 +652,9 @@ class TestSecondaryBiasing:
     def test_3body_channel_topology_measure(self):
         import siren
         fid = siren.get_fiducial_volume("IceCube")
-        ch = siren.injection.DetectorDirected3BodyChannel(fid, directed_index=2)
+        ch = siren.injection.DetectorDirected3BodyChannel(
+            factorization=siren.injection.ThreeBodyMode.Direct,
+            target=fid, directed_index=2)
         assert ch.Topology() == siren.injection.PhaseSpaceTopology.Decay3Body
         assert ch.Measure() == siren.injection.PhaseSpaceMeasure.Recursive2Body(2, 0, 1)
 
@@ -750,6 +753,40 @@ class TestSecondaryBiasing:
         assert abs(siren.injection.Kallen(1.0, 0.0, 0.0) - 1.0) < 1e-14
         p = siren.injection.TwoBodyRestMomentum(0.3, 0.106, 0.140)
         assert p > 0
+
+    def test_builder_dispatches_2body_directed(self):
+        """A 2-secondary signature builds physical@0 + DetectorDirected2Body."""
+        import siren
+        box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+        xs = siren.interactions.DummyCrossSection()
+        sig = siren.dataclasses.InteractionSignature()
+        sig.primary_type = siren.particles.N4
+        sig.target_type = siren.dataclasses.ParticleType.Decay
+        sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+        mc = siren.Simulation._build_phase_space_for_signature(
+            box, sig, xs, siren.particles.Gamma)
+        assert isinstance(mc.channels[0],
+                          siren.injection.PhysicalCrossSectionChannel)
+        assert any(isinstance(c, siren.injection.DetectorDirected2BodyChannel)
+                   for c in mc.channels[1:])
+
+    def test_builder_dispatches_3body_directed(self):
+        """A 3-secondary signature builds physical@0 + DetectorDirected3Body."""
+        import siren
+        box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 100.0))
+        xs = siren.interactions.DummyCrossSection()
+        sig = siren.dataclasses.InteractionSignature()
+        sig.primary_type = siren.particles.N4
+        sig.target_type = siren.dataclasses.ParticleType.Decay
+        sig.secondary_types = [
+            siren.particles.NuLight, siren.particles.EMinus, siren.particles.EPlus]
+        mc = siren.Simulation._build_phase_space_for_signature(
+            box, sig, xs, siren.particles.EMinus,
+            spectator_type=siren.particles.NuLight)
+        assert isinstance(mc.channels[0],
+                          siren.injection.PhysicalCrossSectionChannel)
+        assert any(isinstance(c, siren.injection.DetectorDirected3BodyChannel)
+                   for c in mc.channels[1:])
 
 
 class TestWeighterBatch:

--- a/tests/python/test_visualization.py
+++ b/tests/python/test_visualization.py
@@ -34,7 +34,7 @@ def test_solid_xml_box_emits_full_widths():
     from siren import visualization
     from siren.geometry import Box
 
-    box = Box(2.0, 4.0, 6.0)
+    box = Box(widths=(2.0, 4.0, 6.0))
     el = ET.fromstring(visualization._solid_xml(box, "TESTBOX"))
     assert el.tag == "box"
     assert float(el.get("x")) == pytest.approx(2.0)


### PR DESCRIPTION
Final phase of the interface redesign stack: removes the remaining naming footguns, documents the strategy surface in-place, and ships the first user-facing docs.

## Naming and deprecation

- `DetectorDirected3BodyChannel` gains a keyword constructor over its (previously unbound) `Factorization` enum, exposed as `ThreeBodyMode.Direct`/`.Recursive` -- the factorization is now named instead of selected by constructor arity. Positional forms warn once; fixed-seed tests pin sample identity between the old and new constructors.
- The legacy `PhaseSpaceConvention` enum is deprecated behind a warning proxy: the binding moves to a private name and a pure-Python proxy under the public name warns with the full old-name -> new-name mapping table (`Convention.Dalitz -> Measure.DalitzPair`, ...). Enum values still pass into C++ signatures through the proxy.
- `Box(x, y, z)` positional construction now raises `ConfigurationError` naming the `widths=`/`center=` form (bare dimensions silently placed the box at the detector-frame origin, mis-aiming directed channels). All in-lineage call sites migrated.
- Every phase-space channel class, constructor argument, and strategy enum value (`DirectedMode`, `ScatteringVariable`, `ScatteringQ2Mode`, `ThreeBodyMode`, topology/measure values) carries a docstring stating the topology/measure it implements and when to choose it -- `help()` replaces reading pybind source.
- The unreachable third scattering-dispatch arm in Simulation's channel builder is removed (every real cross section produces 2 or 3 secondaries; verified across the interactions library) with dispatch tests for both arities.
- `InteractionSignature.__eq__`/`__hash__`: confirmed already bound on this lineage; covered by tests.

## Docs

- `docs/quickstart.md`: a verified-runnable DecayModel + `check_closure` + `Simulation` walkthrough with its actual output pasted from a real run.
- `docs/units_conventions.md`: GeV/meters/ns, full-width geometry arguments, detector coordinates, rest-vs-lab measures, the two-stream RNG reproducibility contract, env-var policy (`SIREN_STRICT` only).
- `docs/errors.md`: one section per `[siren-docs: ...]` anchor carried by engine exception messages, each with the one-line fix.

## Deferred to the models-lineage integration (not on this branch)

`resources/examples/example4/` (the 1040-line Dutta-Kim chain rewrite), the `diagnose_*.py` script replacements, and the MesonProduction/VectorPortal closure fixes live on the divergent models family and are deferred to its integration with this stack.

## Test status

pytest 807 passed / 24 skipped (baseline 794); ctest 53/56 (the 3 known machine-local spline-data failures); golden regression archive byte-identical; `SIREN_STRICT=1` full suite clean.

Note: the Copilot review for this PR is pending quota reset; a 3-lens adversarial self-review ran in its place during implementation.
