### PR TITLE
Support python-defined distributions

### DIFF
--- a/projects/distributions/CMakeLists.txt
+++ b/projects/distributions/CMakeLists.txt
@@ -1,15 +1,20 @@
 #core files
 LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/Distributions.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/pyWeightableDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/pyPrimaryInjectionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/pySecondaryInjectionDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/PrimaryExternalDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/PrimaryDirectionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/pyPrimaryDirectionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/IsotropicDirection.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/FixedDirection.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/direction/Cone.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/PrimaryEnergyDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/pyPrimaryEnergyDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/ModifiedMoyalPlusExponentialEnergyDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/TabulatedFluxDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/PowerLaw.cxx
@@ -17,6 +22,7 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy/PiDARNuEDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy_direction/PrimaryEnergyDirectionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/energy_direction/Tabulated2DFluxDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/helicity/PrimaryNeutrinoHelicityDistribution.cxx
@@ -28,6 +34,7 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/DepthFunction.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/LeptonDepthFunction.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/VertexPositionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/pyVertexPositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/PointSourcePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/RangePositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/DecayRangePositionDistribution.cxx
@@ -40,9 +47,11 @@ LIST (APPEND distributions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/vertex/FixedTargetPositionDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/area/PrimaryAreaDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/area/pyPrimaryAreaDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/primary/area/FixedTargetAreaDistribution.cxx
 
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/secondary/vertex/SecondaryVertexPositionDistribution.cxx
+    ${PROJECT_SOURCE_DIR}/projects/distributions/private/secondary/vertex/pySecondaryVertexPositionDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/secondary/vertex/SecondaryPhysicalVertexDistribution.cxx
     ${PROJECT_SOURCE_DIR}/projects/distributions/private/secondary/vertex/SecondaryBoundedVertexDistribution.cxx
 )

--- a/projects/distributions/private/primary/area/pyPrimaryAreaDistribution.cxx
+++ b/projects/distributions/private/primary/area/pyPrimaryAreaDistribution.cxx
@@ -1,0 +1,119 @@
+#include "SIREN/distributions/primary/area/pyPrimaryAreaDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/primary/area/PrimaryAreaDistribution.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/math/Vector3D.h"                    // for Vector3D
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+siren::math::Vector3D pyPrimaryAreaDistribution::SamplePointOfClosestApproach(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        PrimaryAreaDistribution,
+        siren::math::Vector3D,
+        SamplePointOfClosestApproach,
+        "SamplePointOfClosestApproach",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyPrimaryAreaDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_REF(
+        self,
+        PrimaryAreaDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+double pyPrimaryAreaDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        PrimaryAreaDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyPrimaryAreaDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryAreaDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyPrimaryAreaDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        PrimaryAreaDistribution
+    )
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> pyPrimaryAreaDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        PrimaryAreaDistribution,
+        PrimaryInjectionDistribution
+    )
+}
+
+bool pyPrimaryAreaDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryAreaDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyPrimaryAreaDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        PrimaryAreaDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyPrimaryAreaDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        PrimaryAreaDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/primary/direction/pyPrimaryDirectionDistribution.cxx
+++ b/projects/distributions/private/primary/direction/pyPrimaryDirectionDistribution.cxx
@@ -1,0 +1,119 @@
+#include "SIREN/distributions/primary/direction/pyPrimaryDirectionDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/primary/direction/PrimaryDirectionDistribution.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/math/Vector3D.h"                    // for Vector3D
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+siren::math::Vector3D pyPrimaryDirectionDistribution::SampleDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        PrimaryDirectionDistribution,
+        siren::math::Vector3D,
+        SampleDirection,
+        "SampleDirection",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyPrimaryDirectionDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_REF(
+        self,
+        PrimaryDirectionDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+double pyPrimaryDirectionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        PrimaryDirectionDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyPrimaryDirectionDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryDirectionDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyPrimaryDirectionDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        PrimaryDirectionDistribution
+    )
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> pyPrimaryDirectionDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        PrimaryDirectionDistribution,
+        PrimaryInjectionDistribution
+    )
+}
+
+bool pyPrimaryDirectionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryDirectionDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyPrimaryDirectionDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        PrimaryDirectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyPrimaryDirectionDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        PrimaryDirectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/primary/energy/pyPrimaryEnergyDistribution.cxx
+++ b/projects/distributions/private/primary/energy/pyPrimaryEnergyDistribution.cxx
@@ -1,0 +1,149 @@
+#include "SIREN/distributions/primary/energy/pyPrimaryEnergyDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/primary/energy/PrimaryEnergyDistribution.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+double pyPrimaryEnergyDistribution::SampleEnergy(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        PrimaryEnergyDistribution,
+        double,
+        SampleEnergy,
+        "SampleEnergy",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyPrimaryEnergyDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_REF(
+        self,
+        PrimaryEnergyDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyPrimaryEnergyDistribution::SetNormalization(double norm) {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDistribution,
+        void,
+        SetNormalization,
+        "SetNormalization",
+        norm
+    )
+}
+
+double pyPrimaryEnergyDistribution::GetNormalization() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDistribution,
+        double,
+        GetNormalization,
+        "GetNormalization"
+    )
+}
+
+bool pyPrimaryEnergyDistribution::IsNormalizationSet() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDistribution,
+        bool,
+        IsNormalizationSet,
+        "IsNormalizationSet"
+    )
+}
+
+double pyPrimaryEnergyDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        PrimaryEnergyDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyPrimaryEnergyDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyPrimaryEnergyDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        PrimaryEnergyDistribution
+    )
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> pyPrimaryEnergyDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        PrimaryEnergyDistribution,
+        PrimaryInjectionDistribution
+    )
+}
+
+bool pyPrimaryEnergyDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyPrimaryEnergyDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        PrimaryEnergyDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyPrimaryEnergyDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        PrimaryEnergyDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.cxx
+++ b/projects/distributions/private/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.cxx
@@ -1,0 +1,155 @@
+#include "SIREN/distributions/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <utility>                                // for pair
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/math/Vector3D.h"                    // for Vector3D
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+// Alias with no un-parenthesized comma so it can be passed as a single
+// preprocessor macro argument to the SELF_OVERRIDE_PURE_REF invocation below.
+using PrimaryEnergyDirectionSample = std::pair<double, siren::math::Vector3D>;
+
+std::pair<double, siren::math::Vector3D> pyPrimaryEnergyDirectionDistribution::SampleEnergyAndDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        PrimaryEnergyDirectionSample,
+        SampleEnergyAndDirection,
+        "SampleEnergyAndDirection",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyPrimaryEnergyDirectionDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_REF(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyPrimaryEnergyDirectionDistribution::SetNormalization(double norm) {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        void,
+        SetNormalization,
+        "SetNormalization",
+        norm
+    )
+}
+
+double pyPrimaryEnergyDirectionDistribution::GetNormalization() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        double,
+        GetNormalization,
+        "GetNormalization"
+    )
+}
+
+bool pyPrimaryEnergyDirectionDistribution::IsNormalizationSet() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        bool,
+        IsNormalizationSet,
+        "IsNormalizationSet"
+    )
+}
+
+double pyPrimaryEnergyDirectionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyPrimaryEnergyDirectionDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyPrimaryEnergyDirectionDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        PrimaryEnergyDirectionDistribution
+    )
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> pyPrimaryEnergyDirectionDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        PrimaryInjectionDistribution
+    )
+}
+
+bool pyPrimaryEnergyDirectionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyPrimaryEnergyDirectionDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyPrimaryEnergyDirectionDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        PrimaryEnergyDirectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/primary/vertex/pyVertexPositionDistribution.cxx
+++ b/projects/distributions/private/primary/vertex/pyVertexPositionDistribution.cxx
@@ -1,0 +1,137 @@
+#include "SIREN/distributions/primary/vertex/pyVertexPositionDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <tuple>                                  // for tuple
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/math/Vector3D.h"                    // for Vector3D
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+// Alias with no un-parenthesized comma so it can be passed as a single
+// preprocessor macro argument to the SELF_OVERRIDE invocations below.
+using VertexPositionBounds = std::tuple<siren::math::Vector3D, siren::math::Vector3D>;
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> pyVertexPositionDistribution::SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        VertexPositionDistribution,
+        VertexPositionBounds,
+        SamplePosition,
+        "SamplePosition",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pyVertexPositionDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_REF(
+        self,
+        VertexPositionDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+double pyVertexPositionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        VertexPositionDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyVertexPositionDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        VertexPositionDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyVertexPositionDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        VertexPositionDistribution
+    )
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> pyVertexPositionDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        VertexPositionDistribution,
+        PrimaryInjectionDistribution
+    )
+}
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> pyVertexPositionDistribution::InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        VertexPositionDistribution,
+        VertexPositionBounds,
+        InjectionBounds,
+        "InjectionBounds",
+        detector_model,
+        interactions,
+        interaction
+    )
+}
+
+bool pyVertexPositionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        VertexPositionDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyVertexPositionDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        VertexPositionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyVertexPositionDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        VertexPositionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/pyPrimaryInjectionDistribution.cxx
+++ b/projects/distributions/private/pyPrimaryInjectionDistribution.cxx
@@ -1,0 +1,104 @@
+#include "SIREN/distributions/pyPrimaryInjectionDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/Distributions.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+void pyPrimaryInjectionDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        PrimaryInjectionDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+double pyPrimaryInjectionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        PrimaryInjectionDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyPrimaryInjectionDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryInjectionDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyPrimaryInjectionDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        PrimaryInjectionDistribution
+    )
+}
+
+std::shared_ptr<PrimaryInjectionDistribution> pyPrimaryInjectionDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        PrimaryInjectionDistribution,
+        PrimaryInjectionDistribution
+    )
+}
+
+bool pyPrimaryInjectionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        PrimaryInjectionDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyPrimaryInjectionDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        PrimaryInjectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyPrimaryInjectionDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        PrimaryInjectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/pySecondaryInjectionDistribution.cxx
+++ b/projects/distributions/private/pySecondaryInjectionDistribution.cxx
@@ -1,0 +1,104 @@
+#include "SIREN/distributions/pySecondaryInjectionDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/Distributions.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+void pySecondaryInjectionDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::SecondaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        SecondaryInjectionDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+double pySecondaryInjectionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        SecondaryInjectionDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pySecondaryInjectionDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        SecondaryInjectionDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pySecondaryInjectionDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        SecondaryInjectionDistribution
+    )
+}
+
+std::shared_ptr<SecondaryInjectionDistribution> pySecondaryInjectionDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        SecondaryInjectionDistribution,
+        SecondaryInjectionDistribution
+    )
+}
+
+bool pySecondaryInjectionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        SecondaryInjectionDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pySecondaryInjectionDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        SecondaryInjectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pySecondaryInjectionDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        SecondaryInjectionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/pyWeightableDistribution.cxx
+++ b/projects/distributions/private/pyWeightableDistribution.cxx
@@ -1,0 +1,81 @@
+#include "SIREN/distributions/pyWeightableDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/Distributions.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+
+namespace siren {
+namespace distributions {
+
+double pyWeightableDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        WeightableDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pyWeightableDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        WeightableDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pyWeightableDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        WeightableDistribution
+    )
+}
+
+bool pyWeightableDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        WeightableDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pyWeightableDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        WeightableDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pyWeightableDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        WeightableDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/private/pybindings/distributions.cxx
+++ b/projects/distributions/private/pybindings/distributions.cxx
@@ -3,21 +3,28 @@
 #include <string>
 
 #include "../../public/SIREN/distributions/Distributions.h"
+#include "../../public/SIREN/distributions/pyWeightableDistribution.h"
+#include "../../public/SIREN/distributions/pyPrimaryInjectionDistribution.h"
+#include "../../public/SIREN/distributions/pySecondaryInjectionDistribution.h"
 #include "../../public/SIREN/distributions/primary/PrimaryExternalDistribution.h"
 #include "../../public/SIREN/distributions/primary/direction/PrimaryDirectionDistribution.h"
+#include "../../public/SIREN/distributions/primary/direction/pyPrimaryDirectionDistribution.h"
 #include "../../public/SIREN/distributions/primary/direction/Cone.h"
 #include "../../public/SIREN/distributions/primary/direction/FixedDirection.h"
 #include "../../public/SIREN/distributions/primary/direction/IsotropicDirection.h"
 #include "../../public/SIREN/distributions/primary/energy/PrimaryEnergyDistribution.h"
+#include "../../public/SIREN/distributions/primary/energy/pyPrimaryEnergyDistribution.h"
 #include "../../public/SIREN/distributions/primary/energy/Monoenergetic.h"
 #include "../../public/SIREN/distributions/primary/energy/PowerLaw.h"
 #include "../../public/SIREN/distributions/primary/energy/PiDARNuEDistribution.h"
 #include "../../public/SIREN/distributions/primary/energy/TabulatedFluxDistribution.h"
 #include "../../public/SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h"
+#include "../../public/SIREN/distributions/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.h"
 #include "../../public/SIREN/distributions/primary/energy_direction/Tabulated2DFluxDistribution.h"
 #include "../../public/SIREN/distributions/primary/helicity/PrimaryNeutrinoHelicityDistribution.h"
 #include "../../public/SIREN/distributions/primary/mass/PrimaryMass.h"
 #include "../../public/SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+#include "../../public/SIREN/distributions/primary/vertex/pyVertexPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/ColumnDepthPositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/CylinderVolumePositionDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
@@ -32,7 +39,9 @@
 #include "../../public/SIREN/distributions/primary/vertex/PrimaryPhysicalVertexDistribution.h"
 #include "../../public/SIREN/distributions/primary/vertex/PrimaryBoundedVertexDistribution.h"
 #include "../../public/SIREN/distributions/primary/area/PrimaryAreaDistribution.h"
+#include "../../public/SIREN/distributions/primary/area/pyPrimaryAreaDistribution.h"
 #include "../../public/SIREN/distributions/primary/area/FixedTargetAreaDistribution.h"
+#include "../../public/SIREN/distributions/secondary/vertex/pySecondaryVertexPositionDistribution.h"
 #include "../../public/SIREN/distributions/secondary/vertex/SecondaryPhysicalVertexDistribution.h"
 #include "../../public/SIREN/distributions/secondary/vertex/SecondaryBoundedVertexDistribution.h"
 
@@ -57,18 +66,31 @@ PYBIND11_MODULE(distributions,m) {
     .def_property("normalization",&PhysicallyNormalizedDistribution::GetNormalization,&PhysicallyNormalizedDistribution::SetNormalization)
     .def("IsNormalizationSet",&PhysicallyNormalizedDistribution::IsNormalizationSet);
 
-  class_<WeightableDistribution, std::shared_ptr<WeightableDistribution>>(m, "WeightableDistribution")
+  class_<WeightableDistribution, std::shared_ptr<WeightableDistribution>, pyWeightableDistribution>(m, "WeightableDistribution",
+    "Base class for weight-only distributions. Subclass in python and\n"
+    "implement GenerationProbability(detector_model, interactions, record);\n"
+    "optionally override Name, DensityVariables, equal, and less.")
+    .def(init<>())
+    .def("__eq__", [](const WeightableDistribution &self, const WeightableDistribution &other){ return self == other; })
+    .def("GenerationProbability",&WeightableDistribution::GenerationProbability)
     .def("DensityVariables",&WeightableDistribution::DensityVariables)
-    .def("AreEquivalent",&WeightableDistribution::AreEquivalent);
+    .def("Name",&WeightableDistribution::Name)
+    .def("AreEquivalent",&WeightableDistribution::AreEquivalent)
+    TrampolinePickleMethods(pyWeightableDistribution);
 
   class_<NormalizationConstant, std::shared_ptr<NormalizationConstant>, WeightableDistribution, PhysicallyNormalizedDistribution>(m, "NormalizationConstant")
     .def(init<double>())
     .def("GenerationProbability",&NormalizationConstant::GenerationProbability)
     .def("Name",&NormalizationConstant::Name);
 
-  class_<PrimaryInjectionDistribution, std::shared_ptr<PrimaryInjectionDistribution>, WeightableDistribution>(m, "PrimaryInjectionDistribution")
+  class_<PrimaryInjectionDistribution, std::shared_ptr<PrimaryInjectionDistribution>, pyPrimaryInjectionDistribution, WeightableDistribution>(m, "PrimaryInjectionDistribution",
+    "Base class for primary injection distributions. Subclass in python and\n"
+    "implement Sample(rand, detector_model, interactions, record) and\n"
+    "GenerationProbability(detector_model, interactions, record).")
+    .def(init<>())
     .def("Sample",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::PrimaryDistributionRecord &>(&PrimaryInjectionDistribution::Sample, const_))
-    ;
+    .def("clone",&PrimaryInjectionDistribution::clone)
+    TrampolinePickleMethods(pyPrimaryInjectionDistribution);
 
   // External distribution
   class_<PrimaryExternalDistribution, std::shared_ptr<PrimaryExternalDistribution>, PrimaryInjectionDistribution>(m,"PrimaryExternalDistribution",
@@ -97,10 +119,15 @@ PYBIND11_MODULE(distributions,m) {
 
   // Direciton distributions
 
-  class_<PrimaryDirectionDistribution, std::shared_ptr<PrimaryDirectionDistribution>, PrimaryInjectionDistribution>(m, "PrimaryDirectionDistribution")
+  class_<PrimaryDirectionDistribution, std::shared_ptr<PrimaryDirectionDistribution>, pyPrimaryDirectionDistribution, PrimaryInjectionDistribution>(m, "PrimaryDirectionDistribution",
+    "Base class for primary direction distributions. Subclass in python and\n"
+    "implement SampleDirection(rand, detector_model, interactions, record)\n"
+    "returning a Vector3D, plus GenerationProbability.")
+    .def(init<>())
     .def("Sample",&PrimaryDirectionDistribution::Sample)
     .def("DensityVariables",&PrimaryDirectionDistribution::DensityVariables)
-    .def("GenerationProbability",&PrimaryDirectionDistribution::GenerationProbability);
+    .def("GenerationProbability",&PrimaryDirectionDistribution::GenerationProbability)
+    TrampolinePickleMethods(pyPrimaryDirectionDistribution);
 
   class_<Cone, std::shared_ptr<Cone>, PrimaryDirectionDistribution>(m, "Cone")
     .def(init<siren::math::Vector3D, double>());
@@ -116,8 +143,13 @@ PYBIND11_MODULE(distributions,m) {
 
   // Energy distributions
 
-  class_<PrimaryEnergyDistribution, std::shared_ptr<PrimaryEnergyDistribution>, PrimaryInjectionDistribution, PhysicallyNormalizedDistribution>(m, "PrimaryEnergyDistribution")
-    .def("Sample",&PrimaryEnergyDistribution::Sample);
+  class_<PrimaryEnergyDistribution, std::shared_ptr<PrimaryEnergyDistribution>, pyPrimaryEnergyDistribution, PrimaryInjectionDistribution, PhysicallyNormalizedDistribution>(m, "PrimaryEnergyDistribution",
+    "Base class for primary energy distributions. Subclass in python and\n"
+    "implement SampleEnergy(rand, detector_model, interactions, record)\n"
+    "returning the sampled energy, plus GenerationProbability.")
+    .def(init<>())
+    .def("Sample",&PrimaryEnergyDistribution::Sample)
+    TrampolinePickleMethods(pyPrimaryEnergyDistribution);
 
   class_<Monoenergetic, std::shared_ptr<Monoenergetic>, PrimaryEnergyDistribution>(m, "Monoenergetic")
     .def(init<double>())
@@ -163,8 +195,15 @@ PYBIND11_MODULE(distributions,m) {
 
   // Energy Direction distributions
 
-  class_<PrimaryEnergyDirectionDistribution, std::shared_ptr<PrimaryEnergyDirectionDistribution>, PrimaryInjectionDistribution, PhysicallyNormalizedDistribution>(m, "PrimaryEnergyDirectionDistribution")
-    .def("Sample",&PrimaryEnergyDirectionDistribution::Sample);
+  class_<PrimaryEnergyDirectionDistribution, std::shared_ptr<PrimaryEnergyDirectionDistribution>, pyPrimaryEnergyDirectionDistribution, PrimaryInjectionDistribution, PhysicallyNormalizedDistribution>(m, "PrimaryEnergyDirectionDistribution",
+    "Base class for joint energy-direction distributions. Subclass in python\n"
+    "and implement SampleEnergyAndDirection(rand, detector_model,\n"
+    "interactions, record) returning (energy, Vector3D), plus\n"
+    "GenerationProbability.")
+    .def(init<>())
+    .def("Sample",&PrimaryEnergyDirectionDistribution::Sample)
+    .def("SampleEnergyAndDirection",&PrimaryEnergyDirectionDistribution::SampleEnergyAndDirection)
+    TrampolinePickleMethods(pyPrimaryEnergyDirectionDistribution);
 
   class_<Tabulated2DFluxDistribution, std::shared_ptr<Tabulated2DFluxDistribution>, PrimaryEnergyDirectionDistribution>(m, "Tabulated2DFluxDistribution")
     .def(init<std::string, bool>(), arg("fluxTableFilename"), arg("has_physical_normalization")=false)
@@ -205,10 +244,18 @@ PYBIND11_MODULE(distributions,m) {
 
   // Vertex distributions
 
-  class_<VertexPositionDistribution, std::shared_ptr<VertexPositionDistribution>, PrimaryInjectionDistribution>(m, "VertexPositionDistribution")
+  class_<VertexPositionDistribution, std::shared_ptr<VertexPositionDistribution>, pyVertexPositionDistribution, PrimaryInjectionDistribution>(m, "VertexPositionDistribution",
+    "Base class for vertex position distributions. Subclass in python and\n"
+    "implement SamplePosition(rand, detector_model, interactions, record)\n"
+    "returning (initial_position, interaction_vertex) as Vector3D objects,\n"
+    "InjectionBounds(detector_model, interactions, record) returning the\n"
+    "(start, end) bounds used for interaction probabilities, and\n"
+    "GenerationProbability.")
+    .def(init<>())
     .def("DensityVariables",&VertexPositionDistribution::DensityVariables)
-    //.def("InjectionBounds",&VertexPositionDistribution::InjectionBounds)
-    .def("AreEquivalent",&VertexPositionDistribution::AreEquivalent);
+    .def("InjectionBounds",overload_cast<std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::InteractionRecord const &>(&VertexPositionDistribution::InjectionBounds, const_))
+    .def("AreEquivalent",&VertexPositionDistribution::AreEquivalent)
+    TrampolinePickleMethods(pyVertexPositionDistribution);
 
   // First, some range and depth functions
 
@@ -315,9 +362,14 @@ PYBIND11_MODULE(distributions,m) {
     .def("InjectionBounds",&FixedTargetPositionDistribution::InjectionBounds)
     .def("Name",&FixedTargetPositionDistribution::Name);
 
-  class_<PrimaryAreaDistribution, std::shared_ptr<PrimaryAreaDistribution>, PrimaryInjectionDistribution>(m, "PrimaryAreaDistribution")
+  class_<PrimaryAreaDistribution, std::shared_ptr<PrimaryAreaDistribution>, pyPrimaryAreaDistribution, PrimaryInjectionDistribution>(m, "PrimaryAreaDistribution",
+    "Base class for primary area distributions. Subclass in python and\n"
+    "implement SamplePointOfClosestApproach(rand, detector_model,\n"
+    "interactions, record) returning a Vector3D, plus GenerationProbability.")
+    .def(init<>())
     .def("DensityVariables",&PrimaryAreaDistribution::DensityVariables)
-    .def("AreEquivalent",&PrimaryAreaDistribution::AreEquivalent);
+    .def("AreEquivalent",&PrimaryAreaDistribution::AreEquivalent)
+    TrampolinePickleMethods(pyPrimaryAreaDistribution);
 
   class_<FixedTargetAreaDistribution, std::shared_ptr<FixedTargetAreaDistribution>, PrimaryAreaDistribution>(m, "FixedTargetAreaDistribution")
     .def(init<>())
@@ -325,13 +377,27 @@ PYBIND11_MODULE(distributions,m) {
     .def("GenerationProbability",&FixedTargetAreaDistribution::GenerationProbability)
     .def("Name",&FixedTargetAreaDistribution::Name);
 
-  class_<SecondaryInjectionDistribution, std::shared_ptr<SecondaryInjectionDistribution>, WeightableDistribution>(m, "SecondaryInjectionDistribution")
-    .def("Sample",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::SecondaryDistributionRecord &>(&SecondaryInjectionDistribution::Sample, const_));
+  class_<SecondaryInjectionDistribution, std::shared_ptr<SecondaryInjectionDistribution>, pySecondaryInjectionDistribution, WeightableDistribution>(m, "SecondaryInjectionDistribution",
+    "Base class for secondary injection distributions. Subclass in python\n"
+    "and implement Sample(rand, detector_model, interactions, record) and\n"
+    "GenerationProbability(detector_model, interactions, record).")
+    .def(init<>())
+    .def("Sample",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::SecondaryDistributionRecord &>(&SecondaryInjectionDistribution::Sample, const_))
+    .def("clone",&SecondaryInjectionDistribution::clone)
+    TrampolinePickleMethods(pySecondaryInjectionDistribution);
 
-  class_<SecondaryVertexPositionDistribution, std::shared_ptr<SecondaryVertexPositionDistribution>, SecondaryInjectionDistribution>(m, "SecondaryVertexPositionDistribution")
+  class_<SecondaryVertexPositionDistribution, std::shared_ptr<SecondaryVertexPositionDistribution>, pySecondaryVertexPositionDistribution, SecondaryInjectionDistribution>(m, "SecondaryVertexPositionDistribution",
+    "Base class for secondary vertex position distributions. Subclass in\n"
+    "python and implement SampleVertex(rand, detector_model, interactions,\n"
+    "record), InjectionBounds(detector_model, interactions, record), and\n"
+    "GenerationProbability.")
+    .def(init<>())
     .def("DensityVariables",&SecondaryVertexPositionDistribution::DensityVariables)
     .def("AreEquivalent",&SecondaryVertexPositionDistribution::AreEquivalent)
-    .def("Sample",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::SecondaryDistributionRecord &>(&SecondaryVertexPositionDistribution::Sample, const_));
+    .def("Sample",overload_cast<std::shared_ptr<siren::utilities::SIREN_random>, std::shared_ptr<siren::detector::DetectorModel const>, std::shared_ptr<siren::interactions::InteractionCollection const>, siren::dataclasses::SecondaryDistributionRecord &>(&SecondaryVertexPositionDistribution::Sample, const_))
+    .def("SampleVertex",&SecondaryVertexPositionDistribution::SampleVertex)
+    .def("InjectionBounds",&SecondaryVertexPositionDistribution::InjectionBounds)
+    TrampolinePickleMethods(pySecondaryVertexPositionDistribution);
 
   class_<SecondaryPhysicalVertexDistribution, std::shared_ptr<SecondaryPhysicalVertexDistribution>, SecondaryVertexPositionDistribution>(m, "SecondaryPhysicalVertexDistribution")
     .def(init<>())

--- a/projects/distributions/private/secondary/vertex/pySecondaryVertexPositionDistribution.cxx
+++ b/projects/distributions/private/secondary/vertex/pySecondaryVertexPositionDistribution.cxx
@@ -1,0 +1,137 @@
+#include "SIREN/distributions/secondary/vertex/pySecondaryVertexPositionDistribution.h"
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <tuple>                                  // for tuple
+#include <vector>                                 // for vector
+
+#include "SIREN/distributions/secondary/vertex/SecondaryVertexPositionDistribution.h"
+
+#include "SIREN/dataclasses/InteractionRecord.h"    // for InteractionRecord
+#include "SIREN/detector/DetectorModel.h"           // for DetectorModel
+#include "SIREN/interactions/InteractionCollection.h" // for InteractionCollection
+#include "SIREN/math/Vector3D.h"                    // for Vector3D
+#include "SIREN/utilities/Pybind11Trampoline.h"     // for SELF_OVERRIDE macros
+#include "SIREN/utilities/Random.h"                 // for SIREN_random
+
+namespace siren {
+namespace distributions {
+
+// Alias with no un-parenthesized comma so it can be passed as a single
+// preprocessor macro argument to the SELF_OVERRIDE_PURE invocation below.
+using SecondaryVertexPositionBounds = std::tuple<siren::math::Vector3D, siren::math::Vector3D>;
+
+void pySecondaryVertexPositionDistribution::SampleVertex(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::SecondaryDistributionRecord & record) const {
+    SELF_OVERRIDE_PURE_REF(
+        self,
+        SecondaryVertexPositionDistribution,
+        void,
+        SampleVertex,
+        "SampleVertex",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+void pySecondaryVertexPositionDistribution::Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::SecondaryDistributionRecord & record) const {
+    SELF_OVERRIDE_REF(
+        self,
+        SecondaryVertexPositionDistribution,
+        void,
+        Sample,
+        "Sample",
+        rand,
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+double pySecondaryVertexPositionDistribution::GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        SecondaryVertexPositionDistribution,
+        double,
+        GenerationProbability,
+        "GenerationProbability",
+        detector_model,
+        interactions,
+        record
+    )
+}
+
+std::vector<std::string> pySecondaryVertexPositionDistribution::DensityVariables() const {
+    SELF_OVERRIDE(
+        self,
+        SecondaryVertexPositionDistribution,
+        std::vector<std::string>,
+        DensityVariables,
+        "DensityVariables"
+    )
+}
+
+std::string pySecondaryVertexPositionDistribution::Name() const {
+    SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(
+        self,
+        SecondaryVertexPositionDistribution
+    )
+}
+
+std::shared_ptr<SecondaryInjectionDistribution> pySecondaryVertexPositionDistribution::clone() const {
+    SELF_OVERRIDE_CLONE_REQUIRED(
+        self,
+        SecondaryVertexPositionDistribution,
+        SecondaryInjectionDistribution
+    )
+}
+
+std::tuple<siren::math::Vector3D, siren::math::Vector3D> pySecondaryVertexPositionDistribution::InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const {
+    SELF_OVERRIDE_PURE(
+        self,
+        SecondaryVertexPositionDistribution,
+        SecondaryVertexPositionBounds,
+        InjectionBounds,
+        "InjectionBounds",
+        detector_model,
+        interactions,
+        interaction
+    )
+}
+
+bool pySecondaryVertexPositionDistribution::AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const {
+    SELF_OVERRIDE(
+        self,
+        SecondaryVertexPositionDistribution,
+        bool,
+        AreEquivalent,
+        "AreEquivalent",
+        detector_model,
+        interactions,
+        distribution,
+        second_detector_model,
+        second_interactions
+    )
+}
+
+bool pySecondaryVertexPositionDistribution::equal(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(
+        self,
+        SecondaryVertexPositionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+bool pySecondaryVertexPositionDistribution::less(WeightableDistribution const & distribution) const {
+    SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(
+        self,
+        SecondaryVertexPositionDistribution,
+        WeightableDistribution,
+        distribution
+    )
+}
+
+} // namespace distributions
+} // namespace siren

--- a/projects/distributions/public/SIREN/distributions/primary/area/pyPrimaryAreaDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/area/pyPrimaryAreaDistribution.h
@@ -1,0 +1,56 @@
+#pragma once
+#ifndef SIREN_pyPrimaryAreaDistribution_H
+#define SIREN_pyPrimaryAreaDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/area/PrimaryAreaDistribution.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class PrimaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace math { class Vector3D; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for PrimaryAreaDistribution
+class pyPrimaryAreaDistribution : public PrimaryAreaDistribution {
+public:
+    pyPrimaryAreaDistribution() = default;
+
+    siren::math::Vector3D SamplePointOfClosestApproach(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(PrimaryAreaDistribution, pyPrimaryAreaDistribution);
+}; // class pyPrimaryAreaDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyPrimaryAreaDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyPrimaryAreaDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryAreaDistribution, siren::distributions::pyPrimaryAreaDistribution);
+
+#endif // SIREN_pyPrimaryAreaDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/direction/pyPrimaryDirectionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/direction/pyPrimaryDirectionDistribution.h
@@ -1,0 +1,56 @@
+#pragma once
+#ifndef SIREN_pyPrimaryDirectionDistribution_H
+#define SIREN_pyPrimaryDirectionDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/direction/PrimaryDirectionDistribution.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class PrimaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace math { class Vector3D; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for PrimaryDirectionDistribution
+class pyPrimaryDirectionDistribution : public PrimaryDirectionDistribution {
+public:
+    pyPrimaryDirectionDistribution() = default;
+
+    siren::math::Vector3D SampleDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(PrimaryDirectionDistribution, pyPrimaryDirectionDistribution);
+}; // class pyPrimaryDirectionDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyPrimaryDirectionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyPrimaryDirectionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryDirectionDistribution, siren::distributions::pyPrimaryDirectionDistribution);
+
+#endif // SIREN_pyPrimaryDirectionDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/energy/pyPrimaryEnergyDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/energy/pyPrimaryEnergyDistribution.h
@@ -1,0 +1,58 @@
+#pragma once
+#ifndef SIREN_pyPrimaryEnergyDistribution_H
+#define SIREN_pyPrimaryEnergyDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/energy/PrimaryEnergyDistribution.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class PrimaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for PrimaryEnergyDistribution
+class pyPrimaryEnergyDistribution : public PrimaryEnergyDistribution {
+public:
+    pyPrimaryEnergyDistribution() = default;
+
+    double SampleEnergy(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void SetNormalization(double norm) override;
+    double GetNormalization() const override;
+    bool IsNormalizationSet() const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(PrimaryEnergyDistribution, pyPrimaryEnergyDistribution);
+}; // class pyPrimaryEnergyDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyPrimaryEnergyDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyPrimaryEnergyDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryEnergyDistribution, siren::distributions::pyPrimaryEnergyDistribution);
+
+#endif // SIREN_pyPrimaryEnergyDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/energy_direction/pyPrimaryEnergyDirectionDistribution.h
@@ -1,0 +1,60 @@
+#pragma once
+#ifndef SIREN_pyPrimaryEnergyDirectionDistribution_H
+#define SIREN_pyPrimaryEnergyDirectionDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <utility>                                // for pair
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/energy_direction/PrimaryEnergyDirectionDistribution.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class PrimaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace math { class Vector3D; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for PrimaryEnergyDirectionDistribution
+class pyPrimaryEnergyDirectionDistribution : public PrimaryEnergyDirectionDistribution {
+public:
+    pyPrimaryEnergyDirectionDistribution() = default;
+
+    std::pair<double, siren::math::Vector3D> SampleEnergyAndDirection(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void SetNormalization(double norm) override;
+    double GetNormalization() const override;
+    bool IsNormalizationSet() const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(PrimaryEnergyDirectionDistribution, pyPrimaryEnergyDirectionDistribution);
+}; // class pyPrimaryEnergyDirectionDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyPrimaryEnergyDirectionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyPrimaryEnergyDirectionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryEnergyDirectionDistribution, siren::distributions::pyPrimaryEnergyDirectionDistribution);
+
+#endif // SIREN_pyPrimaryEnergyDirectionDistribution_H

--- a/projects/distributions/public/SIREN/distributions/primary/vertex/pyVertexPositionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/primary/vertex/pyVertexPositionDistribution.h
@@ -1,0 +1,59 @@
+#pragma once
+#ifndef SIREN_pyVertexPositionDistribution_H
+#define SIREN_pyVertexPositionDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <tuple>                                  // for tuple
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/primary/vertex/VertexPositionDistribution.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class PrimaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace math { class Vector3D; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for VertexPositionDistribution
+class pyVertexPositionDistribution : public VertexPositionDistribution {
+public:
+    pyVertexPositionDistribution() = default;
+
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> SamplePosition(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const override;
+    using VertexPositionDistribution::InjectionBounds;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(VertexPositionDistribution, pyVertexPositionDistribution);
+}; // class pyVertexPositionDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyVertexPositionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyVertexPositionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::VertexPositionDistribution, siren::distributions::pyVertexPositionDistribution);
+
+#endif // SIREN_pyVertexPositionDistribution_H

--- a/projects/distributions/public/SIREN/distributions/pyPrimaryInjectionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/pyPrimaryInjectionDistribution.h
@@ -1,0 +1,54 @@
+#pragma once
+#ifndef SIREN_pyPrimaryInjectionDistribution_H
+#define SIREN_pyPrimaryInjectionDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/Distributions.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class PrimaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for PrimaryInjectionDistribution
+class pyPrimaryInjectionDistribution : public PrimaryInjectionDistribution {
+public:
+    pyPrimaryInjectionDistribution() = default;
+
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::PrimaryDistributionRecord & record) const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<PrimaryInjectionDistribution> clone() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(PrimaryInjectionDistribution, pyPrimaryInjectionDistribution);
+}; // class pyPrimaryInjectionDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyPrimaryInjectionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyPrimaryInjectionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::PrimaryInjectionDistribution, siren::distributions::pyPrimaryInjectionDistribution);
+
+#endif // SIREN_pyPrimaryInjectionDistribution_H

--- a/projects/distributions/public/SIREN/distributions/pySecondaryInjectionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/pySecondaryInjectionDistribution.h
@@ -1,0 +1,54 @@
+#pragma once
+#ifndef SIREN_pySecondaryInjectionDistribution_H
+#define SIREN_pySecondaryInjectionDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/Distributions.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class SecondaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for SecondaryInjectionDistribution
+class pySecondaryInjectionDistribution : public SecondaryInjectionDistribution {
+public:
+    pySecondaryInjectionDistribution() = default;
+
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::SecondaryDistributionRecord & record) const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<SecondaryInjectionDistribution> clone() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(SecondaryInjectionDistribution, pySecondaryInjectionDistribution);
+}; // class pySecondaryInjectionDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pySecondaryInjectionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pySecondaryInjectionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::SecondaryInjectionDistribution, siren::distributions::pySecondaryInjectionDistribution);
+
+#endif // SIREN_pySecondaryInjectionDistribution_H

--- a/projects/distributions/public/SIREN/distributions/pyWeightableDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/pyWeightableDistribution.h
@@ -1,0 +1,50 @@
+#pragma once
+#ifndef SIREN_pyWeightableDistribution_H
+#define SIREN_pyWeightableDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/Distributions.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for WeightableDistribution
+class pyWeightableDistribution : public WeightableDistribution {
+public:
+    pyWeightableDistribution() = default;
+
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(WeightableDistribution, pyWeightableDistribution);
+}; // class pyWeightableDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pyWeightableDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pyWeightableDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::WeightableDistribution, siren::distributions::pyWeightableDistribution);
+
+#endif // SIREN_pyWeightableDistribution_H

--- a/projects/distributions/public/SIREN/distributions/secondary/vertex/pySecondaryVertexPositionDistribution.h
+++ b/projects/distributions/public/SIREN/distributions/secondary/vertex/pySecondaryVertexPositionDistribution.h
@@ -1,0 +1,58 @@
+#pragma once
+#ifndef SIREN_pySecondaryVertexPositionDistribution_H
+#define SIREN_pySecondaryVertexPositionDistribution_H
+
+#include <memory>                                 // for shared_ptr
+#include <string>                                 // for string
+#include <tuple>                                  // for tuple
+#include <vector>                                 // for vector
+#include <cstdint>                                // for uint32_t
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/distributions/secondary/vertex/SecondaryVertexPositionDistribution.h"
+
+#include "SIREN/utilities/Pybind11Trampoline.h" // for Pybind11Trampoline
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class SecondaryDistributionRecord; } }
+namespace siren { namespace detector { class DetectorModel; } }
+namespace siren { namespace interactions { class InteractionCollection; } }
+namespace siren { namespace math { class Vector3D; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace distributions {
+
+// Trampoline class for SecondaryVertexPositionDistribution
+class pySecondaryVertexPositionDistribution : public SecondaryVertexPositionDistribution {
+public:
+    pySecondaryVertexPositionDistribution() = default;
+
+    void SampleVertex(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::SecondaryDistributionRecord & record) const override;
+    void Sample(std::shared_ptr<siren::utilities::SIREN_random> rand, std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::SecondaryDistributionRecord & record) const override;
+    double GenerationProbability(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & record) const override;
+    std::vector<std::string> DensityVariables() const override;
+    std::string Name() const override;
+    std::shared_ptr<SecondaryInjectionDistribution> clone() const override;
+    std::tuple<siren::math::Vector3D, siren::math::Vector3D> InjectionBounds(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, siren::dataclasses::InteractionRecord const & interaction) const override;
+    bool AreEquivalent(std::shared_ptr<siren::detector::DetectorModel const> detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> interactions, std::shared_ptr<WeightableDistribution const> distribution, std::shared_ptr<siren::detector::DetectorModel const> second_detector_model, std::shared_ptr<siren::interactions::InteractionCollection const> second_interactions) const override;
+    bool equal(WeightableDistribution const & distribution) const override;
+    bool less(WeightableDistribution const & distribution) const override;
+
+    Pybind11TrampolineCerealMethods(SecondaryVertexPositionDistribution, pySecondaryVertexPositionDistribution);
+}; // class pySecondaryVertexPositionDistribution
+
+} // namespace distributions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::distributions::pySecondaryVertexPositionDistribution, 0);
+CEREAL_REGISTER_TYPE(siren::distributions::pySecondaryVertexPositionDistribution);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::distributions::SecondaryVertexPositionDistribution, siren::distributions::pySecondaryVertexPositionDistribution);
+
+#endif // SIREN_pySecondaryVertexPositionDistribution_H

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -47,33 +47,38 @@ PYBIND11_MODULE(injection,m) {
 
   // Process
 
+  // The keep_alive policies below tie python-defined distributions, cross
+  // sections, and decays to the process, injector, or weighter consuming
+  // them; a python-defined object held only by C++ shared_ptrs loses its
+  // python half to garbage collection and virtual calls then fail.
+
   class_<Process, std::shared_ptr<Process>>(m, "Process")
     .def_property("primary_type", &Process::GetPrimaryType, &Process::SetPrimaryType)
-    .def_property("interactions", &Process::GetInteractions, &Process::SetInteractions)
+    .def_property("interactions", &Process::GetInteractions, cpp_function(&Process::SetInteractions, keep_alive<1, 2>()))
     ;
 
   class_<PhysicalProcess, std::shared_ptr<PhysicalProcess>, Process>(m, "PhysicalProcess")
     .def(init<>())
-    .def(init<siren::dataclasses::ParticleType, std::shared_ptr<siren::interactions::InteractionCollection>>())
+    .def(init<siren::dataclasses::ParticleType, std::shared_ptr<siren::interactions::InteractionCollection>>(), keep_alive<1, 3>())
     .def_property("primary_type", &Process::GetPrimaryType, &Process::SetPrimaryType)
-    .def_property("interactions", &Process::GetInteractions, &Process::SetInteractions)
-    .def_property("distributions", &PhysicalProcess::GetPhysicalDistributions, &PhysicalProcess::SetPhysicalDistributions)
+    .def_property("interactions", &Process::GetInteractions, cpp_function(&Process::SetInteractions, keep_alive<1, 2>()))
+    .def_property("distributions", &PhysicalProcess::GetPhysicalDistributions, cpp_function(&PhysicalProcess::SetPhysicalDistributions, keep_alive<1, 2>()))
     ;
 
   class_<PrimaryInjectionProcess, std::shared_ptr<PrimaryInjectionProcess>, Process>(m, "PrimaryInjectionProcess")
     .def(init<>())
-    .def(init<siren::dataclasses::ParticleType, std::shared_ptr<siren::interactions::InteractionCollection>>())
+    .def(init<siren::dataclasses::ParticleType, std::shared_ptr<siren::interactions::InteractionCollection>>(), keep_alive<1, 3>())
     .def_property("primary_type", &Process::GetPrimaryType, &Process::SetPrimaryType)
-    .def_property("interactions", &Process::GetInteractions, &Process::SetInteractions)
-    .def_property("distributions", &PrimaryInjectionProcess::GetPrimaryInjectionDistributions, &PrimaryInjectionProcess::SetPrimaryInjectionDistributions)
+    .def_property("interactions", &Process::GetInteractions, cpp_function(&Process::SetInteractions, keep_alive<1, 2>()))
+    .def_property("distributions", &PrimaryInjectionProcess::GetPrimaryInjectionDistributions, cpp_function(&PrimaryInjectionProcess::SetPrimaryInjectionDistributions, keep_alive<1, 2>()))
     ;
 
   class_<SecondaryInjectionProcess, std::shared_ptr<SecondaryInjectionProcess>, Process>(m, "SecondaryInjectionProcess")
     .def(init<>())
-    .def(init<siren::dataclasses::ParticleType, std::shared_ptr<siren::interactions::InteractionCollection>>())
+    .def(init<siren::dataclasses::ParticleType, std::shared_ptr<siren::interactions::InteractionCollection>>(), keep_alive<1, 3>())
     .def_property("secondary_type", &SecondaryInjectionProcess::GetSecondaryType, &SecondaryInjectionProcess::SetSecondaryType)
-    .def_property("interactions", &Process::GetInteractions, &Process::SetInteractions)
-    .def_property("distributions", &SecondaryInjectionProcess::GetSecondaryInjectionDistributions, &SecondaryInjectionProcess::SetSecondaryInjectionDistributions)
+    .def_property("interactions", &Process::GetInteractions, cpp_function(&Process::SetInteractions, keep_alive<1, 2>()))
+    .def_property("distributions", &SecondaryInjectionProcess::GetSecondaryInjectionDistributions, cpp_function(&SecondaryInjectionProcess::SetSecondaryInjectionDistributions, keep_alive<1, 2>()))
     ;
 
   // Injection
@@ -81,12 +86,12 @@ PYBIND11_MODULE(injection,m) {
   class_<Injector, std::shared_ptr<Injector>>(m, "Injector")
     .def(init<unsigned int, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<siren::utilities::SIREN_random>>())
     .def(init<unsigned int, std::string, std::shared_ptr<siren::utilities::SIREN_random>>())
-    .def(init<unsigned int, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PrimaryInjectionProcess>, std::shared_ptr<siren::utilities::SIREN_random>>())
-    .def(init<unsigned int, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PrimaryInjectionProcess>, std::vector<std::shared_ptr<SecondaryInjectionProcess>>, std::shared_ptr<siren::utilities::SIREN_random>>())
+    .def(init<unsigned int, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PrimaryInjectionProcess>, std::shared_ptr<siren::utilities::SIREN_random>>(), keep_alive<1, 4>())
+    .def(init<unsigned int, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PrimaryInjectionProcess>, std::vector<std::shared_ptr<SecondaryInjectionProcess>>, std::shared_ptr<siren::utilities::SIREN_random>>(), keep_alive<1, 4>(), keep_alive<1, 5>())
     .def("SetStoppingCondition",&Injector::SetStoppingCondition)
     .def("GetStoppingCondition",&Injector::GetStoppingCondition)
-    .def("SetPrimaryProcess",&Injector::SetPrimaryProcess)
-    .def("AddSecondaryProcess",&Injector::AddSecondaryProcess)
+    .def("SetPrimaryProcess",&Injector::SetPrimaryProcess, keep_alive<1, 2>())
+    .def("AddSecondaryProcess",&Injector::AddSecondaryProcess, keep_alive<1, 2>())
     .def("GetPrimaryProcess",&Injector::GetPrimaryProcess)
     .def("GetSecondaryProcesses",&Injector::GetSecondaryProcesses)
     .def("GetSecondaryProcessMap",&Injector::GetSecondaryProcessMap)
@@ -150,9 +155,9 @@ PYBIND11_MODULE(injection,m) {
     ;
 
   class_<Weighter, std::shared_ptr<Weighter>>(m, "Weighter")
-    .def(init<std::vector<std::shared_ptr<Injector>>, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PhysicalProcess>, std::vector<std::shared_ptr<PhysicalProcess>>>())
-    .def(init<std::vector<std::shared_ptr<Injector>>, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PhysicalProcess>>())
-    .def(init<std::vector<std::shared_ptr<Injector>>, std::string>())
+    .def(init<std::vector<std::shared_ptr<Injector>>, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PhysicalProcess>, std::vector<std::shared_ptr<PhysicalProcess>>>(), keep_alive<1, 2>(), keep_alive<1, 4>(), keep_alive<1, 5>())
+    .def(init<std::vector<std::shared_ptr<Injector>>, std::shared_ptr<siren::detector::DetectorModel>, std::shared_ptr<PhysicalProcess>>(), keep_alive<1, 2>(), keep_alive<1, 4>())
+    .def(init<std::vector<std::shared_ptr<Injector>>, std::string>(), keep_alive<1, 2>())
     .def("EventWeight",&Weighter::EventWeight)
     .def("GetInjectors",&Weighter::GetInjectors)
     .def("GetDetectorModel",&Weighter::GetDetectorModel)

--- a/projects/utilities/public/SIREN/utilities/Pybind11Trampoline.h
+++ b/projects/utilities/public/SIREN/utilities/Pybind11Trampoline.h
@@ -3,6 +3,7 @@
 #define SIREN_Pybind11Trampoline_H
 
 #include <sstream>
+#include <functional>
 #include <cxxabi.h>
 
 #include <cereal/cereal.hpp>
@@ -146,6 +147,107 @@
         } while (false); \
         return BaseType::cfuncname(__VA_ARGS__);
 
+// Recover the python half of a trampoline instance into `selfname` when it
+// has not been cached yet. Used by the SELF_OVERRIDE family and by trampoline
+// methods that provide their own C++ defaults.
+#define SELF_RECOVER(selfname, BaseType) \
+        if(!selfname) { \
+            auto *_tinfo = pybind11::detail::get_type_info(typeid(BaseType)); \
+            if(_tinfo) { \
+                pybind11::handle _h = pybind11::detail::get_object_handle(static_cast<const BaseType *>(this), _tinfo); \
+                if(_h) { \
+                    selfname = pybind11::reinterpret_borrow<pybind11::object>(_h); \
+                } \
+            } \
+        }
+
+// Dispatch Name() to a python override when one exists; otherwise report the
+// python class name, falling back to the C++ base type name when the
+// instance has no python half.
+#define SELF_OVERRIDE_NAME_CLASSNAME_DEFAULT(selfname, BaseType) \
+        do { \
+            pybind11::gil_scoped_acquire gil; \
+            SELF_RECOVER(selfname, BaseType) \
+            const BaseType * ref; \
+            if(selfname) { \
+                ref = selfname.cast<BaseType *>(); \
+            } else { \
+                ref = this; \
+            } \
+            pybind11::function override \
+                = pybind11::get_override(static_cast<const BaseType *>(ref), "Name"); \
+            if (override) { \
+                return override().cast<std::string>(); \
+            } \
+            if(selfname) { \
+                return selfname.attr("__class__").attr("__name__").cast<std::string>(); \
+            } \
+            return std::string(PYBIND11_STRINGIFY(BaseType)); \
+        } while (false);
+
+// Dispatch equal() to a python override when one exists; otherwise compare
+// object identity. The framework deduplicates distributions by shared
+// pointer identity, so identity is the safe default for python subclasses.
+#define SELF_OVERRIDE_EQUAL_IDENTITY_DEFAULT(selfname, BaseType, CompareType, other) \
+        do { \
+            pybind11::gil_scoped_acquire gil; \
+            SELF_RECOVER(selfname, BaseType) \
+            const BaseType * ref; \
+            if(selfname) { \
+                ref = selfname.cast<BaseType *>(); \
+            } else { \
+                ref = this; \
+            } \
+            pybind11::function override \
+                = pybind11::get_override(static_cast<const BaseType *>(ref), "equal"); \
+            if (override) { \
+                return override(other).cast<bool>(); \
+            } \
+            return static_cast<CompareType const *>(this) == &other; \
+        } while (false);
+
+// Dispatch less() to a python override when one exists; otherwise order by
+// object address so that python subclasses have a consistent total order
+// within a process.
+#define SELF_OVERRIDE_LESS_IDENTITY_DEFAULT(selfname, BaseType, CompareType, other) \
+        do { \
+            pybind11::gil_scoped_acquire gil; \
+            SELF_RECOVER(selfname, BaseType) \
+            const BaseType * ref; \
+            if(selfname) { \
+                ref = selfname.cast<BaseType *>(); \
+            } else { \
+                ref = this; \
+            } \
+            pybind11::function override \
+                = pybind11::get_override(static_cast<const BaseType *>(ref), "less"); \
+            if (override) { \
+                return override(other).cast<bool>(); \
+            } \
+            return std::less<CompareType const *>()(static_cast<CompareType const *>(this), &other); \
+        } while (false);
+
+// Dispatch clone() to a python override when one exists; otherwise fail with
+// an instructive error. Nothing in the framework calls clone(), so python
+// subclasses only need to define it when they use cloning themselves.
+#define SELF_OVERRIDE_CLONE_REQUIRED(selfname, BaseType, ReturnElementType) \
+        do { \
+            pybind11::gil_scoped_acquire gil; \
+            SELF_RECOVER(selfname, BaseType) \
+            const BaseType * ref; \
+            if(selfname) { \
+                ref = selfname.cast<BaseType *>(); \
+            } else { \
+                ref = this; \
+            } \
+            pybind11::function override \
+                = pybind11::get_override(static_cast<const BaseType *>(ref), "clone"); \
+            if (override) { \
+                return override().cast<std::shared_ptr<ReturnElementType>>(); \
+            } \
+            throw std::runtime_error("clone() is not implemented for this python-defined distribution; define clone(self) returning a fresh instance to enable cloning"); \
+        } while (false);
+
 #define Pybind11TrampolineCerealMethods(BaseType, TrampolineType) \
 public: \
     mutable pybind11::object self; \
@@ -191,7 +293,11 @@ public: \
         return d; \
     } \
     static pybind11::tuple pickle_save(BaseType & cpp_obj) { \
-        pybind11::object x = dynamic_cast<TrampolineType*>(&cpp_obj)->get_representation(); \
+        TrampolineType * trampoline = dynamic_cast<TrampolineType*>(&cpp_obj); \
+        if(!trampoline) { \
+            throw std::runtime_error("Cannot pickle a C++-defined instance through the python trampoline; pickling is only supported for python-defined subclasses"); \
+        } \
+        pybind11::object x = trampoline->get_representation(); \
         return pybind11::make_tuple(x); \
     } \
     static std::pair<std::unique_ptr<BaseType>, pybind11::dict> pickle_load(const pybind11::tuple &t) { \

--- a/tests/python/test_python_distributions.py
+++ b/tests/python/test_python_distributions.py
@@ -1,0 +1,518 @@
+"""Python-subclassed distributions driven through the C++ injector and weighter.
+
+Unit tests call bound base-class methods so the C++ virtual dispatch crosses
+back into the python overrides; end-to-end tests run python distributions
+through the Injector and Weighter against the CCM detector model with a
+dummy cross section. The distribution classes live at module scope so that
+pickle can locate them by qualified name.
+"""
+import os
+import math as pymath
+
+import pytest
+
+siren = pytest.importorskip("siren")
+
+from siren import dataclasses as dc
+from siren import distributions
+from siren import injection
+from siren import interactions
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+NuMu = dc.Particle.ParticleType.NuMu
+
+TIME_CONST = 41.25
+BOX_HALF_WIDTH = 0.5
+BOX_CENTER = (0.0, 0.0, 1.0)
+
+
+def _detector_model():
+    try:
+        dm = siren.detector.DetectorModel()
+        det_dir = _util.get_detector_model_path("CCM")
+        dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+        dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    except Exception as e:  # detector model files not available in this env
+        pytest.skip(f"CCM detector model unavailable: {e}")
+    return dm
+
+
+@pytest.fixture(scope="module")
+def detector_model():
+    return _detector_model()
+
+
+def _interaction_collection():
+    return interactions.InteractionCollection(NuMu, [interactions.DummyCrossSection()])
+
+
+class UniformEnergy(distributions.PrimaryEnergyDistribution):
+    """Uniform energy on [emin, emax] via the SampleEnergy hook."""
+
+    def __init__(self, emin, emax):
+        super().__init__()
+        self.emin = emin
+        self.emax = emax
+
+    def SampleEnergy(self, rand, detector_model, interactions, record):
+        return rand.Uniform(self.emin, self.emax)
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        energy = record.primary_momentum[0]
+        if self.emin <= energy <= self.emax:
+            return 1.0 / (self.emax - self.emin)
+        return 0.0
+
+
+class NamedEnergy(UniformEnergy):
+    """Uniform energy with an explicit Name override."""
+
+    def Name(self):
+        return "not-the-class-name"
+
+
+class CloneableEnergy(UniformEnergy):
+    """Uniform energy with an explicit clone override."""
+
+    def clone(self):
+        return CloneableEnergy(self.emin, self.emax)
+
+
+class FixedZDirection(distributions.PrimaryDirectionDistribution):
+    """Always points along +z via the SampleDirection hook."""
+
+    def __init__(self):
+        super().__init__()
+
+    def SampleDirection(self, rand, detector_model, interactions, record):
+        return smath.Vector3D(0.0, 0.0, 1.0)
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return 1.0
+
+
+class PairEnergyDirection(distributions.PrimaryEnergyDirectionDistribution):
+    """Fixed (energy, direction) pair via the SampleEnergyAndDirection hook."""
+
+    def __init__(self, energy):
+        super().__init__()
+        self.fixed_energy = energy
+
+    def SampleEnergyAndDirection(self, rand, detector_model, interactions, record):
+        return (self.fixed_energy, smath.Vector3D(0.0, 0.0, 1.0))
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return 1.0
+
+
+class BoxVertex(distributions.VertexPositionDistribution):
+    """Uniform vertex position inside an axis-aligned box."""
+
+    def __init__(self):
+        super().__init__()
+
+    def SamplePosition(self, rand, detector_model, interactions, record):
+        cx, cy, cz = BOX_CENTER
+        h = BOX_HALF_WIDTH
+        x = rand.Uniform(cx - h, cx + h)
+        y = rand.Uniform(cy - h, cy + h)
+        z = rand.Uniform(cz - h, cz + h)
+        initial = smath.Vector3D(x, y, cz - 20.0)
+        vertex = smath.Vector3D(x, y, z)
+        return (initial, vertex)
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        cx, cy, cz = BOX_CENTER
+        h = BOX_HALF_WIDTH
+        x, y, z = record.interaction_vertex
+        inside = (abs(x - cx) <= h) and (abs(y - cy) <= h) and (abs(z - cz) <= h)
+        if not inside:
+            return 0.0
+        return 1.0 / (2.0 * h) ** 3
+
+    def InjectionBounds(self, detector_model, interactions, record):
+        x, y, z = record.interaction_vertex
+        cz = BOX_CENTER[2]
+        h = BOX_HALF_WIDTH
+        first = smath.Vector3D(x, y, cz - h)
+        last = smath.Vector3D(x, y, cz + h)
+        return (first, last)
+
+
+class InitialTimeShift(distributions.PrimaryInjectionDistribution):
+    """Generic injection distribution that stamps a fixed initial time."""
+
+    def __init__(self):
+        super().__init__()
+
+    def Sample(self, rand, detector_model, interactions, record):
+        record.initial_time = TIME_CONST
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return 1.0
+
+
+class UnitWeightable(distributions.WeightableDistribution):
+    """Physical-side distribution contributing a constant factor."""
+
+    def __init__(self, factor=1.0):
+        super().__init__()
+        self.factor = factor
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return self.factor
+
+
+class LengthSettingSecondaryVertex(distributions.SecondaryVertexPositionDistribution):
+    """Secondary vertex distribution that pins the decay length."""
+
+    def __init__(self, length):
+        super().__init__()
+        self.length = length
+        self.sample_calls = 0
+
+    def SampleVertex(self, rand, detector_model, interactions, record):
+        self.sample_calls += 1
+        record.length = self.length
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return 1.0
+
+    def InjectionBounds(self, detector_model, interactions, record):
+        x, y, z = record.interaction_vertex
+        return (smath.Vector3D(x, y, z - 1.0), smath.Vector3D(x, y, z + 1.0))
+
+
+class FlagAreaDistribution(distributions.PrimaryAreaDistribution):
+    """Area distribution that records that it was called."""
+
+    def __init__(self):
+        super().__init__()
+        self.sample_calls = 0
+
+    def SamplePointOfClosestApproach(self, rand, detector_model, interactions, record):
+        self.sample_calls += 1
+        return smath.Vector3D(0.0, 0.0, 0.0)
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return 1.0
+
+
+class FlagSecondaryDistribution(distributions.SecondaryInjectionDistribution):
+    """Generic secondary distribution that records that it was called."""
+
+    def __init__(self):
+        super().__init__()
+        self.sample_calls = 0
+
+    def Sample(self, rand, detector_model, interactions, record):
+        self.sample_calls += 1
+
+    def GenerationProbability(self, detector_model, interactions, record):
+        return 1.0
+
+
+def _make_injector(dm, energy_dist=None, direction_dist=None, position_dist=None,
+                   extra_dists=None, seed=7, n_inject=1000):
+    dists = [distributions.PrimaryMass(0)]
+    dists.append(energy_dist if energy_dist is not None
+                 else distributions.PowerLaw(2.0, 0.5, 5.0))
+    dists.append(direction_dist if direction_dist is not None
+                 else distributions.IsotropicDirection())
+    dists.append(position_dist if position_dist is not None
+                 else distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0))
+    if extra_dists:
+        dists.extend(extra_dists)
+
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = NuMu
+    primary_inj.interactions = _interaction_collection()
+    primary_inj.distributions = dists
+
+    rand = utilities.SIREN_random(seed)
+    return injection._Injector(n_inject, dm, primary_inj, rand)
+
+
+def _generate(inj, n):
+    events = []
+    for _ in range(n):
+        try:
+            ev = inj.GenerateEvent()
+        except RuntimeError:
+            break
+        if len(ev.tree) > 0:
+            events.append(ev)
+    return events
+
+
+# --- unit-level dispatch through the bound base-class methods ---
+
+
+def test_energy_distribution_dispatch():
+    dist = UniformEnergy(1.0, 3.0)
+    rand = utilities.SIREN_random(11)
+    record = dc.PrimaryDistributionRecord(NuMu)
+    # The base class Sample is C++; it calls back into python SampleEnergy.
+    dist.Sample(rand, None, None, record)
+    assert 1.0 <= record.energy <= 3.0
+
+
+def test_direction_distribution_dispatch():
+    dist = FixedZDirection()
+    rand = utilities.SIREN_random(11)
+    record = dc.PrimaryDistributionRecord(NuMu)
+    dist.Sample(rand, None, None, record)
+    assert record.direction == pytest.approx((0.0, 0.0, 1.0))
+
+
+def test_energy_direction_distribution_dispatch():
+    dist = PairEnergyDirection(2.5)
+    rand = utilities.SIREN_random(11)
+    record = dc.PrimaryDistributionRecord(NuMu)
+    dist.Sample(rand, None, None, record)
+    assert record.energy == pytest.approx(2.5)
+    assert record.direction == pytest.approx((0.0, 0.0, 1.0))
+
+
+def test_position_distribution_dispatch():
+    dist = BoxVertex()
+    rand = utilities.SIREN_random(11)
+    record = dc.PrimaryDistributionRecord(NuMu)
+    dist.Sample(rand, None, None, record)
+    x, y, z = record.interaction_vertex
+    assert abs(x - BOX_CENTER[0]) <= BOX_HALF_WIDTH
+    assert abs(y - BOX_CENTER[1]) <= BOX_HALF_WIDTH
+    assert abs(z - BOX_CENTER[2]) <= BOX_HALF_WIDTH
+
+    ir = dc.InteractionRecord()
+    ir.interaction_vertex = [x, y, z]
+    first, last = dist.InjectionBounds(None, None, ir)
+    assert first.GetZ() == pytest.approx(BOX_CENTER[2] - BOX_HALF_WIDTH)
+    assert last.GetZ() == pytest.approx(BOX_CENTER[2] + BOX_HALF_WIDTH)
+
+
+def test_area_distribution_dispatch():
+    dist = FlagAreaDistribution()
+    rand = utilities.SIREN_random(11)
+    record = dc.PrimaryDistributionRecord(NuMu)
+    dist.Sample(rand, None, None, record)
+    assert dist.sample_calls == 1
+
+
+def test_secondary_distribution_dispatch():
+    parent = dc.InteractionRecord()
+    parent.signature.primary_type = NuMu
+    parent.signature.secondary_types = [NuMu]
+    parent.secondary_momenta = [[1.0, 0.0, 0.0, 0.5]]
+    parent.secondary_masses = [0.0]
+    parent.secondary_helicities = [-0.5]
+    parent.secondary_ids = [dc.ParticleID(1, 1)]
+
+    rand = utilities.SIREN_random(11)
+
+    generic = FlagSecondaryDistribution()
+    record = dc.SecondaryDistributionRecord(parent, 0)
+    generic.Sample(rand, None, None, record)
+    assert generic.sample_calls == 1
+
+    vertex = LengthSettingSecondaryVertex(12.5)
+    record = dc.SecondaryDistributionRecord(parent, 0)
+    # The base class Sample is C++; it calls back into python SampleVertex.
+    vertex.Sample(rand, None, None, record)
+    assert vertex.sample_calls == 1
+    assert record.length == pytest.approx(12.5)
+
+
+def test_weightable_distribution_dispatch():
+    dist = UnitWeightable(0.75)
+    ir = dc.InteractionRecord()
+    assert dist.GenerationProbability(None, None, ir) == pytest.approx(0.75)
+
+
+# --- trampoline defaults ---
+
+
+def test_name_defaults_to_class_name():
+    assert UniformEnergy(1.0, 3.0).Name() == "UniformEnergy"
+    assert UnitWeightable().Name() == "UnitWeightable"
+
+
+def test_name_override_wins():
+    assert NamedEnergy(1.0, 3.0).Name() == "not-the-class-name"
+
+
+def test_equality_defaults_to_identity():
+    d1 = UniformEnergy(1.0, 3.0)
+    d2 = UniformEnergy(1.0, 3.0)
+    assert d1 == d1
+    assert not (d1 == d2)
+
+
+def test_clone_requires_override():
+    with pytest.raises(RuntimeError, match="clone"):
+        UniformEnergy(1.0, 3.0).clone()
+
+    cloned = CloneableEnergy(1.0, 3.0).clone()
+    assert isinstance(cloned, CloneableEnergy)
+    assert cloned.emin == pytest.approx(1.0)
+    assert cloned.emax == pytest.approx(3.0)
+
+
+def test_pickle_roundtrip_preserves_dispatch():
+    import pickle
+
+    dist = UniformEnergy(1.5, 2.5)
+    restored = pickle.loads(pickle.dumps(dist))
+    assert isinstance(restored, UniformEnergy)
+    assert restored.emin == pytest.approx(1.5)
+    assert restored.emax == pytest.approx(2.5)
+
+    rand = utilities.SIREN_random(11)
+    record = dc.PrimaryDistributionRecord(NuMu)
+    restored.Sample(rand, None, None, record)
+    assert 1.5 <= record.energy <= 2.5
+
+
+# --- end-to-end through the Injector ---
+
+
+def test_injector_with_python_energy_distribution(detector_model):
+    inj = _make_injector(detector_model, energy_dist=UniformEnergy(1.0, 3.0), seed=21)
+    events = _generate(inj, 30)
+    assert events
+    energies = [ev.tree[0].record.primary_momentum[0] for ev in events]
+    assert all(1.0 <= e <= 3.0 for e in energies)
+    assert max(energies) - min(energies) > 1e-6
+
+
+def test_injector_with_python_direction_distribution(detector_model):
+    inj = _make_injector(detector_model, direction_dist=FixedZDirection(), seed=22)
+    events = _generate(inj, 10)
+    assert events
+    for ev in events:
+        e, px, py, pz = ev.tree[0].record.primary_momentum
+        p = pymath.sqrt(px * px + py * py + pz * pz)
+        assert pz / p == pytest.approx(1.0)
+
+
+def test_injector_with_python_position_distribution(detector_model):
+    # The injector locates the vertex distribution with a dynamic cast, so
+    # this also verifies that a python subclass is recognized as a
+    # VertexPositionDistribution.
+    inj = _make_injector(detector_model, position_dist=BoxVertex(), seed=23)
+    events = _generate(inj, 10)
+    assert events
+    for ev in events:
+        x, y, z = ev.tree[0].record.interaction_vertex
+        assert abs(x - BOX_CENTER[0]) <= BOX_HALF_WIDTH
+        assert abs(y - BOX_CENTER[1]) <= BOX_HALF_WIDTH
+        assert abs(z - BOX_CENTER[2]) <= BOX_HALF_WIDTH
+
+
+def test_injector_with_python_generic_distribution(detector_model):
+    inj = _make_injector(detector_model, extra_dists=[InitialTimeShift()], seed=24)
+    events = _generate(inj, 10)
+    assert events
+    for ev in events:
+        assert ev.tree[0].record.primary_initial_time == pytest.approx(TIME_CONST)
+
+
+# --- end-to-end through the Weighter ---
+
+
+def _physical_process(shared_energy_dist, extra_phys=None):
+    primary_phys = injection.PhysicalProcess()
+    primary_phys.primary_type = NuMu
+    primary_phys.interactions = _interaction_collection()
+    dists = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        shared_energy_dist,
+    ]
+    if extra_phys:
+        dists.extend(extra_phys)
+    primary_phys.distributions = dists
+    return primary_phys
+
+
+def test_weighter_with_python_distributions(detector_model):
+    energy_dist = UniformEnergy(1.0, 3.0)
+
+    dists = [
+        distributions.PrimaryMass(0),
+        energy_dist,
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = NuMu
+    primary_inj.interactions = _interaction_collection()
+    primary_inj.distributions = dists
+
+    rand = utilities.SIREN_random(25)
+    inj = injection._Injector(1000, detector_model, primary_inj, rand)
+
+    events = _generate(inj, 20)
+    assert events
+
+    # The python energy distribution instance is shared between the injection
+    # and physical processes, so it cancels in the weight by pointer identity.
+    # The unshared python weightable contributes its constant factor.
+    phys_shared = _physical_process(energy_dist, extra_phys=[UnitWeightable(1.0)])
+    weighter = injection._Weighter([inj], detector_model, phys_shared)
+    weights = [weighter.EventWeight(ev) for ev in events]
+    assert all(pymath.isfinite(w) and w > 0.0 for w in weights)
+
+    # An identical but unshared python energy distribution must give the same
+    # weights, now computed by explicitly evaluating both sides in python.
+    phys_unshared = _physical_process(UniformEnergy(1.0, 3.0), extra_phys=[UnitWeightable(1.0)])
+    weighter_unshared = injection._Weighter([inj], detector_model, phys_unshared)
+    weights_unshared = [weighter_unshared.EventWeight(ev) for ev in events]
+    assert weights_unshared == pytest.approx(weights)
+
+    # Scaling the physical side by a constant factor scales the weights.
+    phys_scaled = _physical_process(energy_dist, extra_phys=[UnitWeightable(2.0)])
+    weighter_scaled = injection._Weighter([inj], detector_model, phys_scaled)
+    weights_scaled = [weighter_scaled.EventWeight(ev) for ev in events]
+    assert weights_scaled == pytest.approx([2.0 * w for w in weights])
+
+
+def test_injector_with_python_secondary_distribution(detector_model):
+    # DummyCrossSection signatures produce the primary type among the
+    # secondaries, so a secondary process on NuMu re-enters the chain once.
+    energy_dist = UniformEnergy(1.0, 3.0)
+    dists = [
+        distributions.PrimaryMass(0),
+        energy_dist,
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = NuMu
+    primary_inj.interactions = _interaction_collection()
+    primary_inj.distributions = dists
+
+    secondary_vertex = LengthSettingSecondaryVertex(3.0)
+    secondary_proc = injection.SecondaryInjectionProcess()
+    secondary_proc.secondary_type = NuMu
+    secondary_proc.interactions = _interaction_collection()
+    secondary_proc.distributions = [secondary_vertex]
+
+    rand = utilities.SIREN_random(26)
+    inj = injection._Injector(1000, detector_model, primary_inj, [secondary_proc], rand)
+
+    def stop_after_first_generation(tree, datum, index):
+        return len(tree.tree) >= 2
+
+    inj.SetStoppingCondition(stop_after_first_generation)
+
+    events = _generate(inj, 5)
+    assert events
+    assert secondary_vertex.sample_calls > 0
+    found_secondary = any(len(ev.tree) > 1 for ev in events)
+    assert found_secondary


### PR DESCRIPTION
This adds python subclassing support for every abstract distribution base class, so custom injection and weighting distributions can be implemented in python and used anywhere a C++ distribution is accepted.

## Authoring surface

Each abstract base is bound with a pybind11 trampoline following the existing `pyCrossSection`/`pyDecay` pattern, with new shared support macros in `Pybind11Trampoline.h`. A python subclass implements the base's sampling hook together with `GenerationProbability`:

| Base class | Implement |
|---|---|
| `WeightableDistribution` | `GenerationProbability` |
| `PrimaryInjectionDistribution` | `Sample`, `GenerationProbability` |
| `SecondaryInjectionDistribution` | `Sample`, `GenerationProbability` |
| `PrimaryEnergyDistribution` | `SampleEnergy`, `GenerationProbability` |
| `PrimaryDirectionDistribution` | `SampleDirection`, `GenerationProbability` |
| `PrimaryEnergyDirectionDistribution` | `SampleEnergyAndDirection`, `GenerationProbability` |
| `VertexPositionDistribution` | `SamplePosition`, `InjectionBounds`, `GenerationProbability` |
| `PrimaryAreaDistribution` | `SamplePointOfClosestApproach`, `GenerationProbability` |
| `SecondaryVertexPositionDistribution` | `SampleVertex`, `InjectionBounds`, `GenerationProbability` |

```python
class UniformEnergy(distributions.PrimaryEnergyDistribution):
    def __init__(self, emin, emax):
        super().__init__()
        self.emin, self.emax = emin, emax
    def SampleEnergy(self, rand, detector_model, interactions, record):
        return rand.Uniform(self.emin, self.emax)
    def GenerationProbability(self, detector_model, interactions, record):
        e = record.primary_momentum[0]
        return 1.0 / (self.emax - self.emin) if self.emin <= e <= self.emax else 0.0
```

The framework-facing virtuals have defaults so python authors do not need to know about them. `Name` reports the python class name. `equal` and `less` compare object identity, which matches how the weighter deduplicates shared distributions (shared pointer identity). `clone` dispatches to a python override when one exists and raises an instructive error otherwise; nothing in the framework calls it. A python distribution shared between the injection and physical processes cancels in the weight exactly as a shared C++ distribution does. Python-defined distributions serialize through the same pickle-inside-cereal bridge used by the DarkNews interactions, so instances pickle directly and injector serialization works when the class is importable at load time.

## Lifetime

A python-defined object held only through C++ shared pointers loses its python half to garbage collection, after which virtual dispatch fails with a pure-virtual error. The injection bindings now carry keep_alive policies that tie python-defined components to the objects consuming them: the process `distributions` and `interactions` setters, the Injector constructors and process setters, and the Weighter constructors. `InteractionCollection` already pinned its constructor arguments; this completes the chain, and covers python-defined cross sections and decays as well.

## Performance

A C++ to python virtual crossing costs about one microsecond, and distributions cross only a few times per event per vertex: one `Sample` per distribution at injection, one `GenerationProbability` per unique distribution plus the position bounds at weighting. On a minimal toy chain (dummy cross section, CCM detector), routing five virtual calls per event through python raised the per-event cost from 10.9 to 16.3 microseconds; against realistic chains the overhead is below a percent. The dominant cost is the python body itself, as with the DarkNews models.

## Tests

`tests/python/test_python_distributions.py` adds eighteen tests: direct dispatch through the bound base-class methods for every base, the trampoline defaults, a pickle round trip that preserves dispatch, and end-to-end runs of python energy, direction, position, generic, and secondary-vertex distributions through the Injector and Weighter, including weight equality between a shared and an unshared python distribution and a scaled physical normalization.
